### PR TITLE
perf(dashboard): skip diff overlay computation when diffMode is off

### DIFF
--- a/understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx
@@ -89,10 +89,10 @@ export default function GraphView() {
       };
     });
 
-    const diffNodeIds = new Set([...changedNodeIds, ...affectedNodeIds]);
+    const diffNodeIds = diffMode ? new Set([...changedNodeIds, ...affectedNodeIds]) : new Set<string>();
     const flowEdges: Edge[] = filteredGraphEdges.map((edge, i) => {
-      const sourceInDiff = diffNodeIds.has(edge.source);
-      const targetInDiff = diffNodeIds.has(edge.target);
+      const sourceInDiff = diffMode && diffNodeIds.has(edge.source);
+      const targetInDiff = diffMode && diffNodeIds.has(edge.target);
       const isImpacted = diffMode && (sourceInDiff || targetInDiff);
 
       return {


### PR DESCRIPTION
Guard diffNodeIds construction and per-edge lookups behind diffMode check to avoid unnecessary Set spreads and has() calls on every graph recompute when diff mode is inactive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated performance optimization in `GraphView` that only gates diff-related set construction/lookups behind `diffMode`, with no behavioral change when diff mode is enabled.
> 
> **Overview**
> **Improves graph recompute performance when diff mode is disabled.** `GraphView` now only builds `diffNodeIds` and performs per-edge `has()` checks when `diffMode` is on, avoiding unnecessary set spreads and lookups during normal (non-diff) rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4161d3eba31b965900c3fbaa8b16dd16531b663e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->