### PR TITLE
docs(readme): add Cursor manual install fallback to 7 translated READMEs

### DIFF
--- a/READMEs/README.es-ES.md
+++ b/READMEs/README.es-ES.md
@@ -205,6 +205,8 @@ El instalador clona el repositorio en `~/.understand-anything/repo` y crea los e
 
 Cursor detecta automáticamente el plugin a través de `.cursor-plugin/plugin.json` cuando se clona este repositorio. No requiere instalación manual: simplemente clona y abre en Cursor.
 
+Si la detección automática no lo reconoce, instálalo manualmente: abre **Cursor Settings → Plugins**, pega `https://github.com/Lum1104/Understand-Anything` en el campo de búsqueda y añádelo desde allí.
+
 ### VS Code + GitHub Copilot
 
 VS Code con GitHub Copilot (v1.108+) detecta automáticamente el plugin a través de `.copilot-plugin/plugin.json` cuando se clona este repositorio. No requiere instalación manual: simplemente clona y abre en VS Code.

--- a/READMEs/README.ja-JP.md
+++ b/READMEs/README.ja-JP.md
@@ -206,6 +206,8 @@ iwr -useb https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/ins
 
 Cursorはこのリポジトリをクローンすると `.cursor-plugin/plugin.json` 経由でプラグインを自動検出します。手動インストールは不要です — クローンしてCursorで開くだけです。
 
+自動検出されない場合は、手動でインストールしてください：**Cursor Settings → Plugins** を開き、検索欄に `https://github.com/Lum1104/Understand-Anything` を貼り付けて追加します。
+
 ### VS Code + GitHub Copilot
 
 GitHub Copilot拡張機能（v1.108+）をインストールしたVS Codeは、`.copilot-plugin/plugin.json` 経由でプラグインを自動検出します。クローンしてVS Codeで開くだけで、手動インストールは不要です。

--- a/READMEs/README.ko-KR.md
+++ b/READMEs/README.ko-KR.md
@@ -205,6 +205,8 @@ iwr -useb https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/ins
 
 이 저장소를 클론하면 Cursor가 `.cursor-plugin/plugin.json`을 통해 플러그인을 자동으로 인식합니다. 수동 설치가 필요 없습니다. 클론 후 Cursor에서 열기만 하면 됩니다.
 
+자동 인식이 되지 않으면 수동으로 설치하세요: **Cursor Settings → Plugins**를 열고 검색란에 `https://github.com/Lum1104/Understand-Anything`를 붙여넣은 뒤 추가하세요.
+
 ### VS Code + GitHub Copilot
 
 GitHub Copilot(v1.108+)이 설치된 VS Code는 `.copilot-plugin/plugin.json`을 통해 플러그인을 자동으로 인식합니다. 수동 설치가 필요 없습니다. 클론 후 VS Code에서 열기만 하면 됩니다.

--- a/READMEs/README.ru-RU.md
+++ b/READMEs/README.ru-RU.md
@@ -206,6 +206,8 @@ iwr -useb https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/ins
 
 Cursor автоматически обнаруживает плагин через `.cursor-plugin/plugin.json` при клонировании этого репозитория. Ручная установка не требуется — просто склонируйте и откройте в Cursor.
 
+Если автообнаружение не сработало, установите вручную: откройте **Cursor Settings → Plugins**, вставьте `https://github.com/Lum1104/Understand-Anything` в поле поиска и добавьте оттуда.
+
 ### VS Code + GitHub Copilot
 
 VS Code с GitHub Copilot (v1.108+) автоматически обнаруживает плагин через `.copilot-plugin/plugin.json` при клонировании этого репозитория. Ручная установка не требуется — просто склонируйте и откройте в VS Code.

--- a/READMEs/README.tr-TR.md
+++ b/READMEs/README.tr-TR.md
@@ -206,6 +206,8 @@ Kurulum betiği depoyu `~/.understand-anything/repo` dizinine klonlar ve seçile
 
 Bu depo klonlandığında Cursor, eklentiyi `.cursor-plugin/plugin.json` aracılığıyla otomatik olarak keşfeder. Manuel kurulum gerekmez — sadece klonla ve Cursor'da aç.
 
