### PR TITLE
docs(skills): update graph structure references

### DIFF
--- a/understand-anything-plugin/skills/understand-chat/SKILL.md
+++ b/understand-anything-plugin/skills/understand-chat/SKILL.md
@@ -12,11 +12,13 @@ Answer questions about this codebase using the knowledge graph at `.understand-a
 
 The knowledge graph JSON has this structure:
 - `project` — {name, description, languages, frameworks, analyzedAt, gitCommitHash}
-- `nodes[]` — each has {id, type, name, filePath, summary, tags[], complexity, languageNotes?}
-  - Node types: file, function, class, module, concept
-  - IDs: `file:path`, `function:path:name`, `class:path:name`
+- `nodes[]` — each has {id, type, name, filePath?, summary, tags[], complexity, languageNotes?}
+  - Code node types: file, function, class, module, concept
+  - Non-code node types: config, document, service, table, endpoint, pipeline, schema, resource
+  - Domain/knowledge node types: domain, flow, step, article, entity, topic, claim, source
+  - IDs use the node type as prefix, e.g. `file:path`, `function:path:name`, `config:path`, `article:path`
 - `edges[]` — each has {source, target, type, direction, weight}
-  - Key types: imports, contains, calls, depends_on
+  - Key types: imports, contains, calls, depends_on, configures, documents, deploys, triggers, contains_flow, flow_step, related, cites
 - `layers[]` — each has {id, name, description, nodeIds[]}
 - `tour[]` — each has {order, title, description, nodeIds[]}
 

--- a/understand-anything-plugin/skills/understand-diff/SKILL.md
+++ b/understand-anything-plugin/skills/understand-diff/SKILL.md
@@ -11,11 +11,13 @@ Analyze the current code changes against the knowledge graph at `.understand-any
 
 The knowledge graph JSON has this structure:
 - `project` — {name, description, languages, frameworks, analyzedAt, gitCommitHash}
-- `nodes[]` — each has {id, type, name, filePath, summary, tags[], complexity, languageNotes?}
-  - Node types: file, function, class, module, concept
-  - IDs: `file:path`, `function:path:name`, `class:path:name`
+- `nodes[]` — each has {id, type, name, filePath?, summary, tags[], complexity, languageNotes?}
+  - Code node types: file, function, class, module, concept
+  - Non-code node types: config, document, service, table, endpoint, pipeline, schema, resource
+  - Domain/knowledge node types: domain, flow, step, article, entity, topic, claim, source
+  - IDs use the node type as prefix, e.g. `file:path`, `function:path:name`, `config:path`, `article:path`
 - `edges[]` — each has {source, target, type, direction, weight}
-  - Key types: imports, contains, calls, depends_on
+  - Key types: imports, contains, calls, depends_on, configures, documents, deploys, triggers, contains_flow, flow_step, related, cites
 - `layers[]` — each has {id, name, description, nodeIds[]}
 - `tour[]` — each has {order, title, description, nodeIds[]}
 
@@ -39,7 +41,7 @@ The knowledge graph JSON has this structure:
 
 4. **Find nodes for changed files** — for each changed file path, use Grep to search the knowledge graph for:
    - Nodes with matching `"filePath"` values (e.g., `grep "changed/file/path"`)
-   - This finds file nodes AND function/class nodes defined in those files
+   - This finds file-level nodes (including non-code types) AND function/class nodes defined in those files
    - Note the `id` values of all matched nodes
 
 5. **Find connected edges (1-hop)** — for each matched node ID, Grep for that ID in the edges to find:

--- a/understand-anything-plugin/skills/understand-explain/SKILL.md
+++ b/understand-anything-plugin/skills/understand-explain/SKILL.md
@@ -12,11 +12,13 @@ Provide a thorough, in-depth explanation of a specific code component.
 
 The knowledge graph JSON has this structure:
 - `project` — {name, description, languages, frameworks, analyzedAt, gitCommitHash}
