### PR TITLE
fix: log skipped invalid gitignore patterns to stderr

### DIFF
--- a/understand-anything-plugin/skills/understand-domain/extract-domain-context.py
+++ b/understand-anything-plugin/skills/understand-domain/extract-domain-context.py
@@ -133,8 +133,8 @@ def parse_gitignore(project_root: Path) -> list[re.Pattern[str]]:
             regex = regex.rstrip("/") + "(/|$)"
         try:
             patterns.append(re.compile(regex))
-        except re.error:
-            pass
+        except re.error as e:
+            print(f"Warning: skipping invalid gitignore pattern '{line}': {e}", file=sys.stderr)
     return patterns
 
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Low) / Debuggability Fix

In `extract-domain-context.py`, the `parse_gitignore()` function silently discards any `.gitignore` pattern that fails to compile as a regex (`except re.error: pass`). While there is no execution risk — patterns are used only for path matching — the silent discard makes it impossible for users to diagnose unexpected behavior when files aren't excluded as expected.

For example, a `.gitignore` pattern like `{build,dist}/` would fail the simplified glob-to-regex conversion and be silently skipped, causing those directories to be included in the domain analysis when the user expected them to be excluded.

## Fix

Capture the exception and print a warning to `stderr`:

```diff
-        except re.error:
-            pass
+        except re.error as e:
+            print(f"Warning: skipping invalid gitignore pattern '{line}': {e}", file=sys.stderr)
```

`sys` is already imported at the top of the file. This is a one-line change with zero impact on normal operation — warnings only appear when an invalid pattern is actually encountered.

## Impact

Users running `extract-domain-context.py` will now see actionable warnings if any `.gitignore` patterns are malformed, making exclusion behavior transparent and debuggable.