### PR TITLE
fix(extract-import-map): normalize tsconfig path-alias candidates with leading "./" (#214)

### DIFF
--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -237,6 +237,111 @@ describe('extract-import-map.mjs — TypeScript / JavaScript resolver', () => {
       'packages/foo/src/y.ts',
     );
   });
+
+  // ── Issue #214: tsconfig path-alias targets with leading "./" ───────────
+  // create-next-app ships `"@/*": ["./*"]` as the default. With a root
+  // tsconfig the candidate would stay as "./lib/thing" while ctx.fileSet
+  // stores normalized "lib/thing", silently dropping every cross-module
+  // import edge. Three originally broken cases plus one regression guard
+  // for the already working `["*"]` form.
+
+  it('resolves tsconfig paths with leading "./" target and no baseUrl (#214)', () => {
+    projectRoot = setupTree({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          paths: { '@/*': ['./*'] },
+        },
+      }),
+      'src/app.ts': `import { x } from '@/lib/thing';\nconst _ = x;\n`,
+      'lib/thing.ts': `export const x = 1;\n`,
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'tsconfig.json', language: 'json', fileCategory: 'config' },
+        { path: 'src/app.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'lib/thing.ts', language: 'typescript', fileCategory: 'code' },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['src/app.ts']).toContain('lib/thing.ts');
+  });
+
+  it('resolves tsconfig paths with leading "./" target and baseUrl "." (#214)', () => {
+    projectRoot = setupTree({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: { '@/*': ['./*'] },
+        },
+      }),
+      'src/app.ts': `import { x } from '@/lib/thing';\nconst _ = x;\n`,
+      'lib/thing.ts': `export const x = 1;\n`,
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'tsconfig.json', language: 'json', fileCategory: 'config' },
+        { path: 'src/app.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'lib/thing.ts', language: 'typescript', fileCategory: 'code' },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['src/app.ts']).toContain('lib/thing.ts');
+  });
+
+  it('resolves tsconfig paths with leading "./" target and baseUrl "src" (#214)', () => {
+    projectRoot = setupTree({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: 'src',
+          paths: { '@/*': ['./*'] },
+        },
+      }),
+      'src/app.ts': `import { x } from '@/thing';\nconst _ = x;\n`,
+      'src/thing.ts': `export const x = 1;\n`,
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'tsconfig.json', language: 'json', fileCategory: 'config' },
+        { path: 'src/app.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'src/thing.ts', language: 'typescript', fileCategory: 'code' },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['src/app.ts']).toContain('src/thing.ts');
+  });
+
+  it('keeps resolving tsconfig paths with bare "*" target (#214 regression guard)', () => {
+    projectRoot = setupTree({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          paths: { '@/*': ['*'] },
+        },
+      }),
+      'src/app.ts': `import { x } from '@/lib/thing';\nconst _ = x;\n`,
+      'lib/thing.ts': `export const x = 1;\n`,
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'tsconfig.json', language: 'json', fileCategory: 'config' },
+        { path: 'src/app.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'lib/thing.ts', language: 'typescript', fileCategory: 'code' },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['src/app.ts']).toContain('lib/thing.ts');
+  });
 });
 
 describe('extract-import-map.mjs — Python resolver', () => {

--- a/understand-anything-plugin/skills/understand/extract-import-map.mjs
+++ b/understand-anything-plugin/skills/understand/extract-import-map.mjs
@@ -430,9 +430,18 @@ export function resolveTsJsImport(rawImport, file, ctx) {
           const relativeToConfig = normalizedBase
             ? posix.join(normalizedBase, mapped)
             : mapped;
-          const candidate = tsConfigDir
-            ? posix.join(tsConfigDir, relativeToConfig)
-            : relativeToConfig;
+          // posix.normalize strips a leading "./" left over when both
+          // tsConfigDir and normalizedBase are empty (root tsconfig with
+          // `"@/*": ["./*"]`, the create-next-app default). Without this the
+          // candidate stays as "./foo" while ctx.fileSet stores "foo", and
+          // probeWithExtensions silently drops every cross-module edge.
+          const candidate = posix.normalize(
+            tsConfigDir
+              ? posix.join(tsConfigDir, relativeToConfig)
+              : relativeToConfig,
+          );
+          // Defensive: tsconfig targets shouldn't escape the project root.
+          if (candidate.startsWith('..')) continue;
           const probed = probeWithExtensions(candidate, ctx.fileSet);
           if (probed) return probed;
         }


### PR DESCRIPTION
## Summary
Fix #214: tsconfig `paths` targets with leading `./` (e.g. `"@/*": ["./*"]`, which is the `create-next-app` default) failed to resolve in `extract-import-map.mjs`, silently dropping all cross-module import edges for affected projects.
## Root cause
In `resolveTsJsImport` (skills/understand/extract-import-map.mjs), when a project's `tsconfig.json` lives at the project root, `tsConfigDir` is the empty string `""`. The existing logic then:
1. Computes `normalizedBase` as `""` when `baseUrl` is `.` / empty / absent.
2. With both `normalizedBase` and `tsConfigDir` falsy, the two `posix.join` calls (lines 430-435) are skipped, so the mapped target keeps its leading `./`.
3. The candidate becomes `"./lib/thing"`, but `ctx.fileSet` stores normalized paths (`"lib/thing"`), so `probeWithExtensions` never matches.
Result: every `@/...` (or equivalent) import resolves to `null`, dropping every cross-module edge for projects using the very common `"@/*": ["./*"]` alias.
## Fix
Run the final candidate through `posix.normalize` before probing, which collapses the leading `./` regardless of which branch produced the candidate. Adds an `if (candidate.startsWith('..')) continue;` guard so a malformed tsconfig target cannot escape the project root.
## Tests
Adds 4 vitest cases in `tests/skill/understand/test_extract_import_map.test.mjs` covering the matrix from #214:
Table: Case; tsconfig paths; baseUrl; Pre-fix; Post-fix
- T1; `"@/*": ["./*"]`; (none); broken; resolves
- T2; `"@/*": ["./*"]`; `"."`; broken; resolves
- T3; `"@/*": ["./*"]`; `"src"`; other branch; regression guard
- T4; `"@/*": ["*"]`; (none); already working; regression guard
All 200 vitest tests pass locally on the modified branch; `pnpm lint` clean; `pnpm --filter @understand-anything/core build` succeeds.
Closes #214