### PR TITLE
perf(dashboard): code-split bundle to drop initial chunk under warning threshold

### DIFF
--- a/understand-anything-plugin/packages/dashboard/src/App.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/App.tsx
@@ -1,22 +1,18 @@
-import { useEffect, useState, useMemo, useCallback } from "react";
+import { useEffect, useState, useMemo, useCallback, lazy, Suspense } from "react";
 import { validateGraph } from "@understand-anything/core/schema";
 import type { GraphIssue } from "@understand-anything/core/schema";
 import { useDashboardStore } from "./store";
 import GraphView from "./components/GraphView";
 import DomainGraphView from "./components/DomainGraphView";
 import KnowledgeGraphView from "./components/KnowledgeGraphView";
-import CodeViewer from "./components/CodeViewer";
 import SearchBar from "./components/SearchBar";
 import NodeInfo from "./components/NodeInfo";
 import LayerLegend from "./components/LayerLegend";
 import DiffToggle from "./components/DiffToggle";
 import FilterPanel from "./components/FilterPanel";
 import ExportMenu from "./components/ExportMenu";
-import PathFinderModal from "./components/PathFinderModal";
-import LearnPanel from "./components/LearnPanel";
 import PersonaSelector from "./components/PersonaSelector";
 import ProjectOverview from "./components/ProjectOverview";
-import KeyboardShortcutsHelp from "./components/KeyboardShortcutsHelp";
 import WarningBanner from "./components/WarningBanner";
 import TokenGate from "./components/TokenGate";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
@@ -24,6 +20,14 @@ import type { KeyboardShortcut } from "./hooks/useKeyboardShortcuts";
 import { ThemeProvider } from "./themes/index.ts";
 import { ThemePicker } from "./components/ThemePicker.tsx";
 import type { ThemeConfig } from "./themes/index.ts";
+
+// Lazy-load heavy / optional components so they ship in separate chunks.
+const CodeViewer = lazy(() => import("./components/CodeViewer"));
+const LearnPanel = lazy(() => import("./components/LearnPanel"));
+const PathFinderModal = lazy(() => import("./components/PathFinderModal"));
+const KeyboardShortcutsHelp = lazy(
+  () => import("./components/KeyboardShortcutsHelp"),
+);
 
 const DEMO_MODE = import.meta.env.VITE_DEMO_MODE === "true";
 const SESSION_TOKEN_KEY = "understand-anything-token";
@@ -321,7 +325,11 @@ function Dashboard({ accessToken }: { accessToken: string }) {
   const sidebarContent = (
     <>
       {selectedNodeId && <NodeInfo />}
-      {isLearnMode && <LearnPanel />}
+      {isLearnMode && (
+        <Suspense fallback={null}>
+          <LearnPanel />
+        </Suspense>
+      )}
       {!selectedNodeId && !isLearnMode && <ProjectOverview />}
     </>
   );
@@ -508,7 +516,9 @@ function Dashboard({ accessToken }: { accessToken: string }) {
                 </button>
               </div>
               <div className="flex-1 min-h-0">
-                <CodeViewer />
+                <Suspense fallback={null}>
+                  <CodeViewer />
+                </Suspense>
               </div>
             </div>
           </div>
@@ -517,17 +527,20 @@ function Dashboard({ accessToken }: { accessToken: string }) {
 
       {/* Keyboard shortcuts help modal */}
       {showKeyboardHelp && (
-        <KeyboardShortcutsHelp
-          shortcuts={shortcuts}
-          onClose={() => setShowKeyboardHelp(false)}
-        />
+        <Suspense fallback={null}>
+          <KeyboardShortcutsHelp
+            shortcuts={shortcuts}
+            onClose={() => setShowKeyboardHelp(false)}
+          />
+        </Suspense>
       )}
 
-      {/* Path Finder Modal */}
-      <PathFinderModal
-        isOpen={pathFinderOpen}
-        onClose={togglePathFinder}
-      />
+      {/* Path Finder Modal — only mounted when open so its chunk is lazy-loaded on demand. */}
+      {pathFinderOpen && (
+        <Suspense fallback={null}>
+          <PathFinderModal isOpen={pathFinderOpen} onClose={togglePathFinder} />
+        </Suspense>
+      )}
     </div>
     </ThemeProvider>
   );

--- a/understand-anything-plugin/packages/dashboard/vite.config.demo.ts
+++ b/understand-anything-plugin/packages/dashboard/vite.config.demo.ts
@@ -18,5 +18,32 @@ export default defineConfig({
     "import.meta.env.VITE_DEMO_MODE": JSON.stringify("true"),
   },
 
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes("node_modules")) return;
+          if (/[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/.test(id)) {
+            return "react-vendor";
+          }
+          if (id.includes("node_modules/@xyflow/")) return "xyflow";
+          if (
+            id.includes("node_modules/@dagrejs/") ||
+            id.includes("node_modules/d3-force/")
+          ) {
+            return "graph-layout";
+          }
+          if (
+            id.includes("node_modules/react-markdown/") ||
+            id.includes("node_modules/hast-util-to-jsx-runtime/") ||
+            /[\\/]node_modules[\\/](remark|rehype|mdast|hast|unist|micromark|decode-named-character-reference|property-information|space-separated-tokens|comma-separated-tokens|html-url-attributes|devlop|bail|ccount|character-entities|is-plain-obj|trim-lines|trough|unified|vfile|zwitch)/.test(id)
+          ) {
+            return "markdown";
+          }
+        },
+      },
+    },
+  },
+
   plugins: [react(), tailwindcss()],
 });

