### PR TITLE
feat(scan): add --exclude CLI flag for /understand (#76)

### DIFF
--- a/tests/skill/understand/test_scan_project.test.mjs
+++ b/tests/skill/understand/test_scan_project.test.mjs
@@ -60,11 +60,11 @@ const _runScriptOutputDirs = [];
  * { status, stdout, stderr, output } where `output` is the parsed JSON
  * written by the script (or null on failure).
  */
-function runScript(projectRoot) {
+function runScript(projectRoot, extraArgs = []) {
   const outputDir = mkdtempSync(join(tmpdir(), 'ua-scan-out-'));
   _runScriptOutputDirs.push(outputDir);
   const outputPath = join(outputDir, 'scan-output.json');
-  const result = spawnSync('node', [SCRIPT, projectRoot, outputPath], {
+  const result = spawnSync('node', [SCRIPT, projectRoot, outputPath, ...extraArgs], {
     encoding: 'utf-8',
   });
   let output = null;
@@ -734,5 +734,104 @@ describe('scan-project.mjs — output schema invariants', () => {
     const paths = r.output.files.map(f => f.path);
     const sortedPaths = [...paths].sort((a, b) => a.localeCompare(b));
     expect(paths).toEqual(sortedPaths);
+  });
+});
+
+describe('scan-project.mjs — --exclude CLI flag', () => {
+  let projectRoot;
+
+  afterEach(() => {
+    if (projectRoot) {
+      rmSync(projectRoot, { recursive: true, force: true });
+      projectRoot = null;
+    }
+  });
+
+  it('drops files matching a single --exclude pattern and echoes appliedExclude', () => {
+    projectRoot = setupTree({
+      'src/index.ts': 'export const x = 1;\n',
+      'src/utils.test.ts': 'test("u", () => {});\n',
+      'src/handlers.test.ts': 'test("h", () => {});\n',
+    });
+    const r = runScript(projectRoot, ['--exclude=**/*.test.ts']);
+    expect(r.status).toBe(0);
+    expect(byPath(r.output, 'src/index.ts')).toBeDefined();
+    expect(byPath(r.output, 'src/utils.test.ts')).toBeUndefined();
+    expect(byPath(r.output, 'src/handlers.test.ts')).toBeUndefined();
+    // appliedExclude is echoed verbatim — order preserved.
+    expect(r.output.appliedExclude).toEqual(['**/*.test.ts']);
+    // Drops are user-driven (no .understandignore involved here either).
+    expect(r.output.filteredByIgnore).toBe(2);
+  });
+
+  it('accepts multiple --exclude flags; each one is appended in order', () => {
+    projectRoot = setupTree({
+      'src/index.ts': 'export const x = 1;\n',
+      'src/utils.test.ts': 'test("u", () => {});\n',
+      'docs/guide.md': '# Guide\n',
+      'docs/api.md': '# API\n',
+    });
+    const r = runScript(projectRoot, [
+      '--exclude=**/*.test.ts',
+      '--exclude=docs/',
+    ]);
+    expect(r.status).toBe(0);
+    expect(byPath(r.output, 'src/index.ts')).toBeDefined();
+    expect(byPath(r.output, 'src/utils.test.ts')).toBeUndefined();
+    expect(byPath(r.output, 'docs/guide.md')).toBeUndefined();
+    expect(byPath(r.output, 'docs/api.md')).toBeUndefined();
+    expect(r.output.appliedExclude).toEqual(['**/*.test.ts', 'docs/']);
+    expect(r.output.filteredByIgnore).toBe(3);
+  });
+
+  it('omits appliedExclude entirely when no --exclude is passed', () => {
+    projectRoot = setupTree({
+      'src/index.ts': 'export const x = 1;\n',
+    });
+    const r = runScript(projectRoot);
+    expect(r.status).toBe(0);
+    // Field MUST NOT be present (back-compat for downstream consumers
+    // that snapshot the exact JSON shape).
+    expect('appliedExclude' in r.output).toBe(false);
+  });
+
+  it('treats unknown --flag tokens as forward-compat no-ops', () => {
+    projectRoot = setupTree({
+      'src/index.ts': 'export const x = 1;\n',
+    });
+    const r = runScript(projectRoot, ['--future-flag=value', '--exclude=src/']);
+    expect(r.status).toBe(0);
+    // Unknown flag silently ignored; --exclude still applied.
+    expect(byPath(r.output, 'src/index.ts')).toBeUndefined();
+    expect(r.output.appliedExclude).toEqual(['src/']);
+  });
+
+  it('--exclude stacks with .understandignore (both filter independently)', () => {
+    projectRoot = setupTree({
+      '.understandignore': 'fixtures/\n',
+      'src/index.ts': 'export const x = 1;\n',
+      'src/utils.test.ts': 'test("u", () => {});\n',
+      'fixtures/data.json': '{}\n',
+    });
+    const r = runScript(projectRoot, ['--exclude=**/*.test.ts']);
+    expect(r.status).toBe(0);
+    expect(byPath(r.output, 'src/index.ts')).toBeDefined();
+    expect(byPath(r.output, 'src/utils.test.ts')).toBeUndefined();
+    expect(byPath(r.output, 'fixtures/data.json')).toBeUndefined();
+    expect(r.output.appliedExclude).toEqual(['**/*.test.ts']);
+    // Both the .understandignore drop and the --exclude drop count as
+    // user-driven.
+    expect(r.output.filteredByIgnore).toBe(2);
+  });
+
+  it('empty --exclude= value is silently dropped (no filter applied)', () => {
+    projectRoot = setupTree({
+      'src/index.ts': 'export const x = 1;\n',
+    });
+    const r = runScript(projectRoot, ['--exclude=']);
+    expect(r.status).toBe(0);
+    expect(byPath(r.output, 'src/index.ts')).toBeDefined();
+    // Empty value -> no patterns collected -> field omitted.
+    expect('appliedExclude' in r.output).toBe(false);
   });
 });

--- a/understand-anything-plugin/agents/project-scanner.md
+++ b/understand-anything-plugin/agents/project-scanner.md
@@ -56,8 +56,11 @@ Invoke the bundled scan script. It walks the project (preferring `git ls-files`,
 mkdir -p $PROJECT_ROOT/.understand-anything/tmp
 node $PLUGIN_ROOT/skills/understand/scan-project.mjs \
   "$PROJECT_ROOT" \
-  "$PROJECT_ROOT/.understand-anything/tmp/ua-scan-files.json"
+  "$PROJECT_ROOT/.understand-anything/tmp/ua-scan-files.json" \
+  [--exclude=<pattern> ...]
 ```
+
+Append one `--exclude=<pattern>` per pattern in `$EXCLUDE_FLAGS` (set in SKILL.md Phase 0 step 3.7). When the user did not pass any `--exclude` flags, omit the bracketed segment entirely. Patterns must use the same gitignore glob syntax as `.understandignore` (e.g. `--exclude='**/*.test.*' --exclude='docs/'`); quote each pattern so the shell doesn't expand globs locally. The script echoes the applied patterns back as `appliedExclude` in its output so the orchestrator can verify the flags were wired through.
 
 Output JSON shape (you will read this verbatim and merge into the final scan-result):
 
@@ -73,6 +76,7 @@ Output JSON shape (you will read this verbatim and merge into the final scan-res
   "totalFiles": 42,
   "filteredByIgnore": 0,
   "estimatedComplexity": "moderate",
+  "appliedExclude": ["**/*.test.*", "docs/"],
   "stats": {
     "filesScanned": 42,
     "byCategory": {"code": 28, "config": 6, "docs": 4, "infra": 2, "script": 2},
@@ -80,6 +84,8 @@ Output JSON shape (you will read this verbatim and merge into the final scan-res
   }
 }
 ```
+
+The `appliedExclude` field is present **only** when one or more `--exclude=<pattern>` flags were passed; it is omitted entirely otherwise (no key, not an empty array). Drop it when assembling the final `scan-result.json` — it is diagnostic output for the orchestrator, not part of the agent contract.
 
 The script:
 - sorts `files` by `path.localeCompare` (deterministic)

--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts
@@ -152,4 +152,87 @@ describe("IgnoreFilter", () => {
       expect(filter.isIgnored("src/index.ts")).toBe(false);
     });
   });
+
+  describe("createIgnoreFilter with extraExclude option", () => {
+    it("excludes files matching CLI patterns", () => {
+      const filter = createIgnoreFilter(testDir, {
+        extraExclude: ["**/*.test.ts", "scratch/"],
+      });
+      expect(filter.isIgnored("src/utils.test.ts")).toBe(true);
+      expect(filter.isIgnored("packages/a/src/foo.test.ts")).toBe(true);
+      expect(filter.isIgnored("scratch/notes.md")).toBe(true);
+      // Source files and the matcher's own helper files stay in.
+      expect(filter.isIgnored("src/utils.ts")).toBe(false);
+      expect(filter.isIgnored("README.md")).toBe(false);
+    });
+
+    it("CLI exclude stacks with .understandignore", () => {
+      writeFileSync(
+        join(testDir, ".understand-anything", ".understandignore"),
+        "fixtures/\n"
+      );
+      const filter = createIgnoreFilter(testDir, {
+        extraExclude: ["docs/"],
+      });
+      // Both the persisted rule and the CLI rule are active.
+      expect(filter.isIgnored("fixtures/data.json")).toBe(true);
+      expect(filter.isIgnored("docs/guide.md")).toBe(true);
+      expect(filter.isIgnored("src/index.ts")).toBe(false);
+    });
+
+    it("empty extraExclude does not change behavior", () => {
+      const baseline = createIgnoreFilter(testDir);
+      const filter = createIgnoreFilter(testDir, { extraExclude: [] });
+      const probes = [
+        "src/index.ts",
+        "node_modules/foo/bar.js",
+        "dist/index.js",
+        "README.md",
+        "package-lock.json",
+      ];
+      for (const p of probes) {
+        expect(filter.isIgnored(p)).toBe(baseline.isIgnored(p));
+      }
+    });
+
+    it("does not affect behavior when options is undefined", () => {
+      const explicit = createIgnoreFilter(testDir, undefined);
+      const implicit = createIgnoreFilter(testDir);
+      const probes = [
+        "src/index.ts",
+        "node_modules/foo/bar.js",
+        "dist/index.js",
+        ".idea/workspace.xml",
+      ];
+      for (const p of probes) {
+        expect(explicit.isIgnored(p)).toBe(implicit.isIgnored(p));
+      }
+    });
+
+    it("CLI exclude applied after .understandignore can be overridden by ! negation in .understandignore", () => {
+      // Layer order: defaults -> .understand-anything/.understandignore ->
+      // .understandignore -> extraExclude. Patterns appended later win,
+      // including over `!` negations. Document the precedence so users
+      // know `--exclude` is the final word.
+      writeFileSync(
+        join(testDir, ".understandignore"),
+        "!keep.log\n"
+      );
+      const filter = createIgnoreFilter(testDir, {
+        extraExclude: ["keep.log"],
+      });
+      // The CLI exclude wins because it is the final layer.
+      expect(filter.isIgnored("keep.log")).toBe(true);
+    });
+
+    it("supports ! negation inside extraExclude to re-include defaults-excluded files", () => {
+      // Symmetric test: `--exclude=!dist/` should re-include dist/ that the
+      // hardcoded defaults would otherwise drop. Useful when CI users want
+      // to override defaults without committing a `.understandignore`.
+      const filter = createIgnoreFilter(testDir, {
+        extraExclude: ["!dist/"],
+      });
+      expect(filter.isIgnored("dist/index.js")).toBe(false);
+    });
+  });
 });

