### PR TITLE
fix: OpenCode plugin not discovering skills

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -32,6 +32,30 @@ Or just ask: "Analyze this codebase and build a knowledge graph"
 
 Restart OpenCode — the plugin re-installs from git automatically.
 
+To pin a specific version:
+
+```json
+{
+  "plugin": ["understand-anything@git+https://github.com/Lum1104/Understand-Anything.git#v1.1.1"]
+}
+```
+
 ## Uninstalling
 
 Remove the plugin line from `opencode.json` and restart.
+
+## Troubleshooting
+
+### Skills not found
+
+1. Verify the plugin line in your `opencode.json`
+2. Check that `~/.cache/opencode/node_modules/understand-anything` exists after restart
+3. Use the `skill` tool to list discovered skills
+
+### Tool mapping
+
+When skills reference Claude Code tools:
+- `TodoWrite` → `todowrite`
+- `Task` with subagents → `@mention` syntax
+- `Skill` tool → OpenCode's native `skill` tool
+- File operations → your native tools

--- a/.opencode/plugins/understand-anything.js
+++ b/.opencode/plugins/understand-anything.js
@@ -1,0 +1,25 @@
+/**
+ * Understand Anything plugin for OpenCode.ai
+ *
+ * Auto-registers the skills directory so OpenCode discovers all
+ * understand-anything skills without manual symlinks or config edits.
+ */
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const UnderstandAnythingPlugin = async ({ client, directory }) => {
+  const skillsDir = path.resolve(__dirname, '../../understand-anything-plugin/skills');
+
+  return {
+    config: async (config) => {
+      config.skills = config.skills || {};
+      config.skills.paths = config.skills.paths || [];
+      if (!config.skills.paths.includes(skillsDir)) {
+        config.skills.paths.push(skillsDir);
+      }
+    },
+  };
+};

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "understand-anything",
   "private": true,
   "type": "module",
+  "main": ".opencode/plugins/understand-anything.js",
   "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b",
   "scripts": {
     "prepare": "pnpm --filter @understand-anything/core build",


### PR DESCRIPTION
## Summary

- OpenCode installs the repo via git but looks at the **root** for the plugin entry point. Our skills live inside `understand-anything-plugin/`, so OpenCode couldn't find them.
- Added `.opencode/plugins/understand-anything.js` that uses the `config` hook to inject `understand-anything-plugin/skills/` into OpenCode's `skills.paths` (same pattern used by [superpowers](https://github.com/obra/superpowers))
- Added `"main"` field to root `package.json` so OpenCode knows where the plugin entry is
- Updated `INSTALL.md` with version pinning and troubleshooting sections

## Test plan

- [x] Install via `"plugin": ["understand-anything@git+https://github.com/Lum1104/Understand-Anything.git#fix/opencode-plugin-discovery"]` in `opencode.json`
- [x] Restart OpenCode and verify skills are discovered (`skill` tool → list skills)
- [x] Verify Claude Code plugin still works normally (unaffected by `"main"` field)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)