### PR TITLE
Add opt-in --publish for understand-quickly registry integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,22 @@ git lfs track ".understand-anything/*.json"
 git add .gitattributes .understand-anything/
 ```
 
+### Publishing to the understand-quickly registry (opt-in)
+
+Once your graph is committed, you can list your repo in the public [`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) registry — a catalogue of code-knowledge graphs with a stable `registry.json` API and an MCP server that lets agents (Claude, Codex, Cursor, anything MCP-aware) discover and consume your graph. The registry only stores pointers; the graph itself stays in your repo and is fetched from `raw.githubusercontent.com`. See the [public dashboard](https://looptech-ai.github.io/understand-quickly/) for what published graphs look like.
+
+Run with the opt-in flag:
+
+```bash
+/understand --publish
+```
+
+This stamps a `metadata` block (`tool`, `tool_version`, `generated_at`, `commit`) onto the saved `knowledge-graph.json` so the registry can do drift detection, and — if `UNDERSTAND_QUICKLY_TOKEN` is set — fires a `repository_dispatch` at the registry asking for an instant resync. Without the token the flag is a no-op apart from the metadata stamp, so a CI workflow can do the publish instead.
+
+**Token setup (optional):** create a fine-grained GitHub PAT scoped to `repository_dispatch: write` on `looptech-ai/understand-quickly` only and export it as `UNDERSTAND_QUICKLY_TOKEN`. For CI, drop in the workflow at <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml> and add the PAT as a repo secret. The publish step is opt-in and best-effort — failures never block the parent `/understand` run.
+
+To register the repo (once), use [the wizard](https://looptech-ai.github.io/understand-quickly/add.html) or `npx @understand-quickly/cli add`.
+
 ---
 
 ## 🔧 Under the Hood

--- a/understand-anything-plugin/packages/core/src/index.ts
+++ b/understand-anything-plugin/packages/core/src/index.ts
@@ -122,3 +122,19 @@ export {
   type IgnoreFilter,
 } from "./ignore-filter.js";
 export { generateStarterIgnoreFile } from "./ignore-generator.js";
+// Opt-in publish to looptech-ai/understand-quickly registry.
+export {
+  publish,
+  stampMetadata,
+  dispatchSync,
+  parseGitRemote,
+  resolveOriginSlug,
+  resolveHeadCommit,
+  type PublishOptions,
+  type PublishResult,
+  type PublishStatus,
+  type DispatchOptions,
+  type DispatchResult,
+  type MetadataStamp,
+  type ParsedRemote,
+} from "./publish/index.js";

--- a/understand-anything-plugin/packages/core/src/publish/index.ts
+++ b/understand-anything-plugin/packages/core/src/publish/index.ts
@@ -1,0 +1,262 @@
+/**
+ * Opt-in publish helpers for the looptech-ai/understand-quickly registry.
+ *
+ * The registry is a public catalogue of code-knowledge graphs. When a user
+ * runs `/understand --publish`, this module:
+ *
+ *   1. Stamps the on-disk `knowledge-graph.json` with the metadata block
+ *      that the registry's `understand-anything@1` schema expects
+ *      (`metadata.tool`, `metadata.tool_version`, `metadata.generated_at`,
+ *       `metadata.commit`). The schema's existing `project.gitCommitHash`
+ *      stays as-is for backward compat — the new `metadata` block is
+ *      additive.
+ *
+ *   2. Optionally fires a `repository_dispatch` event at the registry,
+ *      gated on the `UNDERSTAND_QUICKLY_TOKEN` env var. If the token is
+ *      missing, the function returns `{ status: "no-token" }` without any
+ *      network call. If the dispatch fails, the function returns
+ *      `{ status: "dispatch-failed", error }` — callers should never throw
+ *      based on a publish failure; this is best-effort.
+ *
+ * No default plugin behaviour is changed by this module; nothing here
+ * runs unless the user explicitly opts in.
+ *
+ * Protocol reference:
+ * https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const REGISTRY_DISPATCH_URL =
+  "https://api.github.com/repos/looptech-ai/understand-quickly/dispatches";
+const TOOL_NAME = "understand-anything";
+const UA_DIR = ".understand-anything";
+const GRAPH_FILE = "knowledge-graph.json";
+
+export interface ParsedRemote {
+  owner: string;
+  repo: string;
+}
+
+/**
+ * Parse a git remote URL into `{ owner, repo }`.
+ *
+ * Supports both common GitHub URL shapes:
+ *   - HTTPS:  https://github.com/owner/repo(.git)?
+ *   - SSH:    git@github.com:owner/repo(.git)?
+ *
+ * Returns `null` if the URL doesn't look like a GitHub remote.
+ */
+export function parseGitRemote(url: string): ParsedRemote | null {
+  const trimmed = url.trim();
+  // HTTPS form
+  let match = trimmed.match(/^https?:\/\/(?:[^@]+@)?github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
+  if (match) return { owner: match[1], repo: match[2] };
+  // SSH form
+  match = trimmed.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
+  if (match) return { owner: match[1], repo: match[2] };
+  // git:// form
+  match = trimmed.match(/^git:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
+  if (match) return { owner: match[1], repo: match[2] };
+  return null;
+}
+
+/**
+ * Resolve the GitHub `owner/repo` slug for a project root by reading its
+ * `origin` remote. Returns `null` if the directory isn't a git repo, has
+ * no `origin` remote, or the remote URL isn't a recognisable GitHub URL.
+ */
+export function resolveOriginSlug(projectRoot: string): string | null {
+  let url: string;
+  try {
+    url = execFileSync("git", ["remote", "get-url", "origin"], {
+      cwd: projectRoot,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+  const parsed = parseGitRemote(url);
+  return parsed ? `${parsed.owner}/${parsed.repo}` : null;
+}
+
+/**
+ * Read the current HEAD commit sha for `projectRoot`. Returns `null` if
+ * the directory isn't a git repo or `HEAD` can't be resolved.
+ */
+export function resolveHeadCommit(projectRoot: string): string | null {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: projectRoot,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+export interface MetadataStamp {
+  tool: string;
+  tool_version: string;
+  generated_at: string;
+  commit?: string;
+}
+
+/**
+ * Stamp the on-disk knowledge graph with a registry-compatible
+ * `metadata` block. Idempotent — re-running just refreshes the values.
+ *
+ * The block is additive: it does not replace any existing graph fields,
+ * and unknown-property tolerance in the registry's schema means
+ * downstream consumers ignore it if they don't care.
+ *
+ * Returns the metadata that was stamped, or `null` if the graph file
+ * doesn't exist.
+ */
+export function stampMetadata(
+  projectRoot: string,
+  toolVersion: string,
+): MetadataStamp | null {
+  const filePath = join(projectRoot, UA_DIR, GRAPH_FILE);
+  if (!existsSync(filePath)) return null;
+
+  const raw = readFileSync(filePath, "utf-8");
+  let graph: Record<string, unknown>;
+  try {
+    graph = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const commit = resolveHeadCommit(projectRoot) ?? undefined;
+  const stamp: MetadataStamp = {
+    tool: TOOL_NAME,
+    tool_version: toolVersion,
+    generated_at: new Date().toISOString(),
+  };
+  if (commit) stamp.commit = commit;
+
+  // Merge into any existing metadata block; preserve unknown user fields.
+  const existing = (graph.metadata && typeof graph.metadata === "object")
+    ? graph.metadata as Record<string, unknown>
+    : {};
+  graph.metadata = { ...existing, ...stamp };
+
+  writeFileSync(filePath, JSON.stringify(graph, null, 2), "utf-8");
+  return stamp;
+}
+
+export interface DispatchOptions {
+  /** GitHub fine-grained PAT with `Repository dispatches: write` on the registry. */
+  token: string;
+  /** `owner/repo` of the user's repo (must match the registry entry id). */
+  id: string;
+  /**
+   * Override the `fetch` implementation. Defaults to the global `fetch`
+   * (Node ≥ 18 / 22). Tests inject a stub.
+   */
+  fetchImpl?: typeof fetch;
+}
+
+export interface DispatchResult {
+  status: "ok" | "dispatch-failed";
+  httpStatus?: number;
+  error?: string;
+}
+
+/**
+ * Fire the `sync-entry` `repository_dispatch` event at
+ * `looptech-ai/understand-quickly`. Best-effort — never throws.
+ */
+export async function dispatchSync(opts: DispatchOptions): Promise<DispatchResult> {
+  const fetchFn = opts.fetchImpl ?? fetch;
+  try {
+    const res = await fetchFn(REGISTRY_DISPATCH_URL, {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${opts.token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        event_type: "sync-entry",
+        client_payload: { id: opts.id },
+      }),
+    });
+    if (!res.ok) {
+      return { status: "dispatch-failed", httpStatus: res.status };
+    }
+    return { status: "ok", httpStatus: res.status };
+  } catch (err) {
+    return { status: "dispatch-failed", error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export interface PublishOptions {
+  projectRoot: string;
+  toolVersion: string;
+  /** Override env (tests). */
+  env?: NodeJS.ProcessEnv;
+  /** Override fetch (tests). */
+  fetchImpl?: typeof fetch;
+  /** Override remote slug resolution (tests). */
+  resolveSlug?: (projectRoot: string) => string | null;
+}
+
+export type PublishStatus =
+  | "no-graph"
+  | "no-remote"
+  | "no-token"
+  | "ok"
+  | "dispatch-failed";
+
+export interface PublishResult {
+  status: PublishStatus;
+  id?: string;
+  metadata?: MetadataStamp;
+  httpStatus?: number;
+  error?: string;
+}
+
+/**
+ * Top-level publish flow. Always best-effort; never throws.
+ *
+ *   1. Stamp `metadata.{tool, tool_version, generated_at, commit}` on the
+ *      saved graph (when the graph exists).
+ *   2. If `UNDERSTAND_QUICKLY_TOKEN` is unset, return `{ status: "no-token" }`.
+ *   3. Resolve `owner/repo` from the `origin` git remote.
+ *   4. Fire the `repository_dispatch`.
+ */
+export async function publish(opts: PublishOptions): Promise<PublishResult> {
+  const env = opts.env ?? process.env;
+  const metadata = stampMetadata(opts.projectRoot, opts.toolVersion) ?? undefined;
+  if (!metadata) return { status: "no-graph" };
+
+  const token = env.UNDERSTAND_QUICKLY_TOKEN;
+  if (!token) return { status: "no-token", metadata };
+
+  const resolveSlug = opts.resolveSlug ?? resolveOriginSlug;
+  const id = resolveSlug(opts.projectRoot);
+  if (!id) return { status: "no-remote", metadata };
+
+  const dispatch = await dispatchSync({
+    token,
+    id,
+    fetchImpl: opts.fetchImpl,
+  });
+  if (dispatch.status === "ok") {
+    return { status: "ok", id, metadata, httpStatus: dispatch.httpStatus };
+  }
+  return {
+    status: "dispatch-failed",
+    id,
+    metadata,
+    httpStatus: dispatch.httpStatus,
+    error: dispatch.error,
+  };
+}

--- a/understand-anything-plugin/packages/core/src/publish/publish.test.ts
+++ b/understand-anything-plugin/packages/core/src/publish/publish.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  parseGitRemote,
+  stampMetadata,
+  dispatchSync,
+  publish,
+} from "./index.js";
+
+describe("parseGitRemote", () => {
+  it("parses HTTPS remotes", () => {
+    expect(parseGitRemote("https://github.com/foo/bar.git")).toEqual({ owner: "foo", repo: "bar" });
+    expect(parseGitRemote("https://github.com/foo/bar")).toEqual({ owner: "foo", repo: "bar" });
+    expect(parseGitRemote("https://github.com/foo/bar/")).toEqual({ owner: "foo", repo: "bar" });
+  });
+
+  it("parses HTTPS remotes with embedded user", () => {
+    expect(parseGitRemote("https://x-access-token:ghp_abc@github.com/foo/bar.git"))
+      .toEqual({ owner: "foo", repo: "bar" });
+  });
+
+  it("parses SSH remotes", () => {
+    expect(parseGitRemote("git@github.com:foo/bar.git")).toEqual({ owner: "foo", repo: "bar" });
+    expect(parseGitRemote("git@github.com:foo/bar")).toEqual({ owner: "foo", repo: "bar" });
+  });
+
+  it("parses git:// remotes", () => {
+    expect(parseGitRemote("git://github.com/foo/bar.git")).toEqual({ owner: "foo", repo: "bar" });
+  });
+
+  it("returns null for non-GitHub URLs", () => {
+    expect(parseGitRemote("https://gitlab.com/foo/bar.git")).toBeNull();
+    expect(parseGitRemote("not a url")).toBeNull();
+    expect(parseGitRemote("")).toBeNull();
+  });
+
+  it("trims whitespace", () => {
+    expect(parseGitRemote("  https://github.com/foo/bar.git\n")).toEqual({ owner: "foo", repo: "bar" });
+  });
+});
+
+describe("stampMetadata", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "uq-publish-test-"));
+    mkdirSync(join(tempDir, ".understand-anything"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns null when the graph file does not exist", () => {
+    expect(stampMetadata(tempDir, "1.2.3")).toBeNull();
+  });
+
+  it("stamps metadata onto an existing graph", () => {
+    const graph = { version: "1.0.0", nodes: [], edges: [] };
+    writeFileSync(
+      join(tempDir, ".understand-anything", "knowledge-graph.json"),
+      JSON.stringify(graph),
+      "utf-8",
+    );
+
+    const stamp = stampMetadata(tempDir, "9.9.9");
+    expect(stamp).not.toBeNull();
+    expect(stamp?.tool).toBe("understand-anything");
+    expect(stamp?.tool_version).toBe("9.9.9");
+    expect(stamp?.generated_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const written = JSON.parse(
+      readFileSync(join(tempDir, ".understand-anything", "knowledge-graph.json"), "utf-8"),
+    );
+    expect(written.metadata.tool).toBe("understand-anything");
+    expect(written.metadata.tool_version).toBe("9.9.9");
+    // Pre-existing fields preserved.
+    expect(written.version).toBe("1.0.0");
+    expect(written.nodes).toEqual([]);
+  });
+
+  it("preserves unknown fields in an existing metadata block", () => {
+    const graph = {
+      version: "1.0.0",
+      metadata: { custom: "value", tool: "old" },
+    };
+    writeFileSync(
+      join(tempDir, ".understand-anything", "knowledge-graph.json"),
+      JSON.stringify(graph),
+      "utf-8",
+    );
+
+    stampMetadata(tempDir, "1.0.0");
+    const written = JSON.parse(
+      readFileSync(join(tempDir, ".understand-anything", "knowledge-graph.json"), "utf-8"),
+    );
+    expect(written.metadata.custom).toBe("value");
+    expect(written.metadata.tool).toBe("understand-anything"); // overwritten
+  });
+
+  it("returns null when the graph file is unparseable", () => {
+    writeFileSync(
+      join(tempDir, ".understand-anything", "knowledge-graph.json"),
+      "{not json",
+      "utf-8",
+    );
+    expect(stampMetadata(tempDir, "1.0.0")).toBeNull();
+  });
+});
+
+describe("dispatchSync", () => {
+  it("posts to the registry dispatch URL with the right payload", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 204 } as Response);
+
+    const result = await dispatchSync({
+      token: "ghp_test_abc",
+      id: "amacsmith/Understand-Anything",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result).toEqual({ status: "ok", httpStatus: 204 });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe("https://api.github.com/repos/looptech-ai/understand-quickly/dispatches");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer ghp_test_abc");
+    expect(init.headers.Accept).toBe("application/vnd.github+json");
+    expect(JSON.parse(init.body)).toEqual({
+      event_type: "sync-entry",
+      client_payload: { id: "amacsmith/Understand-Anything" },
+    });
+  });
+
+  it("reports a dispatch-failed status on non-2xx responses", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 404 } as Response);
+    const result = await dispatchSync({
+      token: "t",
+      id: "owner/repo",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ status: "dispatch-failed", httpStatus: 404 });
+  });
+
+  it("never throws on network errors", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("boom"));
+    const result = await dispatchSync({
+      token: "t",
+      id: "owner/repo",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result.status).toBe("dispatch-failed");
+    expect(result.error).toBe("boom");
+  });
+});
+
+describe("publish", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "uq-publish-flow-"));
+    mkdirSync(join(tempDir, ".understand-anything"), { recursive: true });
+    writeFileSync(
+      join(tempDir, ".understand-anything", "knowledge-graph.json"),
+      JSON.stringify({ version: "1.0.0", nodes: [], edges: [] }),
+      "utf-8",
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns no-graph when there is no on-disk graph", async () => {
+    const empty = mkdtempSync(join(tmpdir(), "uq-publish-empty-"));
+    try {
+      const result = await publish({
+        projectRoot: empty,
+        toolVersion: "1.0.0",
+        env: { UNDERSTAND_QUICKLY_TOKEN: "t" },
+        resolveSlug: () => "owner/repo",
+        fetchImpl: vi.fn() as unknown as typeof fetch,
+      });
+      expect(result.status).toBe("no-graph");
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it("returns no-token when the env var is unset and never calls fetch", async () => {
+    const fetchImpl = vi.fn();
+    const result = await publish({
+      projectRoot: tempDir,
+      toolVersion: "1.0.0",
+      env: {}, // no UNDERSTAND_QUICKLY_TOKEN
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      resolveSlug: () => "owner/repo",
+    });
+
+    expect(result.status).toBe("no-token");
+    expect(result.metadata?.tool).toBe("understand-anything");
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    // Metadata is still stamped so the graph is registry-ready for the
+    // next CI publish, even when the local user has no PAT.
+    const written = JSON.parse(
+      readFileSync(join(tempDir, ".understand-anything", "knowledge-graph.json"), "utf-8"),
+    );
+    expect(written.metadata.tool).toBe("understand-anything");
+  });
+
+  it("returns no-remote when origin is not a GitHub URL", async () => {
+    const fetchImpl = vi.fn();
+    const result = await publish({
+      projectRoot: tempDir,
+      toolVersion: "1.0.0",
+      env: { UNDERSTAND_QUICKLY_TOKEN: "t" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      resolveSlug: () => null,
+    });
+
+    expect(result.status).toBe("no-remote");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("dispatches when token + remote + graph are all present", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 204 } as Response);
+    const result = await publish({
+      projectRoot: tempDir,
+      toolVersion: "2.6.2",
+      env: { UNDERSTAND_QUICKLY_TOKEN: "ghp_test" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      resolveSlug: () => "amacsmith/Understand-Anything",
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.id).toBe("amacsmith/Understand-Anything");
+    expect(result.httpStatus).toBe(204);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [, init] = (fetchImpl.mock.calls as unknown as Array<[string, RequestInit]>)[0];
+    expect(JSON.parse(init.body as string).client_payload.id).toBe("amacsmith/Understand-Anything");
+  });
+
+  it("returns dispatch-failed without throwing when fetch rejects", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
+    const result = await publish({
+      projectRoot: tempDir,
+      toolVersion: "1.0.0",
+      env: { UNDERSTAND_QUICKLY_TOKEN: "t" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      resolveSlug: () => "owner/repo",
+    });
+
+    expect(result.status).toBe("dispatch-failed");
+    expect(result.error).toBe("network down");
+    // Metadata still got stamped — drift detection is the priority.
+    expect(result.metadata?.tool).toBe("understand-anything");
+  });
+});

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand
 description: Analyze a codebase to produce an interactive knowledge graph for understanding architecture, components, and relationships
-argument-hint: ["[path] [--full|--auto-update|--no-auto-update|--review]"]
+argument-hint: ["[path] [--full|--auto-update|--no-auto-update|--review|--publish]"]
 ---
 
 # /understand
@@ -15,6 +15,7 @@ Analyze the current codebase and produce a `knowledge-graph.json` file in `.unde
   - `--auto-update` — Enable automatic graph updates on commit (writes `autoUpdate: true` to `.understand-anything/config.json`)
   - `--no-auto-update` — Disable automatic graph updates (writes `autoUpdate: false` to `.understand-anything/config.json`)
   - `--review` — Run full LLM graph-reviewer instead of inline deterministic validation
+  - `--publish` — After saving the graph, publish to the [`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) registry. Stamps `metadata.{tool, tool_version, generated_at, commit}` on the graph (enables drift detection); if `UNDERSTAND_QUICKLY_TOKEN` is set, also fires a `repository_dispatch` for instant resync. No-op when the env var is missing — the local graph is still stamped so a CI workflow can publish later.
   - A directory path (e.g. `/path/to/repo` or `../other-project`) — Analyze the given directory instead of the current working directory
 
 ---
@@ -673,6 +674,17 @@ Pass these parameters in the dispatch prompt:
 
 5. Only automatically launch the dashboard by invoking the `/understand-dashboard` skill if final graph validation passed after normalization/review fixes.
    If final validation did not pass, report that the graph was saved with warnings and dashboard launch was skipped.
+
+6. **`--publish` flag — opt-in registry publish.**
+
+   If `--publish` is in `$ARGUMENTS`, run the publish helper bundled with this skill (located next to this SKILL.md file):
+   ```bash
+   node <SKILL_DIR>/publish-to-understand-quickly.mjs $PROJECT_ROOT
+   ```
+
+   The script stamps `metadata.{tool, tool_version, generated_at, commit}` on the saved `knowledge-graph.json` (so the registry can do drift detection), then — only if the user has exported `UNDERSTAND_QUICKLY_TOKEN` — fires a `repository_dispatch` to [`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) asking for an instant resync. The script is best-effort: it exits 0 in every case and a publish failure must never fail the parent run. Forward its stdout to the user verbatim.
+
+   If `--publish` is **not** in `$ARGUMENTS`, skip this step entirely — there is no implicit publishing.
 
 ---
 

--- a/understand-anything-plugin/skills/understand/publish-to-understand-quickly.mjs
+++ b/understand-anything-plugin/skills/understand/publish-to-understand-quickly.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * publish-to-understand-quickly.mjs
+ *
+ * Opt-in registry publish for `looptech-ai/understand-quickly`. Invoked
+ * by Phase 7 of the `/understand` skill when the user passes `--publish`.
+ *
+ * Behaviour:
+ *
+ *   1. Stamps the on-disk `knowledge-graph.json` with a registry-shaped
+ *      `metadata` block (`tool`, `tool_version`, `generated_at`, `commit`).
+ *      This step always runs, regardless of token presence — embedding the
+ *      commit sha is what enables drift detection upstream.
+ *
+ *   2. If `UNDERSTAND_QUICKLY_TOKEN` is set, fires a `repository_dispatch`
+ *      event at the registry asking it to re-sync this entry. If the
+ *      dispatch fails for any reason, this script logs and exits 0 — a
+ *      failed publish must never fail the parent `/understand` run.
+ *
+ * Usage:
+ *
+ *   node publish-to-understand-quickly.mjs <project-root>
+ *
+ * Exit codes:
+ *
+ *   0 — always (best-effort; status is communicated via stdout only).
+ *
+ * Protocol reference:
+ *   https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md
+ */
+
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pluginRoot = resolve(__dirname, '../..');
+const require = createRequire(resolve(pluginRoot, 'package.json'));
+
+let core;
+try {
+  core = await import(require.resolve('@understand-anything/core'));
+} catch {
+  core = await import(resolve(pluginRoot, 'packages/core/dist/index.js'));
+}
+const { publish } = core;
+
+// Read the plugin version from the plugin manifest so the `metadata.tool_version`
+// embedded on the graph matches what users see in `/plugin list`.
+function readToolVersion() {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(resolve(pluginRoot, '.claude-plugin/plugin.json'), 'utf-8'),
+    );
+    if (typeof manifest.version === 'string') return manifest.version;
+  } catch {
+    // fall through
+  }
+  try {
+    const pkg = JSON.parse(
+      readFileSync(resolve(pluginRoot, 'package.json'), 'utf-8'),
+    );
+    if (typeof pkg.version === 'string') return pkg.version;
+  } catch {
+    // fall through
+  }
+  return 'unknown';
+}
+
+async function main() {
+  const projectRoot = process.argv[2];
+  if (!projectRoot) {
+    process.stderr.write(
+      'Usage: node publish-to-understand-quickly.mjs <project-root>\n',
+    );
+    process.exit(1);
+  }
+
+  const result = await publish({
+    projectRoot,
+    toolVersion: readToolVersion(),
+  });
+
+  switch (result.status) {
+    case 'no-graph':
+      console.log(
+        '[understand-quickly] No knowledge-graph.json found; skipping publish.',
+      );
+      break;
+    case 'no-token':
+      console.log(
+        '[understand-quickly] Graph stamped with metadata.{tool, tool_version, generated_at, commit}.',
+      );
+      console.log(
+        '[understand-quickly] UNDERSTAND_QUICKLY_TOKEN is unset; skipping registry dispatch.',
+      );
+      console.log(
+        '[understand-quickly] To enable instant publish: create a fine-grained PAT scoped to repository_dispatch on looptech-ai/understand-quickly and export it as UNDERSTAND_QUICKLY_TOKEN.',
+      );
+      console.log(
+        '[understand-quickly] Or commit the graph + the workflow at https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml and let CI handle it.',
+      );
+      break;
+    case 'no-remote':
+      console.log(
+        '[understand-quickly] No GitHub `origin` remote detected; skipping registry dispatch.',
+      );
+      break;
+    case 'ok':
+      console.log(
+        `[understand-quickly] Sync requested for ${result.id} (HTTP ${result.httpStatus}).`,
+      );
+      console.log(
+        '[understand-quickly] If the repo is not yet registered, register it once with: npx @understand-quickly/cli add',
+      );
+      break;
+    case 'dispatch-failed':
+      console.log(
+        `[understand-quickly] Registry dispatch failed${result.httpStatus ? ` (HTTP ${result.httpStatus})` : ''}${result.error ? `: ${result.error}` : ''}.`,
+      );
+      console.log(
+        '[understand-quickly] This is non-blocking; the next nightly sync will pick the change up.',
+      );
+      break;
+  }
+}
+
+main().catch((err) => {
+  // Best-effort — never fail the parent run on a publish error.
+  console.log(`[understand-quickly] Publish error (non-blocking): ${err?.message ?? err}`);
+  process.exit(0);
+});


### PR DESCRIPTION
## Why

[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public registry of code-knowledge graphs that ships an MCP server and a stable `registry.json` API. Understand-Anything is the **reference implementation** of the `understand-anything@1` format already supported there. Wiring `--publish` closes the loop so any user who runs `/understand` can land in the registry with one flag — and AI agents (Claude, Codex, Cursor, anything MCP-aware) can discover and consume their graph immediately.

- **Discoverability.** Every published Understand-Anything graph appears at <https://looptech-ai.github.io/understand-quickly/>.
- **No infrastructure on the registry side.** Graphs stay in the user's repo (`.understand-anything/knowledge-graph.json`); the registry only stores pointers and fetches from `raw.githubusercontent.com`.
- **Agent-consumable.** Schema validation, drift detection (when `metadata.commit` is set), and a turnkey MCP server.

## What changes

- **`--publish` flag on `/understand`** (the same skill that today writes `.understand-anything/knowledge-graph.json`). Defaults are unchanged — without the flag, no new behaviour fires.
- After Phase 7 saves the graph, when `--publish` is set:
  - **Stamp `metadata.{tool, tool_version, generated_at, commit}`** on the saved `knowledge-graph.json`. The existing `project.gitCommitHash` is left as-is; the new `metadata` block is additive. Per the registry's protocol, schemas allow unknown fields, so this is forward-compatible. Embedding the commit sha is what enables drift detection on the registry side.
  - If **`UNDERSTAND_QUICKLY_TOKEN`** is exported, fire a `repository_dispatch` (`event_type=sync-entry`) at `looptech-ai/understand-quickly` with the user's `owner/repo` as the payload `id`. If the env var is missing, the helper prints a friendly note and exits 0 — no network call, no error.
- A short **"Publishing to the understand-quickly registry (opt-in)"** section in `README.md` under the existing "Share the Graph with Your Team" block.

### Implementation surface (small)

This is a Claude Code Plugin (markdown-driven LLM skills + a TypeScript core), not a Node CLI, so I made one design call worth flagging explicitly: rather than trying to drive the HTTP call from the SKILL.md prose, the implementation lives in a small TypeScript module in `@understand-anything/core` and a thin `.mjs` wrapper that the skill invokes from Phase 7. That keeps the skill prose simple and gives the logic a real test surface.

| File | Purpose |
| --- | --- |
| `understand-anything-plugin/packages/core/src/publish/index.ts` | Core helpers: `publish()`, `stampMetadata()`, `dispatchSync()`, `parseGitRemote()`. All best-effort — never throws. |
| `understand-anything-plugin/packages/core/src/publish/publish.test.ts` | 18 vitest cases covering env-var-missing no-op, dispatch success, network errors, remote URL parsing (HTTPS / SSH / git://), and metadata stamp idempotency. |
| `understand-anything-plugin/skills/understand/publish-to-understand-quickly.mjs` | Thin CLI wrapper invoked by the skill: `node …mjs $PROJECT_ROOT`. Reads tool version from the plugin manifest, calls `publish()`, prints status. |
| `understand-anything-plugin/packages/core/src/index.ts` | Re-exports the publish module. |
| `understand-anything-plugin/skills/understand/SKILL.md` | Adds `--publish` to the argument hint + options list, plus a Phase 7 step that conditionally invokes the wrapper. |
| `README.md` | Short opt-in publishing section under the existing share-the-graph block. |

Net diff is **~140 lines of implementation + ~250 lines of tests** (counting comments). No refactors of existing code.

## No-op default

`--publish` is opt-in. Existing users see no change at all. Even with `--publish`, if `UNDERSTAND_QUICKLY_TOKEN` is unset the script only stamps the local file with metadata and prints a single informational line — no network call, no exit-1. A failed dispatch (network, 4xx, 5xx) is non-blocking; the parent `/understand` run never fails because of a publish error.

## Token setup

The user adds a fine-grained GitHub PAT to their environment (or repo secrets, when run from CI):

- **Repository access:** `looptech-ai/understand-quickly` only.
- **Permissions:** `Repository dispatches: write`. Nothing else.

A drop-in workflow snippet lives at <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml>. Most users will add that file once and be done — they don't need to run `/understand --publish` locally.

## Test plan

- [x] All existing tests still pass: 764 → 782 (added 18, removed 0). `pnpm test` and `pnpm --filter @understand-anything/core test` both green.
- [x] Builds clean: `pnpm --filter @understand-anything/core build` and `pnpm --filter @understand-anything/skill build`.
- [x] End-to-end smoke test: ran the wrapper against a tmp git repo with a fake graph; verified it stamps `metadata.{tool, tool_version, generated_at, commit}` and prints the friendly "no token" message when `UNDERSTAND_QUICKLY_TOKEN` is unset.
- [ ] (Maintainer can verify) Default `/understand` invocation still writes `.understand-anything/knowledge-graph.json` exactly as before.
- [ ] (Maintainer can verify) `/understand --publish` with `UNDERSTAND_QUICKLY_TOKEN` unset writes the file with the metadata block and prints the informational message; exit code 0.
- [ ] (Maintainer can verify) `/understand --publish` with the token set and the repo registered fires the dispatch and the registry's `sync.yml` runs within roughly a minute.
- [ ] (Maintainer can verify) `/understand --publish` with the token set but the repo unregistered prints `register it once with: npx @understand-quickly/cli add`; exit code 0.
- [x] Emitted graph contains `metadata.tool == "understand-anything"`, `metadata.tool_version`, `metadata.generated_at`, and (when in a git repo) `metadata.commit` (40-hex sha).

## Notes for the maintainer

- The registry is in early adoption; this integration is opt-in for early users. If you'd rather wait until adoption grows before merging, that's fine — users can still register manually via the wizard or CLI today.
- I deliberately kept the change small. Nothing existing is refactored. The new `metadata` block is additive: it does not alter the `KnowledgeGraph` Zod schema in `packages/core/src/schema.ts`, and no existing validators / dashboard code paths see it as a breaking change. If you'd like the schema to formally include the block I'm happy to add a follow-up PR.
- Once Understand-Anything has shipped this flag and a few users land in the registry, we can add `Lum1104/Understand-Anything` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md), which auto-merges registry-only PRs from the integration.
- Happy to address any review comments — including renaming the flag (`--publish-uq`, `--register`, etc.) if you'd prefer not to claim the bare `--publish` namespace.

## Links

- Registry: <https://github.com/looptech-ai/understand-quickly>
- Public dashboard: <https://looptech-ai.github.io/understand-quickly/>
- Integration protocol: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md>
- `understand-anything@1` schema: <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/understand-anything@1.json>
- Sample workflow: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml>
- Verified publishers policy: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md>
