### PR TITLE
Fix pnpm detection for macOS zsh installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ The installer clones the repo to `~/.understand-anything/repo` and creates the r
 - Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`
 - Update later: `./install.sh --update`
 - Uninstall: `./install.sh --uninstall <platform>`
+- macOS/zsh note: `/understand` and `/understand-dashboard` run setup commands through an agent Bash tool. If `pnpm setup` only added `PNPM_HOME` to `~/.zprofile`, restart your CLI/IDE after installing pnpm so Bash sees the updated `PATH`. The plugin also checks the standard pnpm locations automatically.
 
 ### Cursor
 

--- a/understand-anything-plugin/skills/understand-dashboard/SKILL.md
+++ b/understand-anything-plugin/skills/understand-dashboard/SKILL.md
@@ -68,9 +68,28 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
    fi
    ```
 
-4. Install dependencies and build if needed:
+4. Install dependencies and build if needed. First make `pnpm` visible to the Bash tool even on macOS/zsh installs where `pnpm setup` only updated `~/.zprofile`:
    ```bash
-   cd <dashboard-dir> && pnpm install --frozen-lockfile 2>/dev/null || pnpm install
+   if ! command -v pnpm >/dev/null 2>&1; then
+     export PNPM_HOME="${PNPM_HOME:-$HOME/Library/pnpm}"
+     export PATH="$PNPM_HOME:$HOME/.local/share/pnpm:$PATH"
+   fi
+
+   if ! command -v pnpm >/dev/null 2>&1 && command -v corepack >/dev/null 2>&1; then
+     corepack enable >/dev/null 2>&1 || true
+   fi
+
+   if ! command -v pnpm >/dev/null 2>&1; then
+     echo "Error: pnpm was not found in this shell."
+     echo "Install Node.js >= 22 and pnpm >= 10, then re-run /understand-dashboard."
+     echo "On macOS with zsh, pnpm may be installed but only exported from ~/.zprofile; restart your CLI/IDE or ensure PNPM_HOME is on PATH."
+     exit 1
+   fi
+   ```
+
+   Then install:
+   ```bash
+   cd <dashboard-dir> && (pnpm install --frozen-lockfile 2>/dev/null || pnpm install)
    ```
    Then ensure the core package is built (the dashboard depends on it):
    ```bash
@@ -79,7 +98,7 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
 
 5. Start the Vite dev server pointing at the project's knowledge graph:
    ```bash
-   cd <dashboard-dir> && GRAPH_DIR=<project-dir> npx vite --host 127.0.0.1
+   cd <dashboard-dir> && GRAPH_DIR=<project-dir> pnpm exec vite --host 127.0.0.1
    ```
    Run this in the background so the user can continue working.
 

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -113,12 +113,28 @@ Determine whether to run a full analysis or incremental update.
      exit 1
    fi
 
+   if ! command -v pnpm >/dev/null 2>&1; then
+     export PNPM_HOME="${PNPM_HOME:-$HOME/Library/pnpm}"
+     export PATH="$PNPM_HOME:$HOME/.local/share/pnpm:$PATH"
+   fi
+
+   if ! command -v pnpm >/dev/null 2>&1 && command -v corepack >/dev/null 2>&1; then
+     corepack enable >/dev/null 2>&1 || true
+   fi
+
+   if ! command -v pnpm >/dev/null 2>&1; then
+     echo "Error: pnpm was not found in this shell."
+     echo "Install Node.js >= 22 and pnpm >= 10, then re-run /understand."
+     echo "On macOS with zsh, pnpm may be installed but only exported from ~/.zprofile; restart your CLI/IDE or ensure PNPM_HOME is on PATH."
+     exit 1
+   fi
+
    if [ ! -f "$PLUGIN_ROOT/packages/core/dist/index.js" ]; then
      cd "$PLUGIN_ROOT" && (pnpm install --frozen-lockfile 2>/dev/null || pnpm install) && pnpm --filter @understand-anything/core build
    fi
    ```
 
-   If `pnpm` is missing, report to the user: "Install Node.js ≥ 22 and pnpm ≥ 10, then re-run `/understand`."
+   If `pnpm` is missing, report the error from the pre-flight output. Do not try to source `~/.zprofile` from Bash; it may contain zsh-only syntax.
 
 2. Get the current git commit hash:
    ```bash


### PR DESCRIPTION
## Summary
Fixes a macOS/zsh setup issue where pnpm can be installed but unavailable to the Bash tool used by `/understand` and `/understand-dashboard`.

## Changes
- Add PNPM_HOME/PATH bootstrap before pnpm commands
- Try Corepack when pnpm is unavailable
- Improve missing-pnpm error message
- Use `pnpm exec vite` for dashboard launch
- Document the macOS/zsh edge case in README

## Testing
- Ran `git diff --check`
- Ran `bash -n install.sh`
- Full test suite not run; change is limited to skill instructions and README documentation.