### PR TITLE
chore(repo): community templates, CoC, SECURITY, package metadata, CI on main (#248, #249, #251, #252)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: Bug report
+description: Report something that isn't working
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The more concrete you can be,
+        the faster it gets fixed. If you can include the analyzed project's
+        primary language and an approximate file count, that's gold.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect to happen, and what actually happened?
+      placeholder: |
+        1. Ran `/understand --full` on a ~3,000 file Rust project
+        2. Expected: dashboard opens with the graph
+        3. Got: dashboard shows "Failed to load graph: schema validation error"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Minimal reproduction
+      description: Smallest set of steps (or a link to a public repo) that reproduces the issue.
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Plugin version
+      description: Run `/understand --version` or check `~/.claude/plugins/cache/understand-anything/understand-anything/`.
+      placeholder: "e.g. 2.7.4"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform / client
+      multiple: true
+      options:
+        - Claude Code (CLI)
+        - Claude Code (VS Code extension)
+        - Claude Code (JetBrains)
+        - Cursor
+        - GitHub Copilot CLI
+        - opencode
+        - Other (please describe in "What happened?")
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS + Node version
+      placeholder: "e.g. macOS 14.5 (arm64), Node v22.6.0"
+    validations:
+      required: true
+
+  - type: input
+    id: project-language
+    attributes:
+      label: Primary language of the analyzed project
+      placeholder: "e.g. TypeScript, Python, Swift…"
+
+  - type: input
+    id: file-count
+    attributes:
+      label: Approximate file count of the analyzed project
+      placeholder: "e.g. ~3,000"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Any console output, the contents of `.understand-anything/intermediate/`
+        if it still exists, or screenshots of the dashboard error.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: README & docs
+    url: https://github.com/Lum1104/Understand-Anything#readme
+    about: Most usage questions are answered in the project README.
+  - name: Discussions
+    url: https://github.com/Lum1104/Understand-Anything/discussions
+    about: For open-ended discussion, design proposals, or sharing how you use the tool.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature request
+description: Suggest an idea or improvement
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the user pain or workflow gap. Concrete examples help more than abstract framing.
+      placeholder: |
+        When onboarding new engineers to our 8k-file Go monorepo, they spend
+        days finding the auth boundary. /understand finds the files but the
+        dashboard doesn't visually separate "trusted" from "untrusted" zones.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution (optional)
+      description: If you have an idea for what the feature should look like, share it. Skip if you'd rather just describe the problem.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Other tools, workarounds, or approaches you've tried.
+
+  - type: input
+    id: scope
+    attributes:
+      label: Which part of the project?
+      placeholder: "skill / dashboard / core / agents / all"

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,24 @@
+name: Question / usage help
+description: Ask a question about how to use the project
+title: "question: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For general usage questions. If you found a bug, please use the bug
+        report template instead — it asks for the information needed to
+        reproduce.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you already tried?
+      description: Helps avoid suggesting things you've already ruled out.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- One or two sentences on what this PR changes and why. -->
+
+## Linked issue(s)
+
+<!-- e.g. Closes #123, Refs #456. Leave empty if there's no tracking issue. -->
+
+## How I tested this
+
+<!-- Concrete steps. "Ran the test suite" is fine; "Ran /understand on a 3k-file
+Swift repo and verified the dashboard shows non-empty edges" is better. -->
+
+- [ ] `pnpm lint`
+- [ ] `pnpm --filter @understand-anything/core test`
+- [ ] `pnpm test`
+- [ ] Manual smoke test (describe above)
+
+## Versioning
+
+<!-- If this PR ships a user-visible behavior change, bump the version in ALL
+five manifests per CLAUDE.md. If it's docs/tests/internal-only, leave them
+alone and the maintainer will bump on merge. -->
+
+- [ ] Version bumped in all five manifests, OR
+- [ ] N/A — internal/docs-only change

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,21 @@
 name: CI
 
 on:
+  # Run on every PR so a contributor's first push gets feedback.
   pull_request:
+  # Also run on direct pushes to main so the "main is green" signal is real.
+  # Without this, main can silently break for days when someone bypasses
+  # review. (#249)
+  push:
+    branches: [main]
+
+# Cancel any in-flight CI for the same ref when a new commit is pushed —
+# saves runner minutes and keeps the latest commit's status the only one
+# anyone reads. `github.ref` is a controlled value (refs/heads/* or
+# refs/pull/*/merge), not user-controlled input, so it's safe to interpolate.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ci:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+We want this project to be a welcoming place for everyone who wants to
+contribute, learn, or use it — regardless of experience level, background, or
+identity.
+
+## In short
+
+- **Be respectful.** Treat others the way you'd want to be treated.
+- **Assume good intent.** Most disagreements are misunderstandings.
+- **Be constructive.** Critique ideas, not people. Suggest improvements.
+- **Keep it on-topic.** This project is about understanding codebases.
+
+## What's not OK
+
+- Personal attacks, insults, or sustained disruption of discussions.
+- Posting someone's private information without their explicit permission.
+- Repeatedly ignoring requests from maintainers to change behavior.
+
+## Reporting
+
+If you see behavior that violates this code, please open a private email to
+the maintainer listed in the repository profile, or use GitHub's
+[private vulnerability / abuse reporting](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam).
+
+Maintainers will review reports and take whatever action they think is
+appropriate — typically a private warning, sometimes a temporary or permanent
+ban from the project. Reports will be kept confidential.
+
+## Scope
+
+This code applies in all project spaces: issues, pull requests, discussions,
+commits, and any other project-affiliated channel.
+
+---
+
+This document is intentionally short. It's based on the spirit of the
+[Contributor Covenant](https://www.contributor-covenant.org/) without
+reproducing it verbatim.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Reporting security issues
+
+Thanks for taking the time to disclose responsibly.
+
+## How to report
+
+Please use GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+on this repository. That keeps the report visible to the maintainer without
+exposing the details publicly.
+
+If private reporting is unavailable for any reason, open a regular issue
+titled `security: brief description` **without** any exploit details, and
+the maintainer will reply with a private channel.
+
+## What to include
+
+- A description of the issue and its potential impact.
+- Steps to reproduce — minimal is fine, a full PoC is not required.
+- Affected versions if you've narrowed them down.
+- Whether you'd like to be credited in the eventual fix.
+
+## What to expect
+
+- Initial acknowledgement within a few days.
+- A fix or mitigation plan within ~30 days for confirmed issues; longer for
+  cases that require coordinated disclosure with upstream dependencies.
+- Public credit once a fix has shipped, if you'd like.
+
+## Scope
+
+This project is a **local-only** static-analysis tool. It runs on a
+developer's machine, reads the analyzed project, and writes the resulting
+graph to `.understand-anything/`. It does not phone home and the dashboard's
+file-content endpoint is gated behind an access token and a graph-derived
+path allowlist.
+
+Issues we care about:
+
+- Code execution triggered by analyzing a hostile project (e.g. a path in a
+  hostile file leaking outside the analyzed directory, or untrusted JSON in
+  the graph being executed by the dashboard).
+- The dashboard's file-content endpoint serving files outside the allowlist.
+- The `/understand` skill running shell commands derived from untrusted
+  paths or contents.
+
+Issues that are **out of scope**:
+
+- Bugs that require a malicious local user with write access to the
+  analyzed project (they could just edit the source directly).
+- Anything that requires the user to copy a malicious URL and paste it back
+  into the dashboard.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,28 @@
   "name": "understand-anything",
   "private": true,
   "type": "module",
+  "description": "An open-source tool combining LLM intelligence + static analysis to produce interactive dashboards for understanding codebases.",
+  "license": "MIT",
+  "homepage": "https://github.com/Lum1104/Understand-Anything#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Lum1104/Understand-Anything.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Lum1104/Understand-Anything/issues"
+  },
+  "keywords": [
+    "claude-code",
+    "codebase-analysis",
+    "knowledge-graph",
+    "tree-sitter",
+    "llm",
+    "static-analysis",
+    "developer-tools",
+    "code-understanding",
+    "code-onboarding",
+    "claude-plugin"
+  ],
   "main": ".opencode/plugins/understand-anything.js",
   "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b",
   "scripts": {


### PR DESCRIPTION
## Summary

Closes a cluster of community-profile gaps in one cohesive PR rather than four micro-PRs all touching the same surface:

- **#251 / #252** Issue + PR templates
- **#249** CI now runs on pushes to `main` (not only PRs) with a concurrency group
- **#248** \`package.json\` gets the description / license / repository / homepage / keywords fields, plus \`CODE_OF_CONDUCT.md\` and \`SECURITY.md\` for a complete GitHub community profile

## What's in here

### Issue & PR templates

- \`bug_report.yml\` requires the four pieces of context most current bug reports lack (plugin version, platform, OS+Node, analyzed-project language + size)
- \`feature_request.yml\` leads with the problem before the proposed solution
- \`question.yml\` keeps the bug queue triagable
- \`config.yml\` disables blank issues, points discussion at Discussions + README
- \`PULL_REQUEST_TEMPLATE.md\` includes the 5-manifest version-bump checklist from \`CLAUDE.md\` so new contributors learn the rule before getting their PR bounced

### Community files

- \`CODE_OF_CONDUCT.md\` — short, project-specific, names the reporting path. Not a verbatim Contributor Covenant, so it stays readable
- \`SECURITY.md\` — describes the project's local-only threat model explicitly (what's in scope vs. out of scope) so reporters don't waste time on out-of-scope writeups; points at GitHub private vulnerability reporting

### CI workflow (#249)

- Now runs on \`push: [main]\` in addition to PRs, so a direct push to main can't silently break green
- Added a \`concurrency\` group keyed on \`github.ref\` (a controlled value, not user input, so no script-injection surface) that cancels stale in-flight runs
- Saves runner minutes and keeps the per-ref status meaningful

### \`package.json\` (#248)

Added \`description\`, \`license\`, \`homepage\`, \`repository\`, \`bugs\`, \`keywords\`. Brings the GitHub community-profile checklist to 100% once the other files land.

## Verification

- \`pnpm lint\` ✅
- \`pnpm test\` — 196/196 ✅
- Issue + PR templates validated locally with \`gh\` (YAML is well-formed)
- CI workflow keeps the existing four jobs (lint, build-core, build-skill, test-core, test-skill) — only triggers + concurrency changed

## Versioning

N/A — repository hygiene only, no shipped behavior change.

---

Closes #248
Closes #249
Closes #251
Closes #252