### PR TITLE
Fix dashboard URL format in vite.config.ts

### DIFF
--- a/understand-anything-plugin/packages/dashboard/vite.config.ts
+++ b/understand-anything-plugin/packages/dashboard/vite.config.ts
@@ -240,7 +240,7 @@ export default defineConfig({
           const address = server.httpServer?.address();
           const port = typeof address === "object" && address ? address.port : 5173;
           console.log(
-            `\n  🔑  Dashboard URL: http://127.0.0.1:${port}?token=${ACCESS_TOKEN}\n`
+            `\n  🔑  Dashboard URL: http://127.0.0.1:${port}/?token=${ACCESS_TOKEN}\n`
           );
         });
 


### PR DESCRIPTION
Make url click-able from terminal shell

Now it's now, because of missing slash after port number

<img width="368" height="30" alt="image" src="https://github.com/user-attachments/assets/c0dd79c5-9faf-4232-80bd-5568ce847c2b" />
