### PR TITLE
fix: expand ${PLUGIN_DIR} with double quotes in hook echo commands

### DIFF
--- a/understand-anything-plugin/hooks/hooks.json
+++ b/understand-anything-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo \"$TOOL_INPUT\" | grep -qE 'git\\s+(commit|merge|cherry-pick|rebase)' && [ -f .understand-anything/config.json ] && grep -q '\"autoUpdate\".*true' .understand-anything/config.json && [ -f .understand-anything/knowledge-graph.json ] && echo '[understand-anything] Commit detected with auto-update enabled. You MUST read the file at ${PLUGIN_DIR}/hooks/auto-update-prompt.md and execute its instructions to incrementally update the knowledge graph. Do not ask the user for confirmation — just do it.' || true"
+            "command": "echo \"$TOOL_INPUT\" | grep -qE 'git\\s+(commit|merge|cherry-pick|rebase)' && [ -f .understand-anything/config.json ] && grep -q '\"autoUpdate\".*true' .understand-anything/config.json && [ -f .understand-anything/knowledge-graph.json ] && echo \"[understand-anything] Commit detected with auto-update enabled. You MUST read the file at ${PLUGIN_DIR}/hooks/auto-update-prompt.md and execute its instructions to incrementally update the knowledge graph. Do not ask the user for confirmation — just do it.\" || true"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -f .understand-anything/config.json ] && grep -q '\"autoUpdate\".*true' .understand-anything/config.json && [ -f .understand-anything/meta.json ] && [ -f .understand-anything/knowledge-graph.json ] && [ \"$(node -p \"JSON.parse(require('fs').readFileSync('.understand-anything/meta.json','utf8')).gitCommitHash\")\" != \"$(git rev-parse HEAD 2>/dev/null)\" ] && echo '[understand-anything] Knowledge graph is stale. You MUST read the file at ${PLUGIN_DIR}/hooks/auto-update-prompt.md and execute its instructions to check for structural changes and update the graph. Do not ask the user for confirmation — just do it.' || true"
+            "command": "[ -f .understand-anything/config.json ] && grep -q '\"autoUpdate\".*true' .understand-anything/config.json && [ -f .understand-anything/meta.json ] && [ -f .understand-anything/knowledge-graph.json ] && [ \"$(node -p \"JSON.parse(require('fs').readFileSync('.understand-anything/meta.json','utf8')).gitCommitHash\")\" != \"$(git rev-parse HEAD 2>/dev/null)\" ] && echo \"[understand-anything] Knowledge graph is stale. You MUST read the file at ${PLUGIN_DIR}/hooks/auto-update-prompt.md and execute its instructions to check for structural changes and update the graph. Do not ask the user for confirmation — just do it.\" || true"
           }
         ]
       }


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `understand-anything-plugin/hooks/hooks.json`, both the `PostToolUse` and `SessionStart` hook commands use single-quoted strings for the `echo` message that instructs Claude to read `${PLUGIN_DIR}/hooks/auto-update-prompt.md`. In bash, **single quotes suppress all variable expansion**, so `${PLUGIN_DIR}` is passed literally as the five characters `$`, `{`, `P`, `L`, `U`, ... instead of being resolved to the actual plugin directory path.

If Claude Code's hook runner does not pre-expand `${PLUGIN_DIR}` before handing the command to bash, Claude will receive a path like `${PLUGIN_DIR}/hooks/auto-update-prompt.md` — which does not exist — and silently skip the auto-update instructions.

## Fix

Changed the `echo` argument from single quotes to double quotes in both hooks:

```diff
- echo '[understand-anything] ... ${PLUGIN_DIR}/hooks/auto-update-prompt.md ...'
+ echo "[understand-anything] ... ${PLUGIN_DIR}/hooks/auto-update-prompt.md ..."
```

This is the minimal one-character change per hook. Double quotes allow `${PLUGIN_DIR}` to expand at runtime, while still preserving the surrounding bash command structure. No other logic is changed.

## Impact

Without this fix, the auto-update feature (both commit-triggered and session-start staleness check) silently sends Claude a non-existent file path, meaning the knowledge graph is never incrementally updated even when `autoUpdate: true` is configured.