### PR TITLE
chore: fix duplicate __pycache__ entry and add common .gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,25 @@ __pycache__/
 .worktrees/
 homepage/public/demo/
 .private/
-__pycache__/
 *.pyc
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# macOS
+.DS_Store
+
+# Editor
+.vscode/
+*.swp
+*.swo
+
+# Logs
+*.log
+npm-debug.log*
+
+# Test coverage
+.coverage
+htmlcov/


### PR DESCRIPTION
Fixes #250

## Changes
- Remove duplicate `__pycache__/` entry
- Add commonly missing patterns: `.venv/`, `.DS_Store`, `.vscode/`, `*.log`, `.coverage`

Small housekeeping to keep the repo tidy.