### PR TITLE
fix: add plugin manifest at marketplace-declared source path

### DIFF
--- a/understand-anything-plugin/.claude-plugin/plugin.json
+++ b/understand-anything-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "understand-anything",
+  "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
+  "version": "2.3.1",
+  "author": {
+    "name": "Lum1104"
+  },
+  "homepage": "https://github.com/Lum1104/Understand-Anything",
+  "repository": "https://github.com/Lum1104/Understand-Anything",
+  "license": "MIT",
+  "keywords": [
+    "codebase-analysis",
+    "knowledge-graph",
+    "architecture",
+    "onboarding",
+    "dashboard"
+  ]
+}


### PR DESCRIPTION
## Summary

Adding this repo as a Claude Code marketplace fails with:

> Marketplace sync failed. Some plugins in this marketplace have validation errors.

`/.claude-plugin/marketplace.json` declares:

```json
"plugins": [{ "name": "understand-anything", "source": "./understand-anything-plugin" }]
```

Per the [plugin-marketplaces spec](https://code.claude.com/docs/en/plugin-marketplaces), a `source` string is a relative path to the plugin root, and Claude Code then resolves the plugin manifest at `<source>/.claude-plugin/plugin.json`. In this repo, Claude Code looks for `./understand-anything-plugin/.claude-plugin/plugin.json` — but that file does not exist. The only `plugin.json` is at the repo-root `.claude-plugin/`, which is unrelated to the declared plugin source path. Marketplace validation therefore fails and the plugin cannot be installed.

This PR adds the plugin manifest at the path the marketplace source points to. The root-level `.claude-plugin/plugin.json` is left untouched so nothing that depends on the root layout breaks. The version is kept in sync with the root manifest (`2.3.1`).

## Repro on `main`

```
/plugin marketplace add Lum1104/Understand-Anything
```

→ "Marketplace sync failed. Some plugins in this marketplace have validation errors."

## Verification on this branch

- [x] `/plugin marketplace add <local clone of this branch>` — syncs cleanly, no validation errors
- [x] `/plugin install understand-anything@understand-anything` — installs successfully
- [x] Added via the Cowork Directory → Plugins UI — sync succeeds after using a fork with this fix
- [ ] Please confirm on a fresh Claude Code install once merged

| before | after |
| --- | --- |
| <img width="1332" height="833" alt="image" src="https://github.com/user-attachments/assets/1d7e15af-9188-44e9-9f1a-295a56c49958" /> | <img width="1512" height="948" alt="image" src="https://github.com/user-attachments/assets/1f90a2f2-c3f7-434a-9d61-d40edeba553b" /> |

## Notes

- Only change is one new file: `understand-anything-plugin/.claude-plugin/plugin.json`.
- Alternative fix was to change `marketplace.json` `source` to `.` (treat the repo root as the plugin), but that would pull in `homepage/`, `packages/`, etc. as part of the plugin — undesirable. Keeping the existing subfolder layout and adding the expected manifest is the minimal, doc-conformant fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)