### PR TITLE
fix: correct hero image extension from .png to .jpg in Hero.astro

### DIFF
--- a/homepage/src/components/Hero.astro
+++ b/homepage/src/components/Hero.astro
@@ -4,7 +4,7 @@ const githubUrl = 'https://github.com/Lum1104/Understand-Anything';
 
 <section class="hero">
   <div class="hero-bg">
-    <img src="/images/hero.png" alt="" class="hero-bg-img" loading="eager" />
+    <img src="/images/hero.jpg" alt="" class="hero-bg-img" loading="eager" />
     <div class="hero-overlay"></div>
   </div>
 


### PR DESCRIPTION
The homepage Hero component referenced `/images/hero.png`, but the actual asset shipped at `homepage/public/images/hero.jpg`. As a result, https://understand-anything.com/images/hero.png returned HTTP 404 and the hero background failed to load.

修复：把 homepage/src/components/Hero.astro:7 的 /images/hero.png 改成 /images/hero.jpg，与仓库中实际存在的 homepage/public/images/hero.jpg 对齐，消除站点首页的 404。

Repro:
  curl -sI https://understand-anything.com/images/hero.png
  # HTTP/2 404

Root cause:
  homepage/src/components/Hero.astro:7
    <img src="/images/hero.png" ... />   # file does not exist
  homepage/public/images/
    hero.jpg (182179 bytes)              # actual file shipped

Fix:
  Single-line: .png -> .jpg in Hero.astro:7. Asset already published,
  no binary changes needed. After Pages rebuild, /images/hero.jpg
  resolves with HTTP 200.