### PR TITLE
fix(skill): quote understand argument-hint yaml

### DIFF
--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand
 description: Analyze a codebase to produce an interactive knowledge graph for understanding architecture, components, and relationships
-argument-hint: [path] [--full|--auto-update|--no-auto-update|--review]
+argument-hint: ["[path] [--full|--auto-update|--no-auto-update|--review]"]
 ---
 
 # /understand


### PR DESCRIPTION
## Summary
- quote the `argument-hint` value in `understand-anything-plugin/skills/understand/SKILL.md`
- fix invalid YAML frontmatter for the `/understand` skill

## Problem
The previous frontmatter used:

```yaml
argument-hint: [path] [--full|--auto-update|--no-auto-update|--review]
```

This is invalid YAML and causes skill loading to fail in Pi with an error like:

- `Unexpected flow-seq-start`

## Result
After quoting the value, the frontmatter parses correctly and Pi can load the skill normally.