### PR TITLE
chore: clean up duplicate gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@ __pycache__/
 .worktrees/
 homepage/public/demo/
 .private/
-__pycache__/
+.venv/
+venv/
 *.pyc
+*.pyo
+Thumbs.db


### PR DESCRIPTION
Fixes #250

## Summary
- Remove duplicate `__pycache__/` entry from `.gitignore`
- Add common virtual environment, Python bytecode, and Windows cache ignore patterns

## Validation
- Ran `git diff --check`
- Confirmed only `.gitignore` changed
- Not applicable: gitignore-only change