-- `nodes[]` — each has {id, type, name, filePath, summary, tags[], complexity, languageNotes?}
-  - Node types: file, function, class, module, concept
-  - IDs: `file:path`, `function:path:name`, `class:path:name`
+- `nodes[]` — each has {id, type, name, filePath?, summary, tags[], complexity, languageNotes?}
+  - Code node types: file, function, class, module, concept
+  - Non-code node types: config, document, service, table, endpoint, pipeline, schema, resource
+  - Domain/knowledge node types: domain, flow, step, article, entity, topic, claim, source
+  - IDs use the node type as prefix, e.g. `file:path`, `function:path:name`, `config:path`, `article:path`
 - `edges[]` — each has {source, target, type, direction, weight}
-  - Key types: imports, contains, calls, depends_on
+  - Key types: imports, contains, calls, depends_on, configures, documents, deploys, triggers, contains_flow, flow_step, related, cites
 - `layers[]` — each has {id, name, description, nodeIds[]}
 - `tour[]` — each has {order, title, description, nodeIds[]}
 

--- a/understand-anything-plugin/skills/understand-onboard/SKILL.md
+++ b/understand-anything-plugin/skills/understand-onboard/SKILL.md
@@ -11,11 +11,13 @@ Generate a comprehensive onboarding guide from the project's knowledge graph.
 
 The knowledge graph JSON has this structure:
 - `project` — {name, description, languages, frameworks, analyzedAt, gitCommitHash}
-- `nodes[]` — each has {id, type, name, filePath, summary, tags[], complexity, languageNotes?}
-  - Node types: file, function, class, module, concept
-  - IDs: `file:path`, `function:path:name`, `class:path:name`
+- `nodes[]` — each has {id, type, name, filePath?, summary, tags[], complexity, languageNotes?}
+  - Code node types: file, function, class, module, concept
+  - Non-code node types: config, document, service, table, endpoint, pipeline, schema, resource
+  - Domain/knowledge node types: domain, flow, step, article, entity, topic, claim, source
+  - IDs use the node type as prefix, e.g. `file:path`, `function:path:name`, `config:path`, `article:path`
 - `edges[]` — each has {source, target, type, direction, weight}
-  - Key types: imports, contains, calls, depends_on
+  - Key types: imports, contains, calls, depends_on, configures, documents, deploys, triggers, contains_flow, flow_step, related, cites
 - `layers[]` — each has {id, name, description, nodeIds[]}
 - `tour[]` — each has {order, title, description, nodeIds[]}
 
@@ -36,7 +38,7 @@ The knowledge graph JSON has this structure:
 
 4. **Read the tour** — Grep for `"tour"` to get the guided walkthrough steps. These provide the recommended learning path.
 
-5. **Read file-level nodes only** — use Grep to find nodes with `"type": "file"` in the knowledge graph. Skip function-level and class-level nodes to keep the guide high-level. Extract each file node's `name`, `filePath`, `summary`, and `complexity`.
+5. **Read file-level structural nodes only** — use Grep to find nodes with file-level types (`file`, `config`, `document`, `service`, `pipeline`, `table`, `schema`, `resource`, `endpoint`) in the knowledge graph. Skip function-level and class-level nodes to keep the guide high-level. Extract each node's `name`, `filePath`, `summary`, and `complexity`.
 
 6. **Identify complexity hotspots** — from the file-level nodes, find those with the highest `complexity` values. These are areas new developers should approach carefully.
 


### PR DESCRIPTION
## Summary
- Update graph structure references in user-facing understand skills to include current code, non-code, domain, and knowledge node types.
- Expand key edge examples so skill guidance reflects the current knowledge graph schema.
- Clarify diff and onboarding instructions so non-code file-level nodes are included where relevant.

## Test plan
- ReadLints on the edited Skill markdown files.
- Reviewed `git diff main...HEAD` to confirm only the four Skill docs are included.
