### PR TITLE
feat(core): add Dart structural analysis via tree-sitter (#226)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
 
   understand-anything-plugin/packages/core:
     dependencies:
+      '@repomix/tree-sitter-wasms':
+        specifier: 0.1.17
+        version: 0.1.17
       fuse.js:
         specifier: ^7.1.0
         version: 7.1.0
@@ -861,6 +864,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@repomix/tree-sitter-wasms@0.1.17':
+    resolution: {integrity: sha512-tc3HnFqdMF1pXhIMzG3aTaBDpIiHK2tPfn3fwqA6P3WTbHa+1EuuTubbKshvmN7xCHP5Ojz0/VW4R+XvR88KOw==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -3854,6 +3860,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@repomix/tree-sitter-wasms@0.1.17': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 

--- a/understand-anything-plugin/packages/core/package.json
+++ b/understand-anything-plugin/packages/core/package.json
@@ -37,6 +37,7 @@
     "vitest": "^3.1.0"
   },
   "dependencies": {
+    "@repomix/tree-sitter-wasms": "0.1.17",
     "fuse.js": "^7.1.0",
     "ignore": "^7.0.5",
     "tree-sitter-c-sharp": "^0.23.1",

--- a/understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts
@@ -49,10 +49,10 @@ describe("LanguageRegistry", () => {
   });
 
   describe("createDefault", () => {
-    it("registers all 40 built-in language configs", () => {
+    it("registers all 41 built-in language configs", () => {
       const registry = LanguageRegistry.createDefault();
       const all = registry.getAllLanguages();
-      expect(all.length).toBe(40);
+      expect(all.length).toBe(41);
     });
 
     it("maps all expected extensions", () => {

--- a/understand-anything-plugin/packages/core/src/languages/configs/dart.ts
+++ b/understand-anything-plugin/packages/core/src/languages/configs/dart.ts
@@ -1,0 +1,29 @@
+import type { LanguageConfig } from "../types.js";
+
+export const dartConfig = {
+  id: "dart",
+  displayName: "Dart",
+  extensions: [".dart"],
+  treeSitter: {
+    wasmPackage: "@repomix/tree-sitter-wasms",
+    wasmFile: "out/tree-sitter-dart.wasm",
+  },
+  concepts: [
+    "null safety",
+    "async/await",
+    "Future and Stream",
+    "mixins",
+    "extension methods",
+    "named constructors",
+    "factory constructors",
+    "isolates",
+    "widgets",
+    "state management",
+  ],
+  filePatterns: {
+    entryPoints: ["lib/main.dart", "bin/main.dart"],
+    barrels: [],
+    tests: ["test/**/*_test.dart"],
+    config: ["pubspec.yaml", "analysis_options.yaml"],
+  },
+} satisfies LanguageConfig;

--- a/understand-anything-plugin/packages/core/src/languages/configs/index.ts
+++ b/understand-anything-plugin/packages/core/src/languages/configs/index.ts
@@ -9,6 +9,7 @@ import { rubyConfig } from "./ruby.js";
 import { phpConfig } from "./php.js";
 import { swiftConfig } from "./swift.js";
 import { kotlinConfig } from "./kotlin.js";
+import { dartConfig } from "./dart.js";
 import { cConfig } from "./c.js";
 import { cppConfig } from "./cpp.js";
 import { csharpConfig } from "./csharp.js";
@@ -53,6 +54,7 @@ export const builtinLanguageConfigs: LanguageConfig[] = [
   phpConfig,
   swiftConfig,
   kotlinConfig,
+  dartConfig,
   luaConfig,
   cConfig,
   cppConfig,
@@ -98,6 +100,7 @@ export {
   phpConfig,
   swiftConfig,
   kotlinConfig,
+  dartConfig,
   luaConfig,
   cConfig,
   cppConfig,

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/dart-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/dart-extractor.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { createRequire } from "node:module";
+import { DartExtractor } from "../dart-extractor.js";
+
+const require = createRequire(import.meta.url);
+
+let Parser: any;
+let Language: any;
+let dartLang: any;
+
+beforeAll(async () => {
+  const mod = await import("web-tree-sitter");
+  Parser = mod.Parser;
+  Language = mod.Language;
+  await Parser.init();
+  const wasmPath = require.resolve(
+    "@repomix/tree-sitter-wasms/out/tree-sitter-dart.wasm",
+  );
+  dartLang = await Language.load(wasmPath);
+});
+
+function parse(code: string) {
+  const parser = new Parser();
+  parser.setLanguage(dartLang);
+  const tree = parser.parse(code);
+  const root = tree.rootNode;
+  return { tree, parser, root };
+}
+
+describe("DartExtractor", () => {
+  const extractor = new DartExtractor();
+
+  it("has correct languageIds", () => {
+    expect(extractor.languageIds).toEqual(["dart"]);
+  });
+
+  describe("extractStructure - functions", () => {
+    it("extracts a simple top-level function with params and return type", () => {
+      const { tree, parser, root } = parse(`int add(int a, int b) => a + b;
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].name).toBe("add");
+      expect(result.functions[0].params).toEqual(["a", "b"]);
+      expect(result.functions[0].returnType).toBe("int");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a void function with no params", () => {
+      const { tree, parser, root } = parse(`void noop() {}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].name).toBe("noop");
+      expect(result.functions[0].params).toEqual([]);
+      expect(result.functions[0].returnType).toBe("void");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts an async function returning a Future", () => {
+      const { tree, parser, root } = parse(`Future<String> fetch(String id) async {
+  return "";
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].name).toBe("fetch");
+      expect(result.functions[0].params).toEqual(["id"]);
+      // The grammar represents `Future<String>` as type_identifier + type_arguments
+      expect(result.functions[0].returnType).toMatch(/^Future/);
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts multiple top-level functions in declaration order", () => {
+      const { tree, parser, root } = parse(`void one() {}
+int two(int x) => x;
+String three() => "";
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions.map((f) => f.name)).toEqual([
+        "one",
+        "two",
+        "three",
+      ]);
+
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - classes", () => {
+    it("extracts a class with field + constructor + method", () => {
+      const { tree, parser, root } = parse(`class Foo {
+  final int bar;
+  Foo(this.bar);
+  int compute() => bar * 2;
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Foo");
+      expect(result.classes[0].properties).toContain("bar");
+      expect(result.classes[0].methods).toEqual(
+        expect.arrayContaining(["Foo", "compute"]),
+      );
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts an abstract class with method signature only", () => {
+      const { tree, parser, root } = parse(`abstract class Greeter {
+  String greet(String name);
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Greeter");
+      expect(result.classes[0].methods).toContain("greet");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("class methods appear in functions[] as well as the class's methods[]", () => {
+      const { tree, parser, root } = parse(`class Foo {
+  int bar() => 1;
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions.map((f) => f.name)).toContain("bar");
+      expect(result.classes[0].methods).toContain("bar");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts multiple field names declared as a comma list", () => {
+      const { tree, parser, root } = parse(`class Point {
+  double x, y;
+  Point(this.x, this.y);
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes[0].properties).toEqual(
+        expect.arrayContaining(["x", "y"]),
+      );
+
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - mixins", () => {
+    it("extracts a mixin with methods as a class-like entry", () => {
+      const { tree, parser, root } = parse(`mixin Logger {
+  void log(String msg) {}
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Logger");
+      expect(result.classes[0].methods).toContain("log");
+
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - enums", () => {
+    it("extracts enum cases as properties", () => {
+      const { tree, parser, root } = parse(`enum Direction { north, south, east, west }
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Direction");
+      expect(result.classes[0].properties).toEqual([
+        "north",
+        "south",
+        "east",
+        "west",
+      ]);
+
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - extensions", () => {
+    it("extracts an extension with methods as a class-like entry named after the extension", () => {
+      const { tree, parser, root } = parse(`extension StringX on String {
+  String shout() => toUpperCase();
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("StringX");
+      expect(result.classes[0].methods).toContain("shout");
+
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - imports", () => {
+    it("extracts a simple `dart:` import", () => {
+      const { tree, parser, root } = parse(`import "dart:io";
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toHaveLength(1);
+      expect(result.imports[0].source).toBe("dart:io");
+      expect(result.imports[0].specifiers).toEqual(["io"]);
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a `package:` import with an `as` alias", () => {
+      const { tree, parser, root } = parse(`import "package:foo/bar.dart" as bar;
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toHaveLength(1);
+      expect(result.imports[0].source).toBe("package:foo/bar.dart");
+      expect(result.imports[0].specifiers).toEqual(["bar"]);
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a `show` combinator's selectively imported identifiers", () => {
+      const { tree, parser, root } = parse(`import "dart:async" show Future, Stream;
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toHaveLength(1);
+      expect(result.imports[0].source).toBe("dart:async");
+      expect(result.imports[0].specifiers).toEqual(["Future", "Stream"]);
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts multiple imports in declaration order", () => {
+      const { tree, parser, root } = parse(`import "dart:io";
+import "package:flutter/material.dart";
+import "dart:async" show Future;
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toHaveLength(3);
+      expect(result.imports[0].source).toBe("dart:io");
+      expect(result.imports[1].source).toBe("package:flutter/material.dart");
+      expect(result.imports[2].source).toBe("dart:async");
+
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - exports / privacy (underscore prefix)", () => {
+    it("treats functions without a leading underscore as exported", () => {
+      const { tree, parser, root } = parse(`void publicFn() {}
+class Public {}
+`);
+      const result = extractor.extractStructure(root);
+
+      const exportNames = result.exports.map((e) => e.name);
+      expect(exportNames).toEqual(
+        expect.arrayContaining(["publicFn", "Public"]),
+      );
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("does NOT export declarations whose name starts with `_`", () => {
+      const { tree, parser, root } = parse(`void _internal() {}
+class _PrivateClass {}
+`);
+      const result = extractor.extractStructure(root);
+
+      const exportNames = result.exports.map((e) => e.name);
+      expect(exportNames).not.toContain("_internal");
+      expect(exportNames).not.toContain("_PrivateClass");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("exports a mixin / extension / enum by default if not underscore-prefixed", () => {
+      const { tree, parser, root } = parse(`mixin Logger {}
+extension StringX on String {}
+enum Direction { north }
+`);
+      const result = extractor.extractStructure(root);
+
+      const exportNames = result.exports.map((e) => e.name);
+      expect(exportNames).toEqual(
+        expect.arrayContaining(["Logger", "StringX", "Direction"]),
+      );
+
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractCallGraph", () => {
+    it("extracts a direct function call", () => {
+      const { tree, parser, root } = parse(`int helper() => 1;
+
+int caller() {
+  return helper();
+}
+`);
+      const entries = extractor.extractCallGraph(root);
+
+      const helperCall = entries.find((e) => e.callee === "helper");
+      expect(helperCall).toBeDefined();
+      expect(helperCall!.caller).toBe("caller");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a method call on a value (x.foo())", () => {
+      const { tree, parser, root } = parse(`void run() {
+  var s = "hi".toUpperCase();
+}
+`);
+      const entries = extractor.extractCallGraph(root);
+
+      const callees = entries.map((e) => e.callee);
+      expect(callees).toContain("toUpperCase");
+
+      tree.delete();
+      parser.delete();
+    });
+  });
+});

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts
@@ -1,0 +1,553 @@
+import type { StructuralAnalysis, CallGraphEntry } from "../../types.js";
+import type { LanguageExtractor, TreeSitterNode } from "./types.js";
+import { findChild, findChildren } from "./base-extractor.js";
+
+/**
+ * Whether a Dart identifier is library-private. Dart has no `private`
+ * keyword — instead, leading underscore on the identifier makes the
+ * declaration visible only within its own library.
+ */
+function isPrivateName(name: string): boolean {
+  return name.startsWith("_");
+}
+
+/**
+ * Get the first `identifier` text under a node. Used to recover the name
+ * from a function_signature, constructor_signature, etc.
+ */
+function firstIdentifierText(node: TreeSitterNode): string | null {
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child && child.type === "identifier") return child.text;
+  }
+  return null;
+}
+
+/**
+ * Extract the parameter names from a Dart `formal_parameter_list`.
+ *
+ * The grammar distinguishes several parameter shapes:
+ * - Regular     `Type name`          → `formal_parameter` with leading type + `identifier`
+ * - This-init   `this.field`         → `formal_parameter` with no leading `identifier`
+ *                                       (just `this`, `.`, `identifier`)
+ * - Optional    `[Type name = expr]` / `{Type name}` — wrapped in
+ *               `optional_formal_parameters` / `named_formal_parameters`
+ *
+ * For all shapes, we want the user-visible parameter name. For `this.x`
+ * we return `x`; for `Type name` we return `name`; for unrecognised shapes
+ * we fall back to the LAST `identifier` text under the parameter node.
+ */
+function extractParamName(paramNode: TreeSitterNode): string | null {
+  let lastIdentifier: string | null = null;
+  for (let i = 0; i < paramNode.childCount; i++) {
+    const child = paramNode.child(i);
+    if (!child) continue;
+    if (child.type === "identifier") {
+      lastIdentifier = child.text;
+    }
+  }
+  return lastIdentifier;
+}
+
+function extractParams(signatureNode: TreeSitterNode): string[] {
+  const params: string[] = [];
+  const list = findChild(signatureNode, "formal_parameter_list");
+  if (!list) return params;
+  for (let i = 0; i < list.childCount; i++) {
+    const child = list.child(i);
+    if (!child) continue;
+    if (child.type === "formal_parameter") {
+      const name = extractParamName(child);
+      if (name) params.push(name);
+    } else if (
+      child.type === "optional_formal_parameters" ||
+      child.type === "named_formal_parameters"
+    ) {
+      // Wrappers around `[...]` / `{...}` — walk one level deeper.
+      for (const sub of findChildren(child, "formal_parameter")) {
+        const name = extractParamName(sub);
+        if (name) params.push(name);
+      }
+    }
+  }
+  return params;
+}
+
+/**
+ * Extract the return type text from a `function_signature`. Dart puts the
+ * return type as a leading non-identifier child (e.g., `type_identifier`,
+ * `void_type`, or a more complex type construct). We take the first named
+ * child that's NOT the function's own identifier or its parameter list.
+ */
+function extractReturnType(signatureNode: TreeSitterNode): string | undefined {
+  for (let i = 0; i < signatureNode.childCount; i++) {
+    const child = signatureNode.child(i);
+    if (!child || !child.isNamed) continue;
+    if (
+      child.type === "identifier" ||
+      child.type === "formal_parameter_list" ||
+      child.type === "type_parameters"
+    ) {
+      continue;
+    }
+    // Likely the return type (type_identifier, void_type, function_type, …)
+    return child.text;
+  }
+  return undefined;
+}
+
+/**
+ * Dart extractor for tree-sitter structural analysis and call graph
+ * extraction. Handles classes, mixins, enums, extensions, top-level
+ * functions, library imports, and Dart's underscore-prefix privacy rule.
+ */
+export class DartExtractor implements LanguageExtractor {
+  readonly languageIds = ["dart"];
+
+  extractStructure(rootNode: TreeSitterNode): StructuralAnalysis {
+    const functions: StructuralAnalysis["functions"] = [];
+    const classes: StructuralAnalysis["classes"] = [];
+    const imports: StructuralAnalysis["imports"] = [];
+    const exports: StructuralAnalysis["exports"] = [];
+
+    for (let i = 0; i < rootNode.childCount; i++) {
+      const node = rootNode.child(i);
+      if (!node) continue;
+
+      switch (node.type) {
+        case "function_signature":
+          this.extractTopLevelFunction(node, functions, exports);
+          break;
+
+        case "class_definition":
+          this.extractClassLike(node, "class_body", classes, functions, exports);
+          break;
+
+        case "mixin_declaration":
+          this.extractClassLike(node, "class_body", classes, functions, exports);
+          break;
+
+        case "extension_declaration":
+          this.extractClassLike(
+            node,
+            "extension_body",
+            classes,
+            functions,
+            exports,
+          );
+          break;
+
+        case "enum_declaration":
+          this.extractEnum(node, classes, exports);
+          break;
+
+        case "import_or_export":
+          this.extractImport(node, imports);
+          break;
+      }
+    }
+
+    return { functions, classes, imports, exports };
+  }
+
+  extractCallGraph(rootNode: TreeSitterNode): CallGraphEntry[] {
+    const entries: CallGraphEntry[] = [];
+    const functionStack: string[] = [];
+
+    // Dart's grammar makes `function_signature` and `function_body` SIBLINGS
+    // under their common parent (the program or a class body), so calls
+    // inside the body would not see the surrounding name if we only pushed
+    // on entering `function_signature`. Instead, we push when entering a
+    // `function_body` by looking at the preceding sibling for its name.
+    //
+    // web-tree-sitter returns a fresh JS wrapper each time you call
+    // `parent.child(i)`, so `===` identity comparisons against the body
+    // node always fail. We compare via `id` (a tree-unique node identity
+    // preserved across wrappers) instead.
+    const nameForFunctionBody = (body: TreeSitterNode): string | null => {
+      const parent = body.parent;
+      if (!parent) return null;
+      const bodyId = body.id;
+      let bodyIndex = -1;
+      for (let i = 0; i < parent.childCount; i++) {
+        const child = parent.child(i);
+        if (child && child.id === bodyId) {
+          bodyIndex = i;
+          break;
+        }
+      }
+      if (bodyIndex < 0) return null;
+      // Walk backwards to find the function_signature / constructor_signature
+      for (let i = bodyIndex - 1; i >= 0; i--) {
+        const sib = parent.child(i);
+        if (!sib) continue;
+        if (sib.type === "function_signature") return firstIdentifierText(sib);
+        if (sib.type === "method_signature") {
+          const sig = findChild(sib, "function_signature");
+          return sig ? firstIdentifierText(sig) : null;
+        }
+        if (
+          sib.type === "constructor_signature" ||
+          sib.type === "constant_constructor_signature" ||
+          sib.type === "factory_constructor_signature"
+        ) {
+          return firstIdentifierText(sib) ?? "constructor";
+        }
+      }
+      return null;
+    };
+
+    const walk = (node: TreeSitterNode) => {
+      let pushed = false;
+
+      if (node.type === "function_body") {
+        const name = nameForFunctionBody(node);
+        if (name) {
+          functionStack.push(name);
+          pushed = true;
+        }
+      }
+
+      // A call shows up as an `argument_part` (the `(...)` after a callee
+      // expression). We attribute it to the enclosing function and resolve
+      // the callee name by looking at the preceding sibling of its parent
+      // `selector` — either an `identifier` (plain `foo()`) or a
+      // `selector > unconditional_assignable_selector > identifier`
+      // (method call `x.foo()`).
+      if (node.type === "argument_part" && functionStack.length > 0) {
+        const callee = this.extractCalleeForArgumentPart(node);
+        if (callee) {
+          entries.push({
+            caller: functionStack[functionStack.length - 1],
+            callee,
+            lineNumber: node.startPosition.row + 1,
+          });
+        }
+      }
+
+      for (let i = 0; i < node.childCount; i++) {
+        const child = node.child(i);
+        if (child) walk(child);
+      }
+
+      if (pushed) functionStack.pop();
+    };
+
+    walk(rootNode);
+    return entries;
+  }
+
+  // ---- Private helpers ----
+
+  private extractTopLevelFunction(
+    signatureNode: TreeSitterNode,
+    functions: StructuralAnalysis["functions"],
+    exports: StructuralAnalysis["exports"],
+  ): void {
+    const name = firstIdentifierText(signatureNode);
+    if (!name) return;
+    functions.push({
+      name,
+      lineRange: [
+        signatureNode.startPosition.row + 1,
+        signatureNode.endPosition.row + 1,
+      ],
+      params: extractParams(signatureNode),
+      returnType: extractReturnType(signatureNode),
+    });
+    if (!isPrivateName(name)) {
+      exports.push({ name, lineNumber: signatureNode.startPosition.row + 1 });
+    }
+  }
+
+  private extractClassLike(
+    declNode: TreeSitterNode,
+    bodyType: "class_body" | "extension_body",
+    classes: StructuralAnalysis["classes"],
+    functions: StructuralAnalysis["functions"],
+    exports: StructuralAnalysis["exports"],
+  ): void {
+    const name = firstIdentifierText(declNode);
+    if (!name) return;
+
+    const methods: string[] = [];
+    const properties: string[] = [];
+
+    const body = findChild(declNode, bodyType);
+    if (body) {
+      this.collectBodyMembers(body, methods, properties, functions, exports);
+    }
+
+    classes.push({
+      name,
+      lineRange: [
+        declNode.startPosition.row + 1,
+        declNode.endPosition.row + 1,
+      ],
+      methods,
+      properties,
+    });
+
+    if (!isPrivateName(name)) {
+      exports.push({ name, lineNumber: declNode.startPosition.row + 1 });
+    }
+  }
+
+  private extractEnum(
+    declNode: TreeSitterNode,
+    classes: StructuralAnalysis["classes"],
+    exports: StructuralAnalysis["exports"],
+  ): void {
+    const name = firstIdentifierText(declNode);
+    if (!name) return;
+
+    const properties: string[] = [];
+    const body = findChild(declNode, "enum_body");
+    if (body) {
+      for (const entry of findChildren(body, "enum_constant")) {
+        const id = findChild(entry, "identifier");
+        if (id) properties.push(id.text);
+      }
+    }
+
+    classes.push({
+      name,
+      lineRange: [
+        declNode.startPosition.row + 1,
+        declNode.endPosition.row + 1,
+      ],
+      methods: [],
+      properties,
+    });
+
+    if (!isPrivateName(name)) {
+      exports.push({ name, lineNumber: declNode.startPosition.row + 1 });
+    }
+  }
+
+  /**
+   * Walk a class_body / extension_body / mixin_body and collect methods
+   * and properties.
+   *
+   * The Dart grammar wraps most class members in a `declaration` node, but
+   * regular methods appear as a top-level `method_signature` (which wraps
+   * a `function_signature`) followed by a sibling `function_body`. Fields
+   * live inside `declaration > initialized_identifier_list`. Constructors
+   * live inside `declaration > constructor_signature`.
+   */
+  private collectBodyMembers(
+    body: TreeSitterNode,
+    methods: string[],
+    properties: string[],
+    functions: StructuralAnalysis["functions"],
+    exports: StructuralAnalysis["exports"],
+  ): void {
+    for (let i = 0; i < body.childCount; i++) {
+      const child = body.child(i);
+      if (!child) continue;
+
+      if (child.type === "method_signature") {
+        const sig = findChild(child, "function_signature");
+        if (!sig) continue;
+        const name = firstIdentifierText(sig);
+        if (!name) continue;
+        methods.push(name);
+        functions.push({
+          name,
+          lineRange: [sig.startPosition.row + 1, sig.endPosition.row + 1],
+          params: extractParams(sig),
+          returnType: extractReturnType(sig),
+        });
+        if (!isPrivateName(name)) {
+          exports.push({ name, lineNumber: sig.startPosition.row + 1 });
+        }
+      } else if (child.type === "declaration") {
+        this.handleClassDeclaration(child, methods, properties, functions, exports);
+      }
+    }
+  }
+
+  private handleClassDeclaration(
+    decl: TreeSitterNode,
+    methods: string[],
+    properties: string[],
+    functions: StructuralAnalysis["functions"],
+    exports: StructuralAnalysis["exports"],
+  ): void {
+    // A `declaration` inside a class body can be a constructor, a field,
+    // or a function signature (e.g. abstract methods which have no body).
+    const ctor =
+      findChild(decl, "constructor_signature") ||
+      findChild(decl, "constant_constructor_signature") ||
+      findChild(decl, "factory_constructor_signature");
+    if (ctor) {
+      const name = firstIdentifierText(ctor) ?? "constructor";
+      methods.push(name);
+      return;
+    }
+
+    const fnSig = findChild(decl, "function_signature");
+    if (fnSig) {
+      const name = firstIdentifierText(fnSig);
+      if (name) {
+        methods.push(name);
+        functions.push({
+          name,
+          lineRange: [fnSig.startPosition.row + 1, fnSig.endPosition.row + 1],
+          params: extractParams(fnSig),
+          returnType: extractReturnType(fnSig),
+        });
+        if (!isPrivateName(name)) {
+          exports.push({ name, lineNumber: fnSig.startPosition.row + 1 });
+        }
+      }
+      return;
+    }
+
+    // Field declaration — initialized_identifier_list holds one or more
+    // identifiers sharing a type.
+    const initList = findChild(decl, "initialized_identifier_list");
+    if (initList) {
+      for (const entry of findChildren(initList, "initialized_identifier")) {
+        const id = findChild(entry, "identifier");
+        if (id) properties.push(id.text);
+      }
+    }
+  }
+
+  /**
+   * Extract a Dart import.
+   *
+   * Grammar:
+   *   import_or_export > library_import > import_specification
+   *     - `import` keyword
+   *     - configurable_uri > uri > string_literal (the URI text)
+   *     - optional `as <identifier>` for an alias
+   *     - optional `combinator > show <ids> / hide <ids>`
+   */
+  private extractImport(
+    declNode: TreeSitterNode,
+    imports: StructuralAnalysis["imports"],
+  ): void {
+    const libImport = findChild(declNode, "library_import");
+    if (!libImport) return;
+    const spec = findChild(libImport, "import_specification");
+    if (!spec) return;
+
+    const uriContainer = findChild(spec, "configurable_uri");
+    if (!uriContainer) return;
+    const uriNode = findChild(uriContainer, "uri");
+    if (!uriNode) return;
+    const stringLit = findChild(uriNode, "string_literal");
+    const source = stringLit
+      ? stringLit.text.replace(/^["']|["']$/g, "")
+      : uriNode.text.replace(/^["']|["']$/g, "");
+
+    // Default specifier: last `/`-delimited segment of the URI's path
+    // portion (e.g. "package:foo/bar.dart" → "bar.dart"). For Dart's core
+    // libs ("dart:io"), use the portion after `:`.
+    let defaultSpecifier = source;
+    if (source.includes("/")) {
+      defaultSpecifier = source.slice(source.lastIndexOf("/") + 1);
+    } else if (source.includes(":")) {
+      defaultSpecifier = source.slice(source.lastIndexOf(":") + 1);
+    }
+
+    // Collect aliases / combinator identifiers
+    const specifiers: string[] = [];
+    let sawAs = false;
+    for (let i = 0; i < spec.childCount; i++) {
+      const child = spec.child(i);
+      if (!child) continue;
+      if (child.type === "as") sawAs = true;
+      else if (sawAs && child.type === "identifier") {
+        specifiers.push(child.text);
+        sawAs = false;
+      } else if (child.type === "combinator") {
+        for (const id of findChildren(child, "identifier")) {
+          specifiers.push(id.text);
+        }
+      }
+    }
+
+    if (specifiers.length === 0) specifiers.push(defaultSpecifier);
+
+    imports.push({
+      source,
+      specifiers,
+      lineNumber: declNode.startPosition.row + 1,
+    });
+  }
+
+  /**
+   * Resolve the callee identifier for an `argument_part` node.
+   *
+   * Dart represents both `foo()` and `x.foo()` by following the callee
+   * expression with a `selector` whose child is the `argument_part`. The
+   * callee itself lives in the GRANDPARENT chain, immediately before the
+   * call-selector.
+   *
+   * For `foo()`:
+   *   <parent>
+   *     identifier "foo"      ← we want this
+   *     selector              ← argument_part's parent
+   *       argument_part ()
+   *
+   * For `x.foo()`:
+   *   <parent>
+   *     <receiver expression>
+   *     selector              ← `.foo` (assignable selector)
+   *       unconditional_assignable_selector
+   *         . , identifier "foo"   ← we want this
+   *     selector              ← argument_part's parent (call selector)
+   *       argument_part ()
+   *
+   * Walk from the argument_part's parent (selector) up to the
+   * grandparent, find the parent-selector's index, then look at the
+   * sibling immediately before it. If that sibling is an `identifier` use
+   * its text; if it's a `selector`, dig into its assignable-selector
+   * child for the method name.
+   */
+  private extractCalleeForArgumentPart(
+    argPartNode: TreeSitterNode,
+  ): string | null {
+    const callSelector = argPartNode.parent;
+    if (!callSelector) return null;
+    const grandparent = callSelector.parent;
+    if (!grandparent) return null;
+
+    // Find the call-selector's index among the grandparent's children.
+    // web-tree-sitter returns fresh node wrappers from .child(i), so we
+    // identify the call-selector by its `id` rather than by reference.
+    const callSelectorId = callSelector.id;
+    let selectorIndex = -1;
+    for (let i = 0; i < grandparent.childCount; i++) {
+      const child = grandparent.child(i);
+      if (child && child.id === callSelectorId) {
+        selectorIndex = i;
+        break;
+      }
+    }
+    if (selectorIndex <= 0) return null;
+
+    // The sibling immediately before the call-selector is the callee.
+    const prev = grandparent.child(selectorIndex - 1);
+    if (!prev) return null;
+
+    if (prev.type === "identifier") return prev.text;
+
+    if (prev.type === "selector") {
+      const assignable =
+        findChild(prev, "unconditional_assignable_selector") ||
+        findChild(prev, "conditional_assignable_selector");
+      if (assignable) {
+        const id = findChild(assignable, "identifier");
+        if (id) return id.text;
+      }
+      // Fallback: any identifier directly inside the prior selector
+      const id = findChild(prev, "identifier");
+      if (id) return id.text;
+    }
+    return null;
+  }
+}

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/index.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/index.ts
@@ -9,6 +9,7 @@ export { RubyExtractor } from "./ruby-extractor.js";
 export { PhpExtractor } from "./php-extractor.js";
 export { CppExtractor } from "./cpp-extractor.js";
 export { CSharpExtractor } from "./csharp-extractor.js";
+export { DartExtractor } from "./dart-extractor.js";
 
 import type { LanguageExtractor } from "./types.js";
 import { TypeScriptExtractor } from "./typescript-extractor.js";
@@ -20,6 +21,7 @@ import { RubyExtractor } from "./ruby-extractor.js";
 import { PhpExtractor } from "./php-extractor.js";
 import { CppExtractor } from "./cpp-extractor.js";
 import { CSharpExtractor } from "./csharp-extractor.js";
+import { DartExtractor } from "./dart-extractor.js";
 
 export const builtinExtractors: LanguageExtractor[] = [
   new TypeScriptExtractor(),
@@ -31,4 +33,5 @@ export const builtinExtractors: LanguageExtractor[] = [
   new PhpExtractor(),
   new CppExtractor(),
   new CSharpExtractor(),
+  new DartExtractor(),
 ];


### PR DESCRIPTION
## Summary

Completes the **Flutter portion of #226** — `.dart` files now produce functions, classes, mixins, extensions, enums, imports, exports, and call-graph edges. Same pattern PR1 used for Swift, just a different grammar shape.

This is a sibling PR to the Swift extractor; together they cover the iOS + Flutter combination called out in #226.

## What's covered

- `function_signature` (top-level + class methods) with params and return type
- `class_definition` — fields, constructors (regular / const / factory), and methods are extracted
- `mixin_declaration`, `extension_declaration`, `enum_declaration` are all surfaced as class-like entries
- `import_or_export` handles `dart:` URIs, `package:` URIs, `as` aliases, and `show` combinator identifiers
- **Privacy rule**: Dart has no `private` keyword — names starting with `_` are library-private. The extractor mirrors this: any non-underscored top-level name is exported

## Grammar wrinkles worth flagging for review

| Wrinkle | How it's handled |
|---|---|
| `function_signature` and `function_body` are **siblings**, not nested | Call-graph walker pushes the function name when entering a `function_body` and resolves the name from the preceding sibling |
| Calls are decomposed: callee → `selector > argument_part` | `extractCalleeForArgumentPart` handles both `foo()` (sibling identifier) and `x.foo()` (prior `selector > unconditional_assignable_selector > identifier`) |
| **web-tree-sitter gotcha**: `parent.child(i)` returns a fresh wrapper, so `===` fails | We compare via `.id` (a tree-unique node identity preserved across wrappers). Documented inline since this is non-obvious and bit me during dev |

## Files

| Area | File | Status |
|---|---|---|
| Config | `languages/configs/dart.ts` | New |
| Index | `languages/configs/index.ts` | + `dartConfig` |
| Extractor | `plugins/extractors/dart-extractor.ts` | New |
| Registration | `plugins/extractors/index.ts` | + `DartExtractor` |
| Tests | `plugins/extractors/__tests__/dart-extractor.test.ts` | New (21 cases) |
| Test bump | `__tests__/language-registry.test.ts` | Expected count 40 → 41 for the new builtin config |
| Dep | `core/package.json` | + `@repomix/tree-sitter-wasms@0.1.17` (same bundle as Swift — also ships `tree-sitter-dart.wasm`) |

## Verification

- ✅ `pnpm lint` clean
- ✅ `pnpm --filter @understand-anything/core build` clean
- ✅ `pnpm --filter @understand-anything/skill build` clean
- ✅ `pnpm --filter @understand-anything/core test`: **691/691** (+21 new Dart cases + 1 updated count assertion)
- ✅ `pnpm test`: 196/196 (no regressions)

## Test plan

- [ ] Reviewer runs `pnpm install` to pull the new dep
- [ ] `pnpm --filter @understand-anything/core test` passes (691 tests, includes 21 new Dart cases)
- [ ] Spot check: run `/understand --full` against a Flutter project and confirm relationship edges now appear between `.dart` files

Refs #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)