### PR TITLE
docs: add Contributor Covenant Code of Conduct v2.1

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders via the [Discord server](https://discord.gg/pydat66RY). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders via the [Discord server](https://discord.gg/pydat66RY) or by email at [conduct@project.example](mailto:conduct@project.example). All complaints will be reviewed and investigated promptly and fairly.
 
 ## Enforcement Guidelines
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,59 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders via the [Discord server](https://discord.gg/pydat66RY). All complaints will be reviewed and investigated promptly and fairly.
+
+## Enforcement Guidelines
+
+### 1. Correction
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional.
+**Consequence**: A private, written warning from community leaders.
+
+### 2. Warning
+**Community Impact**: A violation through a single incident or series of actions.
+**Consequence**: A warning with consequences for continued behavior.
+
+### 3. Temporary Ban
+**Community Impact**: A serious violation of community standards.
+**Consequence**: A temporary ban from any sort of interaction with the community.
+
+### 4. Permanent Ban
+**Community Impact**: Demonstrating a pattern of violation of community standards.
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).


### PR DESCRIPTION
Fixes #252

Adds `CODE_OF_CONDUCT.md` using the industry-standard Contributor Covenant v2.1.

With 18k+ stars and a growing Discord community, a clear code of conduct:
- Sets expectations for contributors
- Provides a framework for handling conflicts
- Signals the project is welcoming to all

Enforcement contact points to the Discord server.