### PR TITLE
docs(readme): replace broken Discord invite with GitHub Discussions (#287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 <a href="https://discord.gg/pydat66RY">Join the Discord community &rarr;</a></strong>
+  <strong>💬 <a href="https://github.com/Lum1104/Understand-Anything/discussions">Join the discussion on GitHub &rarr;</a></strong>
   <br />
   <em>Ask questions, share what you've built, get help from the community.</em>
 </p>

--- a/READMEs/README.es-ES.md
+++ b/READMEs/README.es-ES.md
@@ -31,7 +31,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 <a href="https://discord.gg/pydat66RY">Únete a la comunidad de Discord &rarr;</a></strong>
+  <strong>💬 <a href="https://github.com/Lum1104/Understand-Anything/discussions">Únete a la discusión en GitHub &rarr;</a></strong>
   <br />
   <em>Pregunta, comparte lo que construyes y recibe ayuda de la comunidad.</em>
 </p>

--- a/READMEs/README.ja-JP.md
+++ b/READMEs/README.ja-JP.md
@@ -32,7 +32,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 <a href="https://discord.gg/pydat66RY">Discord コミュニティに参加 &rarr;</a></strong>
+  <strong>💬 <a href="https://github.com/Lum1104/Understand-Anything/discussions">GitHub のディスカッションに参加 &rarr;</a></strong>
   <br />
   <em>質問・作品の共有・コミュニティとの交流はこちらから。</em>
 </p>

--- a/READMEs/README.ko-KR.md
+++ b/READMEs/README.ko-KR.md
@@ -31,7 +31,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 <a href="https://discord.gg/pydat66RY">Discord 커뮤니티 참여하기 &rarr;</a></strong>
+  <strong>💬 <a href="https://github.com/Lum1104/Understand-Anything/discussions">GitHub 토론 참여하기 &rarr;</a></strong>
   <br />
   <em>질문하고, 만든 것을 공유하고, 커뮤니티의 도움을 받으세요.</em>
 </p>

--- a/READMEs/README.ru-RU.md
+++ b/READMEs/README.ru-RU.md
@@ -32,7 +32,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 <a href="https://discord.gg/pydat66RY">Присоединяйтесь к сообществу в Discord &rarr;</a></strong>
+  <strong>💬 <a href="https://github.com/Lum1104/Understand-Anything/discussions">Присоединяйтесь к обсуждению на GitHub &rarr;</a></strong>
   <br />
   <em>Задавайте вопросы, делитесь тем, что вы построили, получайте помощь от сообщества.</em>
 </p>

--- a/READMEs/README.tr-TR.md
+++ b/READMEs/README.tr-TR.md
@@ -32,7 +32,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 <a href="https://discord.gg/pydat66RY">Discord topluluğuna katıl &rarr;</a></strong>
+  <strong>💬 <a href="https://github.com/Lum1104/Understand-Anything/discussions">GitHub'daki tartışmaya katıl &rarr;</a></strong>
   <br />
   <em>Sorular sor, yaptıklarını paylaş, topluluktan yardım al.</em>
 </p>

--- a/READMEs/README.zh-CN.md
+++ b/READMEs/README.zh-CN.md
@@ -31,7 +31,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 <a href="https://discord.gg/pydat66RY">加入 Discord 社区 &rarr;</a></strong>
+  <strong>💬 <a href="https://github.com/Lum1104/Understand-Anything/discussions">加入 GitHub 讨论 &rarr;</a></strong>
   <br />
   <em>来提问、分享你的项目、和社区一起讨论。</em>
 </p>

--- a/READMEs/README.zh-TW.md
+++ b/READMEs/README.zh-TW.md
@@ -31,7 +31,7 @@
 </p>
 
 <p align="center">
-  <strong>💬 <a href="https://discord.gg/pydat66RY">加入 Discord 社群 &rarr;</a></strong>
+  <strong>💬 <a href="https://github.com/Lum1104/Understand-Anything/discussions">加入 GitHub 討論 &rarr;</a></strong>
   <br />
   <em>來提問、分享你的專案、和社群一起討論。</em>
 </p>


### PR DESCRIPTION
## Summary

Closes #287 — the Discord invite link in every translated README (\`discord.gg/pydat66RY\`) returns *invite invalid*.

Replaced with a link to the project's GitHub Discussions (already enabled, 8 active threads), which is a durable channel that doesn't rot the same way short-lived Discord invites do.

## What's in here

Updated all 8 README variants:
- \`README.md\` (English)
- \`READMEs/README.ru-RU.md\` (Russian)
- \`READMEs/README.ja-JP.md\` (Japanese)
- \`READMEs/README.es-ES.md\` (Spanish)
- \`READMEs/README.zh-TW.md\` (Traditional Chinese)
- \`READMEs/README.zh-CN.md\` (Simplified Chinese)
- \`READMEs/README.tr-TR.md\` (Turkish)
- \`READMEs/README.ko-KR.md\` (Korean)

Translated the call-out text in-place rather than reverting it to English — matches the existing i18n quality of these files.

## If you want Discord back later

The call-out block sits in the same place in every README. To flip back to a Discord invite, replace the \`github.com/.../discussions\` URL and the call-out text in each file. Happy to send that follow-up PR if a new invite is generated.

## Verification

- \`grep -rn pydat66RY\` returns 0 matches across all .md files
- \`grep -rn 'Lum1104/Understand-Anything/discussions'\` in README files returns 8 matches (one per translation)
- No code or build files touched — docs-only

## Versioning

N/A — docs only.

Closes #287