### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   <strong>Turn any codebase, knowledge base, or docs into an interactive knowledge graph you can explore, search, and ask questions about.</strong>
   <br />
-  <em>Works with Claude Code, Codex, Cursor, Copilot, Gemini CLI, and more.</em>
+  <em>Works with Claude Code, Codex, Cursor, Copilot, Gemini CLI, Astraflow, and more.</em>
 </p>
 
 <p align="center">
@@ -24,6 +24,7 @@
   <a href="#gemini-cli"><img src="https://img.shields.io/badge/Gemini_CLI-4285F4" alt="Gemini CLI" /></a>
   <a href="#opencode"><img src="https://img.shields.io/badge/OpenCode-38bdf8" alt="OpenCode" /></a>
   <a href="#mistral-vibe-cli"><img src="https://img.shields.io/badge/Vibe_CLI-7c3aed" alt="Vibe CLI" /></a>
+  <a href="#astraflow"><img src="https://img.shields.io/badge/Astraflow-0052D9" alt="Astraflow" /></a>
   <a href="https://understand-anything.com"><img src="https://img.shields.io/badge/Homepage-d4a574" alt="Homepage" /></a>
   <a href="https://understand-anything.com/demo/"><img src="https://img.shields.io/badge/Live_Demo-00c853" alt="Live Demo" /></a>
 </p>
@@ -190,6 +191,8 @@ Understand-Anything works across multiple AI coding platforms.
 curl -fsSL https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/install.sh | bash
 # or skip the prompt by passing the platform:
 curl -fsSL https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/install.sh | bash -s codex
+# or for Astraflow:
+curl -fsSL https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/install.sh | bash -s astraflow
 ```
 
 **Windows (PowerShell):**
@@ -199,7 +202,7 @@ iwr -useb https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/ins
 
 The installer clones the repo to `~/.understand-anything/repo` and creates the right symlinks for the chosen platform. Restart your CLI/IDE afterwards.
 
-- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`
+- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `astraflow`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`
 - Update later: `./install.sh --update`
 - Uninstall: `./install.sh --uninstall <platform>`
 
@@ -239,6 +242,7 @@ copilot plugin install Lum1104/Understand-Anything:understand-anything-plugin
 | Hermes | ✅ Supported | `install.sh hermes` |
 | Cline | ✅ Supported | `install.sh cline` |
 | KIMI CLI | ✅ Supported | `install.sh kimi` |
+| Astraflow | ✅ Supported | `install.sh astraflow` |
 
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -31,6 +31,7 @@ $Platforms = [ordered]@{
     gemini      = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     codex       = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     opencode    = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
+    astraflow   = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     pi          = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     openclaw    = @{ Target = (Join-Path $HOME '.openclaw\skills');           Style = 'folder' }
     antigravity = @{ Target = (Join-Path $HOME '.gemini\antigravity\skills'); Style = 'folder' }

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,7 @@ platforms_table() {
 gemini|$HOME/.agents/skills|per-skill
 codex|$HOME/.agents/skills|per-skill
 opencode|$HOME/.agents/skills|per-skill
+astraflow|$HOME/.agents/skills|per-skill
 pi|$HOME/.agents/skills|per-skill
 openclaw|$HOME/.openclaw/skills|folder
 antigravity|$HOME/.gemini/antigravity/skills|folder


### PR DESCRIPTION
## Summary

This PR adds [Astraflow](https://astraflow.ucloud-global.com) by UCloud as a supported platform for Understand-Anything.

**What is Astraflow?**
Astraflow (优刻得) is an OpenAI-compatible AI model aggregation platform supporting 200+ models. It provides both a global endpoint (`https://api-us-ca.umodelverse.ai/v1`) and a China endpoint (`https://api.modelverse.cn/v1`), making it easy to plug in as an agent backend wherever an OpenAI-compatible API is accepted.

- 🌐 Global: https://astraflow.ucloud-global.com
- 🇨🇳 China: https://astraflow.ucloud.cn

## Changes

### `install.sh`
- Added `astraflow` to the `platforms_table` using `per-skill` style with `$HOME/.agents/skills` — the same target as `codex` and `opencode`, which also use OpenAI-compatible agent backends.

### `install.ps1`
- Added `astraflow` to the `$Platforms` ordered hash table with the same `per-skill` / `.agents\skills` configuration.

### `README.md`
- Updated the subtitle to mention Astraflow alongside other supported platforms.
- Added an Astraflow badge to the badge row.
- Added `astraflow` to the one-line install example and the supported platform values list.
- Added Astraflow row to the Platform Compatibility table.

## Installation

**macOS / Linux:**
```bash
curl -fsSL https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/install.sh | bash -s astraflow
```

**Windows (PowerShell):**
```powershell
iwr -useb https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/install.ps1 | iex
# then choose "astraflow" from the prompt
```

Set your `ASTRAFLOW_API_KEY` environment variable and point your agent's base URL to `https://api-us-ca.umodelverse.ai/v1` (global) or `https://api.modelverse.cn/v1` (China) before running `/understand`.