--- a/understand-anything-plugin/packages/core/src/ignore-filter.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-filter.ts
@@ -75,6 +75,21 @@ export interface IgnoreFilter {
 }
 
 /**
+ * Optional knobs for createIgnoreFilter. Currently used to layer ad-hoc
+ * patterns sourced from CLI flags (e.g. `/understand --exclude=<pattern>`)
+ * on top of the persistent `.understandignore` rules.
+ */
+export interface CreateIgnoreFilterOptions {
+  /**
+   * Additional gitignore-style patterns appended after the user's
+   * `.understandignore` files. Use the same syntax as `.understandignore`
+   * (globs, `!` negation, trailing `/` for dirs). Empty/undefined leaves
+   * behavior identical to the no-options form.
+   */
+  extraExclude?: string[];
+}
+
+/**
  * Creates an IgnoreFilter that merges hardcoded defaults with user-defined
  * patterns from .understandignore files.
  *
@@ -82,8 +97,12 @@ export interface IgnoreFilter {
  * 1. Hardcoded defaults
  * 2. .understand-anything/.understandignore (if exists)
  * 3. .understandignore at project root (if exists)
+ * 4. CLI `--exclude=<pattern>` patterns (from `options.extraExclude`)
  */
-export function createIgnoreFilter(projectRoot: string): IgnoreFilter {
+export function createIgnoreFilter(
+  projectRoot: string,
+  options?: CreateIgnoreFilterOptions,
+): IgnoreFilter {
   const ig: Ignore = ignore();
 
   // Layer 1: hardcoded defaults
@@ -101,6 +120,12 @@ export function createIgnoreFilter(projectRoot: string): IgnoreFilter {
   if (existsSync(rootIgnorePath)) {
     const content = readFileSync(rootIgnorePath, "utf-8");
     ig.add(content);
+  }
+
+  // Layer 4: CLI --exclude patterns. Applied last so they can override
+  // earlier layers (including default + user .understandignore) via `!`.
+  if (options?.extraExclude && options.extraExclude.length > 0) {
+    ig.add(options.extraExclude);
   }
 
   return {

--- a/understand-anything-plugin/packages/core/src/index.ts
+++ b/understand-anything-plugin/packages/core/src/index.ts
@@ -120,5 +120,6 @@ export {
   createIgnoreFilter,
   DEFAULT_IGNORE_PATTERNS,
   type IgnoreFilter,
+  type CreateIgnoreFilterOptions,
 } from "./ignore-filter.js";
 export { generateStarterIgnoreFile } from "./ignore-generator.js";

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand
 description: Analyze a codebase to produce an interactive knowledge graph for understanding architecture, components, and relationships
-argument-hint: ["[path] [--full|--auto-update|--no-auto-update|--review|--language <lang>]"]
+argument-hint: ["[path] [--full|--auto-update|--no-auto-update|--review|--language <lang>|--exclude=<pattern>]"]
 ---
 
 # /understand
@@ -16,7 +16,14 @@ Analyze the current codebase and produce a `knowledge-graph.json` file in `.unde
   - `--no-auto-update` — Disable automatic graph updates (writes `autoUpdate: false` to `.understand-anything/config.json`)
   - `--review` — Run full LLM graph-reviewer instead of inline deterministic validation
   - `--language <lang>` — Generate all textual content (summaries, descriptions, tags, titles, languageNotes, languageLesson) in the specified language. Accepts ISO 639-1 codes (`zh`, `ja`, `ko`, `en`, `es`, `fr`, `de`, etc.) or friendly names (`chinese`, `japanese`, `korean`, `english`, `spanish`, etc.). Locale variants supported: `zh-TW`, `zh-HK`, etc. Defaults to `en` (English). Stores preference in `.understand-anything/config.json` for consistency across incremental updates.
+  - `--exclude=<pattern>` — Exclude files matching the pattern (gitignore glob syntax, same as `.understandignore`). Can be repeated. Example: `/understand --exclude='**/*.test.*' --exclude='docs/'`
   - A directory path (e.g. `/path/to/repo` or `../other-project`) — Analyze the given directory instead of the current working directory
+
+## Notes
+
+- `--exclude` patterns are applied after `.understandignore` rules. They use the same gitignore glob syntax.
+- `--exclude` cannot override `.gitignore` in git repositories — files already excluded by `.gitignore` are filtered at enumeration time by `git ls-files` before `--exclude` is consulted.
+- `--exclude` is per-invocation. To make an exclusion stick across runs, add it to `.understand-anything/.understandignore` instead.
 
 ---
 
@@ -149,6 +156,12 @@ Determine whether to run a full analysis or incremental update.
       ```markdown
       > **Language directive**: Generate all textual content (summaries, descriptions, tags, titles, languageNotes, languageLesson) in **{language}**. Maintain technical accuracy while using natural, native-level phrasing in the target language. Keep technical terms in English when no standard translation exists (e.g., "middleware", "hook", "barrel").
       ```
+
+ 3.7. **Exclude patterns:**
+    - Parse `$ARGUMENTS` for any number of `--exclude=<pattern>` flags. Each occurrence is one pattern. Patterns use the same gitignore glob syntax as `.understandignore`.
+    - Collect them into an ordered list `$EXCLUDE_FLAGS` (preserve order, allow duplicates — the underlying `ignore` matcher already de-dupes semantically).
+    - These flags do NOT touch `.understand-anything/config.json` — they are per-invocation only. To make an exclusion permanent, instruct the user to add it to `.understand-anything/.understandignore`.
+    - When dispatching the project-scanner agent in Phase 1, append each `--exclude=<pattern>` from `$EXCLUDE_FLAGS` to the bundled `scan-project.mjs` invocation. The agent's docs cover the wiring; this step just makes sure the flags are not silently dropped on the way through.
 
  4. **Check for subdomain knowledge graphs to merge:**
    List all `*knowledge-graph*.json` files in `$PROJECT_ROOT/.understand-anything/` **excluding** `knowledge-graph.json` itself (e.g. `frontend-knowledge-graph.json`, `backend-knowledge-graph.json`). If any subdomain graphs exist, run the merge script bundled with this skill (located next to this SKILL.md file — use the skill directory path, not the project root):

--- a/understand-anything-plugin/skills/understand/scan-project.mjs
+++ b/understand-anything-plugin/skills/understand/scan-project.mjs
@@ -24,7 +24,12 @@
  *   - Complexity estimation (project-scanner.md Step 7 thresholds)
  *
  * Usage:
- *   node scan-project.mjs <projectRoot> <outputPath>
+ *   node scan-project.mjs <projectRoot> <outputPath> [--exclude=<pattern> ...]
+ *
+ * CLI flags:
+ *   --exclude=<pattern>   Additional gitignore-style pattern to exclude.
+ *                         Repeatable. Stacks on top of `.understandignore`.
+ *                         Example: --exclude='**​/*.test.*' --exclude='docs/'
  *
  * Output JSON (subset of what project-scanner.md Phase 1 expects — the LLM
  * agent merges this with Step A's narrative fields and Step C's importMap to
@@ -35,6 +40,7 @@
  *     "totalFiles": N,
  *     "filteredByIgnore": M,
  *     "estimatedComplexity": "small" | "moderate" | "large" | "very-large",
+ *     "appliedExclude": ["pat1", "pat2"],   // present only if --exclude was passed
  *     "stats": { "filesScanned": N, "byCategory": {...}, "byLanguage": {...} }
  *   }
  *
@@ -639,14 +645,49 @@ function countLines(absPath, posixPath) {
 }
 
 // ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `process.argv`-style array into positional args + recognized flags.
+ *
+ * Recognized flags:
+ *   --exclude=<pattern>   Repeatable. Collected into `excludes`.
+ *
+ * Unknown `--flag` tokens are silently ignored to keep the CLI forward-
+ * compatible with future agents that may pass extra options. Positional
+ * arguments are collected in order — first becomes `projectRoot`, second
+ * becomes `outputPath`. Argv slot 0/1 (node + script path) are skipped.
+ */
+export function parseArgs(argv) {
+  const positional = [];
+  const excludes = [];
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith('--exclude=')) {
+      const value = arg.slice('--exclude='.length);
+      // Skip empty values (`--exclude=`) — they would silently match nothing.
+      if (value) excludes.push(value);
+    } else if (!arg.startsWith('--')) {
+      positional.push(arg);
+    }
+    // Other --flag tokens: ignored for forward compatibility.
+  }
+  return {
+    projectRoot: positional[0],
+    outputPath: positional[1],
+    excludes,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const [, , projectRoot, outputPath] = process.argv;
+  const { projectRoot, outputPath, excludes } = parseArgs(process.argv);
   if (!projectRoot || !outputPath) {
     process.stderr.write(
-      'Usage: node scan-project.mjs <projectRoot> <outputPath>\n',
+      'Usage: node scan-project.mjs <projectRoot> <outputPath> [--exclude=<pattern> ...]\n',
     );
     process.exit(1);
   }
@@ -668,11 +709,17 @@ async function main() {
   // 1. Enumerate. Either git ls-files or recursive walk.
   const candidates = enumerateFiles(projectRoot);
 
-  // 2. Filter via createIgnoreFilter (defaults + user .understandignore).
-  //    Build a defaults-only filter in parallel to count user-driven drops.
-  const combined = createIgnoreFilter(projectRoot);
+  // 2. Filter via createIgnoreFilter (defaults + user .understandignore +
+  //    optional CLI --exclude patterns). Build a defaults-only filter in
+  //    parallel to count user-driven drops. The defaults-only filter never
+  //    sees CLI excludes — they count as user-driven, exactly like
+  //    .understandignore patterns.
+  const combined = createIgnoreFilter(projectRoot, {
+    extraExclude: excludes.length > 0 ? excludes : undefined,
+  });
   const userIgnoresPresent = hasUserIgnoreFile(projectRoot);
-  const defaultsOnly = userIgnoresPresent ? buildDefaultsOnlyFilter() : combined;
+  const hasUserDrivenPatterns = userIgnoresPresent || excludes.length > 0;
+  const defaultsOnly = hasUserDrivenPatterns ? buildDefaultsOnlyFilter() : combined;
 
   let filteredByIgnore = 0;
   const kept = [];
@@ -685,8 +732,8 @@ async function main() {
     // Dropped by combined filter. If defaults-only would have ALSO dropped
     // it, this is a baseline default drop — not counted. If defaults-only
     // would have KEPT it, this drop is attributable to the user's
-    // .understandignore content.
-    if (userIgnoresPresent && !defaultsOnly.isIgnored(rel)) {
+    // .understandignore content or a CLI --exclude pattern.
+    if (hasUserDrivenPatterns && !defaultsOnly.isIgnored(rel)) {
       filteredByIgnore++;
     }
   }
@@ -744,6 +791,11 @@ async function main() {
     totalFiles: fileEntries.length,
     filteredByIgnore,
     estimatedComplexity,
+    // Echo CLI --exclude patterns back so downstream consumers can verify
+    // the flag was wired through (and surface it in the dashboard later).
+    // Only emitted when at least one --exclude was passed; otherwise the
+    // field is omitted entirely so existing snapshots/tests stay byte-stable.
+    ...(excludes.length > 0 ? { appliedExclude: excludes } : {}),
     stats: {
       filesScanned: fileEntries.length,
       byCategory,
@@ -799,4 +851,5 @@ export default {
   detectLanguage,
   detectCategory,
   estimateComplexity,
+  parseArgs,
 };


### PR DESCRIPTION
Addresses sub-task 4 from #76 — letting users narrow the scan scope from the command line without editing .understandignore.

**What it does:**

`/understand --exclude='**/*.test.*' --exclude='docs/'` now excludes matching files from the knowledge graph. Patterns use the same gitignore glob syntax as `.understandignore`, and stack on top of it (applied as the last layer).

**Changes:**

- `ignore-filter.ts`: `createIgnoreFilter` accepts an optional `{ extraExclude }` parameter, appended after all file-based layers
- `scan-project.mjs`: new `parseArgs()` collects `--exclude=<pattern>` flags (repeatable, equals-separated to match `compute-batches.mjs` style). Output JSON includes `appliedExclude` when patterns are active so downstream agents can verify what was applied
- `SKILL.md` + `project-scanner.md`: documented the new flag, its syntax, and limitations (can't override .gitignore since those files are filtered at `git ls-files` enumeration time)
- 6 unit tests for `createIgnoreFilter` with `extraExclude`
- 6 integration tests for `scan-project.mjs` CLI behavior

**Design choices:**

- Only `--exclude` for now. `--include` has limited utility (can't rescue .gitignore-filtered files) and adds semantic complexity — happy to add it as a follow-up if there's demand.
- Unknown `--flag` tokens are silently ignored for forward compatibility with future agent options.
- Empty `--exclude=` values are skipped with no error (defensive, avoids accidental wildcard match).
- `filteredByIgnore` count now covers both `.understandignore` and CLI excludes (same accounting bucket).

All existing tests pass. The 6+6 new tests cover single/multi pattern, stacking with .understandignore, empty value handling, unknown flag tolerance, and backward compat (no flags = identical behavior).