### PR TITLE
fix(skill): preserve scan-result.json across Phase 7 cleanup for incremental runs (#293)

### DIFF
--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -770,9 +770,16 @@ Report to the user: `[Phase 7/7] Saving knowledge graph...`
    }
    ```
 
-4. Clean up intermediate files:
+4. Clean up intermediate files, **preserving `scan-result.json`** so future incremental runs can skip Phase 1 SCAN (see issue #293):
    ```bash
-   rm -rf $PROJECT_ROOT/.understand-anything/intermediate
+   # Preserve scan-result.json — Phase 1's deterministic file inventory.
+   # Future incremental runs (Phase 2 compute-batches.mjs --changed-files=…)
+   # need this inventory; without it, Phase 1 must re-dispatch and pay ~157k
+   # tokens / ~158s per incremental run.
+   INTER="$PROJECT_ROOT/.understand-anything/intermediate"
+   if [ -d "$INTER" ]; then
+     find "$INTER" -mindepth 1 -maxdepth 1 -not -name 'scan-result.json' -exec rm -rf {} +
+   fi
    rm -rf $PROJECT_ROOT/.understand-anything/tmp
    ```
 


### PR DESCRIPTION
## Summary

Fix #293: `/understand`'s Phase 7 cleanup deletes `intermediate/scan-result.json`, but Phase 2's incremental path (`compute-batches.mjs --changed-files=…`) requires it. Every "incremental" run is forced to re-dispatch Phase 1 SCAN — ~157k tokens / ~158s wasted per spoke, even when the inventory hasn't structurally changed.

## Fix (Option A — minimal, skill-text only)

Replace the bash `rm -rf intermediate/` in `SKILL.md` Phase 7 step 4 with a `find … -not -name 'scan-result.json' -exec rm -rf {} +` that preserves the baseline file while cleaning everything else. Adds a defensive `if [ -d "$INTER" ]` guard and a comment referencing #293.

No `.mjs` / `.py` / `.ts` changes — `compute-batches.mjs` and `merge-batch-graphs.py` are untouched. This matches **Option A** of the three fix paths the issue author proposed.

```bash
INTER="$PROJECT_ROOT/.understand-anything/intermediate"
if [ -d "$INTER" ]; then
  find "$INTER" -mindepth 1 -maxdepth 1 -not -name 'scan-result.json' -exec rm -rf {} +
fi
rm -rf $PROJECT_ROOT/.understand-anything/tmp
```

## Verification

This is an **efficiency fix** — the produced `knowledge-graph.json` is byte-identical before and after this PR. The visible difference is in `intermediate/`'s contents after Phase 7 cleanup runs.

I reproduced the Phase 7 cleanup behavior with a fixture that mirrors a real post-Phase-1 intermediate dir (`scan-result.json` + `batch-0.json` + `layers.json` + `assemble-review.json` + `tmp/scratch.txt`):

**Before the fix** (`main` @ `26edf61`):

```
=== INTER before cleanup ===
total 24
-rw-r--r-- assemble-review.json
-rw-r--r-- batch-0.json
-rw-r--r-- layers.json
-rw-r--r-- scan-result.json

=== INTER after cleanup ===
(intermediate/ directory does not exist)

=== tmp/ after cleanup ===
(tmp/ directory does not exist)

✗ scan-result.json DELETED (next incremental forced to re-dispatch Phase 1, ~157k tokens wasted)
```

**After the fix** (this PR):

```
=== INTER before cleanup ===
total 24
-rw-r--r-- assemble-review.json
-rw-r--r-- batch-0.json
-rw-r--r-- layers.json
-rw-r--r-- scan-result.json

=== INTER after cleanup ===
total 12
-rw-r--r-- scan-result.json   (only file preserved)

=== tmp/ after cleanup ===
(tmp/ directory does not exist)

✓ scan-result.json PRESERVED (Phase 1 inventory available for next incremental run)
```

Every other intermediate artifact is still cleaned (`batch-*.json` / `layers.json` / `assemble-review.json`); `tmp/` is still cleaned. Only `scan-result.json` is preserved.

`pnpm test` → 200/200; `pnpm lint` → clean; `python3 -m unittest tests.skill.understand.test_merge_batch_graphs` → 69/69; `bash -n` on the new cleanup block → exit 0.

### Known limitation (transparent)

If new files appear in the project between runs, the preserved `scan-result.json` is stale for those paths, and `compute-batches.mjs` may not batch them correctly under `--changed-files=…`. This matches the tradeoff the issue author already accepted ("Other intermediate files can still be cleaned"). A follow-up could add a freshness check (e.g. compare `git ls-files` count or hash) — happy to file as a separate issue if you'd like.

Closes #293