--- a/understand-anything-plugin/packages/dashboard/vite.config.ts
+++ b/understand-anything-plugin/packages/dashboard/vite.config.ts
@@ -27,6 +27,33 @@ export default defineConfig({
     },
   },
 
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes("node_modules")) return;
+          if (/[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/.test(id)) {
+            return "react-vendor";
+          }
+          if (id.includes("node_modules/@xyflow/")) return "xyflow";
+          if (
+            id.includes("node_modules/@dagrejs/") ||
+            id.includes("node_modules/d3-force/")
+          ) {
+            return "graph-layout";
+          }
+          if (
+            id.includes("node_modules/react-markdown/") ||
+            id.includes("node_modules/hast-util-to-jsx-runtime/") ||
+            /[\\/]node_modules[\\/](remark|rehype|mdast|hast|unist|micromark|decode-named-character-reference|property-information|space-separated-tokens|comma-separated-tokens|html-url-attributes|devlop|bail|ccount|character-entities|is-plain-obj|trim-lines|trough|unified|vfile|zwitch)/.test(id)
+          ) {
+            return "markdown";
+          }
+        },
+      },
+    },
+  },
+
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
## Summary
Fixes #86 — the dashboard built into a single ~770 kB JS chunk and tripped Vite's 500 kB chunk-size warning.

This PR splits the bundle two ways:

1. **Manual vendor chunks** in `vite.config.ts` / `vite.config.demo.ts` via `rollupOptions.output.manualChunks`:
   - `react-vendor` — react / react-dom / scheduler
   - `xyflow` — @xyflow/react
   - `graph-layout` — @dagrejs/dagre + d3-force
   - `markdown` — react-markdown + the full remark / rehype / mdast / hast / micromark dependency tree
2. **Lazy-loaded views** in `App.tsx` via `React.lazy` + `<Suspense fallback={null}>`:
   - `CodeViewer` (only when a file node is opened)
   - `LearnPanel` (only in Learn persona / tour mode — pulls the whole markdown chunk)
   - `PathFinderModal` (only while the modal is open — previously always mounted)
   - `KeyboardShortcutsHelp` (only when the help modal is open)

## Before / after (from `pnpm --filter @understand-anything/dashboard build`)

**Before**
```
dist/assets/index-*.js   769.80 kB │ gzip: 235.12 kB
(!) Some chunks are larger than 500 kB after minification
```

**After**
```
dist/assets/KeyboardShortcutsHelp-*.js    2.06 kB │ gzip:  0.91 kB
dist/assets/CodeViewer-*.js               2.82 kB │ gzip:  1.08 kB
dist/assets/LearnPanel-*.js               5.42 kB │ gzip:  1.71 kB
dist/assets/PathFinderModal-*.js          6.30 kB │ gzip:  2.01 kB
dist/assets/graph-layout-*.js            55.15 kB │ gzip: 19.96 kB
dist/assets/markdown-*.js               117.59 kB │ gzip: 36.18 kB
dist/assets/xyflow-*.js                 181.01 kB │ gzip: 58.92 kB
dist/assets/react-vendor-*.js           193.84 kB │ gzip: 60.55 kB
dist/assets/index-*.js                  205.21 kB │ gzip: 55.31 kB
```

- Warning is gone (no chunk > 500 kB).
- Main `index` chunk shrank ~565 kB raw (~180 kB gzip).
- `markdown` (~118 kB raw / 36 kB gzip) is fully deferred until a user enters Learn mode — pure savings for the common read-only viewer path.
- Vendor chunks (`react-vendor`, `xyflow`, `graph-layout`) change far less often than app code, improving long-term browser cache reuse.

## Test plan
- [x] `pnpm --filter @understand-anything/dashboard build` — no warnings, chunks as above
- [x] `pnpm --filter @understand-anything/dashboard build:demo` — demo variant chunks cleanly too
- [x] `pnpm --filter @understand-anything/core test` — 654 / 654 pass
- [x] `tsc -b` (run as part of `build`) — no type errors
- [x] Manual smoke: open dashboard, click a file node (CodeViewer), press `?` (KeyboardShortcutsHelp), press `p` (PathFinderModal), switch to Junior persona (LearnPanel) — each should load its lazy chunk and render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)