### PR TITLE
chore: add ESLint tooling with TypeScript support

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,29 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.strict,
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ['*.config.*'],
+        },
+      },
+    },
+  },
+  {
+    ignores: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/build/**',
+      '**/.understand-anything/**',
+      '**/.claude-plugin/**',
+      '**/.cursor-plugin/**',
+      '**/.copilot-plugin/**',
+      '**/coverage/**',
+    ],
+  },
+);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "lint": "eslint ."
   },
   "devDependencies": {
+    "@eslint/js": "^9.0.0",
+    "eslint": "^9.0.0",
     "typescript": "^5.7.0",
+    "typescript-eslint": "^8.0.0",
     "vitest": "^3.1.0"
   },
   "pnpm": {


### PR DESCRIPTION
## Summary

The repository has a `pnpm lint` script that runs `eslint .` but ESLint and typescript-eslint were not listed in devDependencies, causing the script to fail.

Added:
- `eslint` (^9.0.0)
- `@eslint/js` (^9.0.0)
- `typescript-eslint` (^8.0.0)

Also added `eslint.config.mjs` with flat config format (ESLint 9+) using `typescript-eslint` strict rules. Ignores node_modules, dist, build, and framework-specific output directories.

## Problem

Running `pnpm lint` fails with `eslint: not found` because ESLint is not installed as a dependency.

## Solution

Add the required ESLint packages as devDependencies and create the flat-config file. Does not fix any linting errors - this PR only adds the tooling infrastructure.

## Tests

ESLint tooling added; actual lint error fixes will be a separate concern.

## Risk / Compatibility

- No runtime code changes
- No new runtime dependencies added
- Only tooling (devDependency) additions