### PR TITLE
fix(scan-project): preserve non-ASCII path bytes via `git ls-files -z`

### DIFF
--- a/understand-anything-plugin/skills/understand/scan-project.mjs
+++ b/understand-anything-plugin/skills/understand/scan-project.mjs
@@ -464,17 +464,25 @@ function toPosix(p) {
  * so the ignore filter has to do more work in the fallback path.
  */
 function enumerateViaGit(projectRoot) {
-  const result = spawnSync('git', ['ls-files', '-co', '--exclude-standard'], {
+  // -z = NUL-terminated output. Without it, `git ls-files` C-escapes non-ASCII
+  // bytes in path names — paths containing emoji, accented characters, CJK
+  // codepoints, etc. come back quoted with octal escapes (e.g.
+  // `"30. \360\237\217\227 BD-CCER/file.md"` for a path containing 🏗️).
+  // Those quoted-escaped strings then fail to round-trip back to real disk
+  // paths in downstream consumers, so files in such directories are silently
+  // dropped from the scan. The -z form emits raw bytes between NUL separators,
+  // preserving every codepoint as-is. This is the same approach git itself
+  // uses for `--null` everywhere downstream (xargs -0, etc.).
+  const result = spawnSync('git', ['ls-files', '-z', '-co', '--exclude-standard'], {
     cwd: projectRoot,
     encoding: 'utf-8',
     maxBuffer: 256 * 1024 * 1024, // 256MB — huge monorepos can produce >10MB of paths
   });
   if (result.status !== 0 || !result.stdout) return null;
-  // Each line is one path, project-relative, already POSIX on all platforms
-  // because git emits forward slashes regardless of OS.
+  // Each NUL-separated chunk is one path, project-relative, already POSIX on
+  // all platforms because git emits forward slashes regardless of OS.
   return result.stdout
-    .split('\n')
-    .map(s => s.trim())
+    .split('\0')
     .filter(Boolean)
     .map(toPosix);
 }


### PR DESCRIPTION
## Summary

`enumerateViaGit` in `scan-project.mjs` runs `git ls-files -co --exclude-standard` (newline-separated output) and parses with `split('\n').map(trim)`. Without `-z`, git C-escapes non-ASCII path bytes and wraps the result in double quotes — for example, a directory named `30. 🏗️ docs/` is emitted as `"30. \360\237\217\227\357\270\217 docs/"`. Downstream consumers can't round-trip those octal-quoted strings to real disk paths, so **every file under such a directory is silently dropped from the scan**.

This PR switches to `-z` (NUL-terminated output) — the same convention git itself documents for downstream parsers (e.g. `xargs -0`). Two-line behavioral change in one function; no other call sites affected.

## Reproduction

In a repo with at least one non-ASCII directory name (e.g. `30. 🏗️ docs/`):

```bash
# Broken — quoted, octal-escaped:
git ls-files
# "30. \360\237\217\227\357\270\217 docs/file.md"

# Fixed — raw bytes, NUL-separated:
git ls-files -z | tr '\0' '\n'
# 30. 🏗️ docs/file.md
```

Before this PR, `enumerateViaGit` returned the quoted string from the first form. `split('\n')` then yielded a single token containing escaped backslashes that no `fs.statSync` / `readFileSync` would ever resolve.

## Impact

Any project containing non-ASCII characters in directory or file names — emoji, accented characters, CJK codepoints, etc. — loses files from the scan when the parent directory contains such characters. The dropped files exist on disk; only the listing path is malformed.

Surfaced on Windows but the behavior is git-version- and locale-dependent rather than OS-dependent; git always quotes non-ASCII paths under default settings (`core.quotepath=true`).

## Fix rationale

`git ls-files -z` emits NUL-terminated raw bytes. NUL is not a valid character in POSIX or Windows paths, so it's the canonical separator for "binary-safe path lists." The fix:

1. Add `-z` to the `git ls-files` argv.
2. `split('\0')` instead of `split('\n')`.
3. Drop `.trim()` — NUL-separated output has no whitespace to strip.
4. Drop the redundant `filter(Boolean)` simplification (kept `.filter(Boolean)` since a trailing `\0` produces an empty terminal chunk).

The function signature and return shape are unchanged. The fallback `enumerateViaWalk` path is untouched.

## Verification

Verified against a real project containing emoji-prefixed directory names. Before the fix, `enumerateViaGit` returned octal-quoted strings:

```
"30. \360\237\217\227\357\270\217\360\237\247\231\342\200\215\342\231\202\357\270\217\360\237\224\256 BD-CCSP/01. Demo's/DEMO--Expense-Report-to-MailForge-Flight.md"
```

After the fix, paths come back clean and resolvable:

```
30. 🏗️🧙‍♂️🔮 BD-CCSP/01. Demo's/DEMO--Expense-Report-to-MailForge-Flight.md
```

Confirmed via direct shell test (`git ls-files -z | tr '\0' '\n'`).

## Origin

Discovered during a multi-agent `/understand` scan of an Atlas Intelligence spoke repo. The Atlas fleet uses `30. 🏗️ BD-{app}/` directory prefixes for design-intent doc trees (Blueprint, phase plans, side-quest journals). The scan silently dropped **~33 files** in those directories per repo, hiding the entire design-intent layer from the resulting knowledge graph. Once seen, the failure mode generalizes immediately to any non-ASCII directory name.

Detailed report including subagent timing breakdown, token economics, and other findings: [atlas-intelligence-io/fleet-feedback#491](https://github.com/atlas-intelligence-io/fleet-feedback/issues/491).

## Notes for the reviewer

- The change is intentionally minimal — same function, same return shape, same fallback path.
- I considered also stripping the `try { JSON.parse(...) }` post-processing some other downstream consumers do for quoted paths, but `enumerateViaGit` itself doesn't do any such processing, so there's nothing to remove here. Other call sites that might receive quoted paths from elsewhere (e.g. third-party tooling) aren't affected by this change.
- Happy to add a `__tests__/enumerate.test.ts` case if useful — let me know and I'll spin one up.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)