### PR TITLE
feat(dashboard): add diff-only filter to isolate impact chain

### DIFF
--- a/understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx
@@ -3,12 +3,15 @@ import { useI18n } from "../contexts/I18nContext";
 
 export default function DiffToggle() {
   const diffMode = useDashboardStore((s) => s.diffMode);
+  const diffFilterOnly = useDashboardStore((s) => s.diffFilterOnly);
   const toggleDiffMode = useDashboardStore((s) => s.toggleDiffMode);
+  const toggleDiffFilterOnly = useDashboardStore((s) => s.toggleDiffFilterOnly);
   const changedNodeIds = useDashboardStore((s) => s.changedNodeIds);
   const affectedNodeIds = useDashboardStore((s) => s.affectedNodeIds);
   const { t } = useI18n();
 
   const hasDiff = changedNodeIds.size > 0;
+  const canFilter = diffMode && hasDiff;
 
   return (
     <div className="flex items-center gap-2">
@@ -32,6 +35,24 @@ export default function DiffToggle() {
       >
         Diff {diffMode && hasDiff ? "ON" : "OFF"}
       </button>
+
+      {canFilter && (
+        <button
+          onClick={toggleDiffFilterOnly}
+          className={`px-2 py-0.5 rounded text-[11px] font-medium transition-colors ${
+            diffFilterOnly
+              ? "bg-[var(--color-diff-affected-dim)] text-[var(--color-diff-affected)]"
+              : "bg-elevated text-text-secondary hover:bg-surface"
+          }`}
+          title={
+            diffFilterOnly
+              ? t.diffToggle.showAll
+              : t.diffToggle.showFilterOnly
+          }
+        >
+          Filter {diffFilterOnly ? "ON" : "OFF"}
+        </button>
+      )}
 
       {diffMode && hasDiff && (
         <div className="flex items-center gap-3">

--- a/understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx
@@ -214,6 +214,10 @@ function useOverviewGraph() {
   const nodeIdToLayerId = useDashboardStore((s) => s.nodeIdToLayerId);
   const searchResults = useDashboardStore((s) => s.searchResults);
   const drillIntoLayer = useDashboardStore((s) => s.drillIntoLayer);
+  const diffMode = useDashboardStore((s) => s.diffMode);
+  const diffFilterOnly = useDashboardStore((s) => s.diffFilterOnly);
+  const changedNodeIds = useDashboardStore((s) => s.changedNodeIds);
+  const affectedNodeIds = useDashboardStore((s) => s.affectedNodeIds);
 
   // Build cluster nodes / flow edges / dims synchronously; only the layout
   // call itself is async, so we memo the structural pieces and run ELK in an
@@ -240,12 +244,30 @@ function useOverviewGraph() {
       }
     }
 
+    // Diff-only filter: compute which layers contain changed/affected nodes
+    const diffNodeIds = diffMode ? new Set([...changedNodeIds, ...affectedNodeIds]) : new Set<string>();
+    const diffLayerIds = new Set<string>();
+    if (diffMode && diffFilterOnly && diffNodeIds.size > 0) {
+      for (const nodeId of diffNodeIds) {
+        const lid = nodeIdToLayerId.get(nodeId);
+        if (lid) diffLayerIds.add(lid);
+      }
+    }
+
+    // Filter layers in diff-only mode
+    const visibleLayers = diffMode && diffFilterOnly && diffLayerIds.size > 0
+      ? layers.filter((l) => diffLayerIds.has(l.id))
+      : layers;
+
     // Create cluster nodes. Per-layer aggregation goes through
     // `computeLayerStats`, which iterates `layer.nodeIds` against the
     // `nodesById` index — O(K) per layer instead of the previous
     // O(N) Array.filter that ran `layer.nodeIds.includes(n.id)` (#102).
-    const clusterNodes: LayerClusterFlowNode[] = layers.map((layer, i) => {
+    const clusterNodes: LayerClusterFlowNode[] = visibleLayers.map((layer) => {
       const { aggregateComplexity } = computeLayerStats(layer, nodesById);
+      const isDiffAffected = diffMode && [...diffNodeIds].some(
+        (id) => nodeIdToLayerId.get(id) === layer.id,
+      );
 
       return {
         id: layer.id,
@@ -257,26 +279,32 @@ function useOverviewGraph() {
           layerDescription: layer.description,
           fileCount: layer.nodeIds.length,
           aggregateComplexity,
-          layerColorIndex: i,
+          layerColorIndex: graph.layers.indexOf(layer),
           searchMatchCount: searchMatchByLayer.get(layer.id),
+          isDiffAffected,
+          isDiffFaded: diffMode && !isDiffAffected,
           onDrillIn: drillIntoLayer,
         },
       };
     });
 
+    const visibleLayerIds = new Set(visibleLayers.map((l) => l.id));
+
     // Aggregate edges between layers
     const aggregated = aggregateLayerEdges(graph);
-    const flowEdges: Edge[] = aggregated.map((agg, i) => ({
-      id: `le-${i}`,
-      source: agg.sourceLayerId,
-      target: agg.targetLayerId,
-      label: `${agg.count}`,
-      style: {
-        stroke: "rgba(212,165,116,0.4)",
-        strokeWidth: Math.min(1 + Math.log2(agg.count + 1), 5),
-      },
-      labelStyle: { fill: "#a39787", fontSize: 11, fontWeight: 600 },
-    }));
+    const flowEdges: Edge[] = aggregated
+      .filter((agg) => visibleLayerIds.has(agg.sourceLayerId) && visibleLayerIds.has(agg.targetLayerId))
+      .map((agg, i) => ({
+        id: `le-${i}`,
+        source: agg.sourceLayerId,
+        target: agg.targetLayerId,
+        label: `${agg.count}`,
+        style: {
+          stroke: "rgba(212,165,116,0.4)",
+          strokeWidth: Math.min(1 + Math.log2(agg.count + 1), 5),
+        },
+        labelStyle: { fill: "#a39787", fontSize: 11, fontWeight: 600 },
+      }));
 
     const dims = new Map<string, { width: number; height: number }>();
     for (const n of clusterNodes) {
@@ -284,7 +312,7 @@ function useOverviewGraph() {
     }
 
     return { clusterNodes, flowEdges, dims };
-  }, [graph, nodesById, nodeIdToLayerId, searchResults, drillIntoLayer]);
+  }, [graph, nodesById, nodeIdToLayerId, searchResults, drillIntoLayer, diffMode, diffFilterOnly, changedNodeIds, affectedNodeIds]);
 
   const [overview, setOverview] = useState<{ nodes: Node[]; edges: Edge[] }>({
     nodes: [],
@@ -371,6 +399,7 @@ function useLayerDetailTopology(): LayerDetailTopology & {
   const selectNode = useDashboardStore((s) => s.selectNode);
   const persona = useDashboardStore((s) => s.persona);
   const diffMode = useDashboardStore((s) => s.diffMode);
+  const diffFilterOnly = useDashboardStore((s) => s.diffFilterOnly);
   const changedNodeIds = useDashboardStore((s) => s.changedNodeIds);
   const affectedNodeIds = useDashboardStore((s) => s.affectedNodeIds);
   const focusNodeId = useDashboardStore((s) => s.focusNodeId);
@@ -466,6 +495,22 @@ function useLayerDetailTopology(): LayerDetailTopology & {
       }
       filteredGraphNodes = filteredGraphNodes.filter((n) =>
         focusNeighborIds.has(n.id),
+      );
+      filteredNodeIds = new Set(filteredGraphNodes.map((n) => n.id));
+      filteredGraphEdges = filteredGraphEdges.filter(
+        (e) => filteredNodeIds.has(e.source) && filteredNodeIds.has(e.target),
+      );
+    }
+
+    // Diff-only filter: show only changed/affected nodes and their connecting edges
+    if (diffMode && diffFilterOnly) {
+      const diffNodeIds = new Set([...changedNodeIds, ...affectedNodeIds]);
+      const diffInLayer = new Set<string>();
+      for (const id of diffNodeIds) {
+        if (filteredNodeIds.has(id)) diffInLayer.add(id);
+      }
+      filteredGraphNodes = filteredGraphNodes.filter((n) =>
+        diffInLayer.has(n.id),
       );
       filteredNodeIds = new Set(filteredGraphNodes.map((n) => n.id));
       filteredGraphEdges = filteredGraphEdges.filter(
@@ -643,6 +688,7 @@ function useLayerDetailTopology(): LayerDetailTopology & {
     activeLayerId,
     persona,
     diffMode,
+    diffFilterOnly,
     changedNodeIds,
     affectedNodeIds,
     focusNodeId,

--- a/understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx
@@ -17,6 +17,8 @@ export interface LayerClusterData extends Record<string, unknown> {
   aggregateComplexity: string;
   layerColorIndex: number;
   searchMatchCount?: number;
+  isDiffAffected?: boolean;
+  isDiffFaded?: boolean;
   onDrillIn: (layerId: string) => void;
 }
 
@@ -29,12 +31,18 @@ function LayerClusterNode({
   const complexityColor =
     complexityColors[data.aggregateComplexity] ?? complexityColors.simple;
 
+  const diffClass = data.isDiffAffected
+    ? " ring-2 ring-[var(--color-diff-changed)] diff-changed-glow"
+    : data.isDiffFaded
+      ? " diff-faded"
+      : "";
+
   return (
     <div
-      className="relative rounded-xl bg-elevated border border-border-subtle overflow-hidden cursor-pointer transition-all duration-200 hover:border-gold/40 hover:shadow-lg group"
+      className={`relative rounded-xl bg-elevated border border-border-subtle overflow-hidden cursor-pointer transition-all duration-200 hover:border-gold/40 hover:shadow-lg group${diffClass}`}
       style={{
         width: 300,
-        boxShadow: "0 4px 16px rgba(0,0,0,0.4)",
+        boxShadow: data.isDiffAffected ? "0 0 16px rgba(224, 82, 82, 0.2)" : "0 4px 16px rgba(0,0,0,0.4)",
       }}
       onClick={() => data.onDrillIn(data.layerId)}
     >

--- a/understand-anything-plugin/packages/dashboard/src/locales/en.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/en.ts
@@ -132,6 +132,10 @@ export const en = {
     noData: "No diff data loaded",
     changed: "Changed",
     affected: "Affected",
+    filterOn: "Filter ON",
+    filterOff: "Filter OFF",
+    showFilterOnly: "Show only diff-affected nodes",
+    showAll: "Show all nodes",
   },
   learnPanel: {
     finish: "Finish",

--- a/understand-anything-plugin/packages/dashboard/src/locales/ja.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/ja.ts
@@ -132,6 +132,10 @@ export const ja = {
     noData: "差分データが読み込まれていません",
     changed: "変更済み",
     affected: "影響あり",
+    filterOn: "フィルターON",
+    filterOff: "フィルターOFF",
+    showFilterOnly: "差分影響ノードのみ表示",
+    showAll: "全ノード表示",
   },
   learnPanel: {
     finish: "完了",

--- a/understand-anything-plugin/packages/dashboard/src/locales/ko.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/ko.ts
@@ -132,6 +132,10 @@ export const ko = {
     noData: "차분 데이터가 로드되지 않음",
     changed: "변경됨",
     affected: "영향받음",
+    filterOn: "필터 ON",
+    filterOff: "필터 OFF",
+    showFilterOnly: "차분 영향 노드만 표시",
+    showAll: "모든 노드 표시",
   },
   learnPanel: {
     finish: "완료",

--- a/understand-anything-plugin/packages/dashboard/src/locales/ru.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/ru.ts
@@ -132,6 +132,10 @@ export const ru = {
     noData: "Данные об изменениях не загружены",
     changed: "Изменено",
     affected: "Затронуто",
+    filterOn: "Фильтр ВКЛ",
+    filterOff: "Фильтр ВЫКЛ",
+    showFilterOnly: "Показать только затронутые узлы",
+    showAll: "Показать все узлы",
   },
   learnPanel: {
     finish: "Завершить",

--- a/understand-anything-plugin/packages/dashboard/src/locales/zh-TW.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/zh-TW.ts
@@ -132,6 +132,10 @@ export const zhTW = {
     noData: "未載入差異資料",
     changed: "已修改",
     affected: "受影響",
+    filterOn: "篩選開",
+    filterOff: "篩選關",
+    showFilterOnly: "僅顯示差異影響節點",
+    showAll: "顯示所有節點",
   },
   learnPanel: {
     finish: "完成",

--- a/understand-anything-plugin/packages/dashboard/src/locales/zh.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/zh.ts
@@ -132,6 +132,10 @@ export const zh = {
     noData: "未加载差异数据",
     changed: "已修改",
     affected: "受影响",
+    filterOn: "过滤开",
+    filterOff: "过滤关",
+    showFilterOnly: "仅显示差异影响节点",
+    showAll: "显示所有节点",
   },
   learnPanel: {
     finish: "完成",

--- a/understand-anything-plugin/packages/dashboard/src/store.ts
+++ b/understand-anything-plugin/packages/dashboard/src/store.ts
@@ -127,6 +127,7 @@ interface DashboardStore {
   persona: Persona;
 
   diffMode: boolean;
+  diffFilterOnly: boolean;
   changedNodeIds: Set<string>;
   affectedNodeIds: Set<string>;
 
@@ -172,6 +173,7 @@ interface DashboardStore {
 
   setDiffOverlay: (changed: string[], affected: string[]) => void;
   toggleDiffMode: () => void;
+  toggleDiffFilterOnly: () => void;
   clearDiffOverlay: () => void;
 
   toggleFilterPanel: () => void;
@@ -310,6 +312,7 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   persona: "junior",
 
   diffMode: false,
+  diffFilterOnly: false,
   changedNodeIds: new Set<string>(),
   affectedNodeIds: new Set<string>(),
 
@@ -551,15 +554,27 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   setDiffOverlay: (changed, affected) =>
     set({
       diffMode: true,
+      diffFilterOnly: false,
       changedNodeIds: new Set(changed),
       affectedNodeIds: new Set(affected),
     }),
 
   toggleDiffMode: () => set((state) => ({ diffMode: !state.diffMode })),
 
+  toggleDiffFilterOnly: () =>
+    set((state) => ({
+      diffFilterOnly: !state.diffFilterOnly,
+      // Filter changes shift which nodes/containers are visible; drop caches.
+      containerLayoutCache: new Map(),
+      containerSizeMemory: new Map(),
+      expandedContainers: new Set(),
+      pendingFocusContainer: null,
+    })),
+
   clearDiffOverlay: () =>
     set({
       diffMode: false,
+      diffFilterOnly: false,
       changedNodeIds: new Set<string>(),
       affectedNodeIds: new Set<string>(),
     }),


### PR DESCRIPTION
## Summary
- Add a "Filter" toggle next to the existing "Diff ON/OFF" button that removes non-diff nodes from the graph, so users can see only the diff impact chain after running `/understand-diff`.
- Filter layer-detail nodes/edges to changed + affected set when the toggle is active; filter the overview to only layers containing diff nodes.
- Apply diff ring/fade styling to `LayerClusterNode` in overview; add i18n strings for the filter toggle (en, zh, ja, ko, ru, zh-TW).

## Test plan
- [ ] Run `/understand-diff` on a project, open dashboard, toggle Diff ON
- [ ] Toggle Filter ON → confirm only changed/affected nodes remain in graph and overview
- [ ] Toggle Filter OFF → confirm full graph returns
- [ ] Switch locales (en/zh/ja/ko/ru/zh-TW) → confirm filter label is localized