### PR TITLE
fix(skills/understand): extract-structure isCli silently no-ops via symlinked SKILL_DIR

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "author": {
     "name": "Lum1104"
   },

--- a/.copilot-plugin/plugin.json
+++ b/.copilot-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "author": {
     "name": "Lum1104"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "understand-anything",
   "displayName": "Understand Anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "author": {
     "name": "Lum1104"
   },

--- a/understand-anything-plugin/.claude-plugin/plugin.json
+++ b/understand-anything-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "author": {
     "name": "Lum1104"
   },

--- a/understand-anything-plugin/agents/file-analyzer.md
+++ b/understand-anything-plugin/agents/file-analyzer.md
@@ -64,6 +64,8 @@ node <SKILL_DIR>/extract-structure.mjs \
 
 If the script exits non-zero, read stderr and report the error. Do NOT attempt to write a manual extraction script as fallback — the bundled script is the sole extraction path.
 
+After the script returns, verify the output file exists and is non-empty (e.g. `test -s $PROJECT_ROOT/.understand-anything/tmp/ua-file-extract-results-<batchIndex>.json`). Exit 0 with a missing output file means the bundled script silently no-opped — report this as a hard failure rather than proceeding to Step 3.
+
 ### Step 3 — Read the extraction results
 
 Read `$PROJECT_ROOT/.understand-anything/tmp/ua-file-extract-results-<batchIndex>.json`. The output format is:

--- a/understand-anything-plugin/package.json
+++ b/understand-anything-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understand-anything/skill",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/understand-anything-plugin/skills/understand/extract-structure.mjs
+++ b/understand-anything-plugin/skills/understand/extract-structure.mjs
@@ -19,7 +19,7 @@
 import { createRequire } from 'node:module';
 import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // skills/understand/ -> plugin root is two dirs up
@@ -133,6 +133,10 @@ async function main() {
   };
 
   writeFileSync(outputPath, JSON.stringify(output, null, 2), 'utf-8');
+
+  if (!existsSync(outputPath)) {
+    throw new Error(`output file missing after write: ${outputPath}`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -302,11 +306,25 @@ export function buildResult(file, totalLines, nonEmptyLines, analysis, callGraph
 // ---------------------------------------------------------------------------
 // Run only when executed directly as a CLI; importing the module (e.g. from
 // tests) must not trigger main().
+//
+// Canonicalize both sides through realpathSync. Node ESM resolves
+// import.meta.url through symlinks but pathToFileURL(process.argv[1]) preserves
+// them, so a raw equality check silently no-ops when the script is invoked via
+// a symlinked plugin install path (the default in Claude Code / Copilot CLI
+// caches). See GitHub issue #162.
 // ---------------------------------------------------------------------------
-const isCli =
-  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+function isCliEntry() {
+  if (!process.argv[1]) return false;
+  try {
+    const modulePath = realpathSync(fileURLToPath(import.meta.url));
+    const argvPath = realpathSync(process.argv[1]);
+    return modulePath === argvPath;
+  } catch {
+    return false;
+  }
+}
 
-if (isCli) {
+if (isCliEntry()) {
   try {
     await main();
   } catch (err) {


### PR DESCRIPTION
## Summary

- Fix `extract-structure.mjs` `isCli` guard: canonicalize both `import.meta.url` and `process.argv[1]` through `realpathSync` so symlinked install paths (the Claude Code / Copilot CLI default) no longer cause silent exit-0 with no output. Closes #162.
- Add `existsSync` assertion after `writeFileSync` as a defensive sanity check inside `main()`.
- Update `agents/file-analyzer.md` Step 2 to require `test -s` on the output file after running the script — exit 0 with missing output is now a hard failure rather than a silent path to Step 3.
- Bump version 2.7.3 → 2.7.4 in all five plugin manifest files.

## Test plan

- [x] `pnpm --filter @understand-anything/skill test` — 775 tests passing (incl. 10 extract-structure tests).
- [x] Repro script: create a symlink to `extract-structure.mjs`, invoke via the symlinked path with a minimal empty-batch input — pre-fix this silently exited 0 with no output, post-fix produces the expected `scriptCompleted: true` JSON.
- [ ] Reviewer: run `/understand --full` end-to-end on a real project to confirm the file-analyzer agents now write extract-results files in normal plugin-cache installs.

Verification transcript:

```
=== Invoking via symlinked path ===
exit=0
=== Output file check ===
OK: output written (90 bytes)
{
  "scriptCompleted": true,
  "filesAnalyzed": 0,
  "filesSkipped": [],
  "results": []
}
```