### PR TITLE
fix: use printf instead of echo to pipe TOOL_INPUT into grep

### DIFF
--- a/understand-anything-plugin/hooks/hooks.json
+++ b/understand-anything-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo \"$TOOL_INPUT\" | grep -qE 'git\\s+(commit|merge|cherry-pick|rebase)' && [ -f .understand-anything/config.json ] && grep -q '\"autoUpdate\".*true' .understand-anything/config.json && [ -f .understand-anything/knowledge-graph.json ] && echo '[understand-anything] Commit detected with auto-update enabled. You MUST read the file at ${PLUGIN_DIR}/hooks/auto-update-prompt.md and execute its instructions to incrementally update the knowledge graph. Do not ask the user for confirmation — just do it.' || true"
+            "command": "printf '%s' \"$TOOL_INPUT\" | grep -qE 'git\\s+(commit|merge|cherry-pick|rebase)' && [ -f .understand-anything/config.json ] && grep -q '\"autoUpdate\".*true' .understand-anything/config.json && [ -f .understand-anything/knowledge-graph.json ] && echo '[understand-anything] Commit detected with auto-update enabled. You MUST read the file at ${PLUGIN_DIR}/hooks/auto-update-prompt.md and execute its instructions to incrementally update the knowledge graph. Do not ask the user for confirmation — just do it.' || true"
           }
         ]
       }


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Medium)

In the `PostToolUse` hook in `hooks.json`, raw hook event JSON is piped into `grep` via `echo "$TOOL_INPUT"`. The `echo` built-in in some shells (notably `/bin/sh` and `dash`) interprets escape sequences and flags embedded in the string — for example, if `TOOL_INPUT` begins with `-e` or `-n`, `echo` may strip or misinterpret the value before it reaches `grep`. While no execution vector exists here (grep is used purely for pattern matching with a fixed regex), the input is unvalidated and could cause the hook to behave unexpectedly.

## Fix

Replace `echo "$TOOL_INPUT"` with `printf '%s' "$TOOL_INPUT"`:

```diff
- "command": "echo \"$TOOL_INPUT\" | grep -qE ..."
+ "command": "printf '%s' \"$TOOL_INPUT\" | grep -qE ..."
```

`printf '%s'` passes the value as a plain string with no interpretation of escape sequences or flags, regardless of shell. This is the standard POSIX-safe pattern for piping arbitrary strings into pipelines.

## Impact

Low risk in practice — the grep regex is fixed and the hook exits with `|| true`, so the worst case under the current code is a false negative (hook doesn't fire when it should). The `printf` change removes this ambiguity at no cost.