### PR TITLE
fix(skills/understand-domain): resolve plugin root for agent prompt loading (#146)

### DIFF
--- a/understand-anything-plugin/skills/understand-domain/SKILL.md
+++ b/understand-anything-plugin/skills/understand-domain/SKILL.md
@@ -42,6 +42,50 @@ fi
 
 Use `$PROJECT_ROOT` (not the bare CWD) for every reference to "the current project" / `<project-root>` in subsequent phases.
 
+**Important:** do **not** assume the plugin root is simply two directories above the skill path string. In many installations `~/.agents/skills/understand-domain` is a symlink into the real plugin checkout. Prefer runtime-provided plugin roots first (for Claude), then fall back to universal symlinks, skill symlink resolution, and common clone-based install paths.
+
+Resolve the plugin root like this:
+
+```bash
+SKILL_REAL=$(realpath ~/.agents/skills/understand-domain 2>/dev/null || readlink -f ~/.agents/skills/understand-domain 2>/dev/null || echo "")
+SELF_RELATIVE=$([ -n "$SKILL_REAL" ] && cd "$SKILL_REAL/../.." 2>/dev/null && pwd || echo "")
+COPILOT_SKILL_REAL=$(realpath ~/.copilot/skills/understand-domain 2>/dev/null || readlink -f ~/.copilot/skills/understand-domain 2>/dev/null || echo "")
+COPILOT_SELF_RELATIVE=$([ -n "$COPILOT_SKILL_REAL" ] && cd "$COPILOT_SKILL_REAL/../.." 2>/dev/null && pwd || echo "")
+
+PLUGIN_ROOT=""
+for candidate in \
+  "${CLAUDE_PLUGIN_ROOT}" \
+  "$HOME/.understand-anything-plugin" \
+  "$SELF_RELATIVE" \
+  "$COPILOT_SELF_RELATIVE" \
+  "$HOME/.codex/understand-anything/understand-anything-plugin" \
+  "$HOME/.opencode/understand-anything/understand-anything-plugin" \
+  "$HOME/.pi/understand-anything/understand-anything-plugin" \
+  "$HOME/understand-anything/understand-anything-plugin"; do
+  if [ -n "$candidate" ] && [ -f "$candidate/package.json" ] && [ -f "$candidate/pnpm-workspace.yaml" ]; then
+    PLUGIN_ROOT="$candidate"
+    break
+  fi
+done
+
+if [ -z "$PLUGIN_ROOT" ]; then
+  echo "Error: Cannot find the understand-anything plugin root."
+  echo "Checked:"
+  echo "  - ${CLAUDE_PLUGIN_ROOT:-<unset CLAUDE_PLUGIN_ROOT>}"
+  echo "  - $HOME/.understand-anything-plugin"
+  echo "  - ${SELF_RELATIVE:-<unresolved path derived from ~/.agents/skills/understand-domain>}"
+  echo "  - ${COPILOT_SELF_RELATIVE:-<unresolved path derived from ~/.copilot/skills/understand-domain>}"
+  echo "  - $HOME/.codex/understand-anything/understand-anything-plugin"
+  echo "  - $HOME/.opencode/understand-anything/understand-anything-plugin"
+  echo "  - $HOME/.pi/understand-anything/understand-anything-plugin"
+  echo "  - $HOME/understand-anything/understand-anything-plugin"
+  echo "Make sure the plugin is installed correctly."
+  exit 1
+fi
+```
+
+Use `$PLUGIN_ROOT` for every reference to agent definitions in subsequent phases.
+
 ### Phase 1: Detect Existing Graph
 
 1. Check if `$PROJECT_ROOT/.understand-anything/knowledge-graph.json` exists
@@ -78,7 +122,7 @@ The preprocessing script does NOT produce a domain graph — it produces **raw m
 
 ### Phase 4: Domain Analysis
 
-1. Read the domain-analyzer agent prompt from `agents/domain-analyzer.md`
+1. Read the domain-analyzer agent prompt from `$PLUGIN_ROOT/agents/domain-analyzer.md`
 2. Dispatch a subagent with the domain-analyzer prompt + the context from Phase 2 or 3
 3. The agent writes its output to `$PROJECT_ROOT/.understand-anything/intermediate/domain-analysis.json`
 


### PR DESCRIPTION
Fixes #146

`understand-domain` was loading the domain-analyzer agent prompt via a relative path (`agents/domain-analyzer.md`), which broke when the skill was symlinked into place. 

Ported the `$PLUGIN_ROOT` resolution pattern from `understand/SKILL.md` so the agent prompt is loaded from the actual plugin root regardless of how the skill is installed.