+Otomatik keşif çalışmazsa manuel kur: **Cursor Settings → Plugins**'i aç, arama alanına `https://github.com/Lum1104/Understand-Anything` yapıştır ve oradan ekle.
+
 ### VS Code + GitHub Copilot
 
 GitHub Copilot uzantısı (v1.108+) yüklü VS Code, `.copilot-plugin/plugin.json` aracılığıyla eklentiyi otomatik keşfeder. Manuel kurulum gerekmez — sadece klonla ve VS Code'da aç.

--- a/READMEs/README.zh-CN.md
+++ b/READMEs/README.zh-CN.md
@@ -205,6 +205,8 @@ iwr -useb https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/ins
 
 克隆此仓库后，Cursor 会自动通过 `.cursor-plugin/plugin.json`文件发现插件。无需手动安装 — 只需克隆并在 Cursor 中打开即可。
 
+若自动发现未生效，可手动安装：打开 **Cursor Settings → Plugins**，在搜索框中粘贴 `https://github.com/Lum1104/Understand-Anything` 并添加。
+
 ### VS Code + GitHub Copilot
 
 安装 GitHub Copilot 扩展（v1.108+）后，VS Code 会通过 `.copilot-plugin/plugin.json` 自动发现插件，克隆后直接在 VS Code 中打开即可，无需手动安装。

--- a/READMEs/README.zh-TW.md
+++ b/READMEs/README.zh-TW.md
@@ -205,6 +205,8 @@ iwr -useb https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/ins
 
 複製此儲存庫後，Cursor 會自動透過 `.cursor-plugin/plugin.json` 檔案發現外掛程式。無需手動安裝 — 只需複製並在 Cursor 中開啟即可。
 
+若自動發現未生效，可手動安裝：開啟 **Cursor Settings → Plugins**，在搜尋框中貼上 `https://github.com/Lum1104/Understand-Anything` 並新增。
+
 ### VS Code + GitHub Copilot
 
 安裝 GitHub Copilot 擴充功能（v1.108+）後，VS Code 會透過 `.copilot-plugin/plugin.json` 自動發現外掛程式，複製後直接在 VS Code 中開啟即可，無需手動安裝。


### PR DESCRIPTION
## Summary

PR #199 added the community-reported Cursor manual-install workaround to `README.md` after users hit auto-discovery failures (#172). The seven translated READMEs under `READMEs/` still only describe auto-discovery and omit the fallback. This PR mirrors #199 into each locale file so non-English readers get the same fix.

## Problem

`README.md` (lines 206–210) now reads:

> If auto-discovery doesn't pick it up, install it manually: open **Cursor Settings → Plugins**, paste `https://github.com/Lum1104/Understand-Anything` into the search field, and add it from there.

Each `READMEs/README.*.md` Cursor section (e.g. `READMEs/README.zh-CN.md:204–206`) stops after the auto-discovery sentence with no manual fallback.

## Solution

Add one localized sentence per locale file, keeping **Cursor Settings → Plugins** and the repo URL untranslated (UI labels + link target). Wording follows each file's existing register (e.g. zh-CN 简体 vs zh-TW 繁體).

## Out of scope

- `README.md` — already fixed in #199
- `homepage/src/components/Install.astro` — separate surface; no Cursor-specific manual fallback there today
- Gemini CLI → Antigravity rename (#168) — maintainer noted the rebrand transition is not until June 18

## Test plan

- [x] Grep confirmed all 7 `READMEs/README.*.md` files had no manual-fallback line before edit
- [x] Each added line matches the #199 workaround (Settings → Plugins + repo URL)
- [x] Docs-only; no code/build steps required

## Related

- #172 — original Cursor auto-discovery report
- #199 — prior PR that added the fallback to English README only

Made with [Cursor](https://cursor.com)