### PR TITLE
fix: include access token in auto-opened dashboard URL

### DIFF
--- a/understand-anything-plugin/packages/dashboard/vite.config.ts
+++ b/understand-anything-plugin/packages/dashboard/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   server: {
     host: "127.0.0.1",
     port: 5173,
+    open: `/?token=${ACCESS_TOKEN}`,
   },
 
   resolve: {

--- a/understand-anything-plugin/skills/understand-dashboard/SKILL.md
+++ b/understand-anything-plugin/skills/understand-dashboard/SKILL.md
@@ -56,7 +56,7 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
 
 5. Start the Vite dev server pointing at the project's knowledge graph:
    ```bash
-   cd <dashboard-dir> && GRAPH_DIR=<project-dir> npx vite --host 127.0.0.1 --open
+   cd <dashboard-dir> && GRAPH_DIR=<project-dir> npx vite --host 127.0.0.1
    ```
    Run this in the background so the user can continue working.
 


### PR DESCRIPTION
Remove --open from CLI and set server.open to /?token= so the browser opens with the access token already included.