### PR TITLE
feat(install): add Trae (ByteDance AI IDE) platform support (#229)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   <a href="#gemini-cli"><img src="https://img.shields.io/badge/Gemini_CLI-4285F4" alt="Gemini CLI" /></a>
   <a href="#opencode"><img src="https://img.shields.io/badge/OpenCode-38bdf8" alt="OpenCode" /></a>
   <a href="#mistral-vibe-cli"><img src="https://img.shields.io/badge/Vibe_CLI-7c3aed" alt="Vibe CLI" /></a>
+  <a href="#trae"><img src="https://img.shields.io/badge/Trae-7e22ce" alt="Trae" /></a>
   <a href="https://understand-anything.com"><img src="https://img.shields.io/badge/Homepage-d4a574" alt="Homepage" /></a>
   <a href="https://understand-anything.com/demo/"><img src="https://img.shields.io/badge/Live_Demo-00c853" alt="Live Demo" /></a>
 </p>
@@ -183,7 +184,7 @@ Understand-Anything works across multiple AI coding platforms.
 /plugin install understand-anything
 ```
 
-### One-line install (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI)
+### One-line install (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Trae)
 
 **macOS / Linux:**
 ```bash
@@ -199,7 +200,7 @@ iwr -useb https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/ins
 
 The installer clones the repo to `~/.understand-anything/repo` and creates the right symlinks for the chosen platform. Restart your CLI/IDE afterwards.
 
-- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`
+- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`
 - Update later: `./install.sh --update`
 - Uninstall: `./install.sh --uninstall <platform>`
 
@@ -239,6 +240,7 @@ copilot plugin install Lum1104/Understand-Anything:understand-anything-plugin
 | Hermes | ✅ Supported | `install.sh hermes` |
 | Cline | ✅ Supported | `install.sh cline` |
 | KIMI CLI | ✅ Supported | `install.sh kimi` |
+| Trae | ✅ Supported | `install.sh trae` |
 
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -38,6 +38,7 @@ $Platforms = [ordered]@{
     hermes      = @{ Target = (Join-Path $HOME '.hermes\skills');             Style = 'folder' }
     cline       = @{ Target = (Join-Path $HOME '.cline\skills');              Style = 'folder' }
     kimi        = @{ Target = (Join-Path $HOME '.kimi\skills');               Style = 'folder' }
+    trae        = @{ Target = (Join-Path $HOME '.trae\skills');               Style = 'per-skill' }
 }
 
 function Show-Usage {

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,7 @@ vscode|$HOME/.copilot/skills|per-skill
 hermes|$HOME/.hermes/skills|folder
 cline|$HOME/.cline/skills|folder
 kimi|$HOME/.kimi/skills|folder
+trae|$HOME/.trae/skills|per-skill
 EOF
 }
 


### PR DESCRIPTION
## Summary
Adds Trae (ByteDance AI IDE) to the supported platform list, as requested in #229.

Trae supports the Agent Skills standard (SKILL.md), so this PR follows the established `per-skill` install pattern (same shape as `codex` / `vibe` / `kimi` etc.) — no new manifest directory, no logic changes, purely a data addition.

## Changes
- `install.sh` — one row added to the `platforms_table()` heredoc: `trae|$HOME/.trae/skills|per-skill`
- `install.ps1` — one entry added to the `$Platforms` ordered hashtable (Windows path via `Join-Path`)
- `README.md` — Trae added in four places (badge, one-line install header, supported `<platform>` values list, Platform Compatibility table)

## Skill directory path note
The reporter's issue specifies `~/.trae/skills/`, which this PR uses. We surfaced this because third-party Trae guides mention `.trae/skills/` (project-level) in some contexts. If `~/.trae/skills/` turns out to be wrong for the global install pattern, the fix is a one-line edit to both `install.sh` and `install.ps1` — happy to amend on request.

## Tests
This is a pure data addition with no JS/TS code changes. Existing test suites still pass:
- `pnpm test` — full vitest suite (196 tests, unchanged baseline from main)
- `pnpm lint` — clean
- `bash -n install.sh` — syntax OK

Closes #229