### PR TITLE
fix: use POSIX-compatible pipe instead of bash herestring in hooks

### DIFF
--- a/understand-anything-plugin/hooks/hooks.json
+++ b/understand-anything-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "grep -qE 'git\\s+(commit|merge|cherry-pick|rebase)' <<< \"$TOOL_INPUT\" && [ -f .understand-anything/config.json ] && grep -q '\"autoUpdate\".*true' .understand-anything/config.json && [ -f .understand-anything/knowledge-graph.json ] && echo '[understand-anything] Commit detected with auto-update enabled. You MUST read the file at ${PLUGIN_DIR}/hooks/auto-update-prompt.md and execute its instructions to incrementally update the knowledge graph. Do not ask the user for confirmation — just do it.' || true"
+            "command": "echo \"$TOOL_INPUT\" | grep -qE 'git\\s+(commit|merge|cherry-pick|rebase)' && [ -f .understand-anything/config.json ] && grep -q '\"autoUpdate\".*true' .understand-anything/config.json && [ -f .understand-anything/knowledge-graph.json ] && echo '[understand-anything] Commit detected with auto-update enabled. You MUST read the file at ${PLUGIN_DIR}/hooks/auto-update-prompt.md and execute its instructions to incrementally update the knowledge graph. Do not ask the user for confirmation — just do it.' || true"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- The `PostToolUse` hook in `hooks.json` uses `<<<` (bash herestring syntax), which fails when Claude Code runs hooks under `/bin/sh` with `Syntax error: redirection unexpected`
- Replaced `grep -qE '...' <<< "$TOOL_INPUT"` with `echo "$TOOL_INPUT" | grep -qE '...'` for POSIX compatibility
