### PR TITLE
feat: add deterministic EPUB book understanding

### DIFF
--- a/tests/skill/understand_book/test_analysis_synthesis.py
+++ b/tests/skill/understand_book/test_analysis_synthesis.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Tests for synthesizing /understand-book LLM analysis results."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent.parent.parent
+_SKILL_DIR = _REPO_ROOT / "understand-anything-plugin" / "skills" / "understand-book"
+_SYNTH_SCRIPT = _SKILL_DIR / "llm-adapters" / "synthesize-analysis-results.py"
+
+
+def _write_analysis_result_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    intermediate_dir = tmp_path / ".understand-anything" / "intermediate"
+    results_dir = intermediate_dir / "analysis-results"
+    results_dir.mkdir(parents=True)
+    result_path = results_dir / "analysis-batch-001.result.json"
+    result_payload = {
+        "version": 1,
+        "kind": "understand-book-analysis-result",
+        "provider": "local-command",
+        "model": "fake-llm",
+        "batch_id": "analysis-batch-001",
+        "source_batch_path": str(intermediate_dir / "analysis-batches" / "analysis-batch-001.json"),
+        "analysis": {
+            "summary": "本章说明人工智能改变阅读方式。",
+            "key_points": ["阅读方式变化", "证据需要回链"],
+            "chunk_insights": [
+                {
+                    "chunk_id": "ch01-c001",
+                    "claim": "人工智能改变阅读方式",
+                    "evidence_anchor": "ch01:0-12",
+                },
+                {
+                    "chunk_id": "ch02-c001",
+                    "claim": "证据必须绑定原文",
+                    "evidence_anchor": "ch02:0-10",
+                },
+            ],
+            "open_questions": ["作者没有说明评估方法。"],
+        },
+    }
+    result_path.write_text(json.dumps(result_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    manifest_path = intermediate_dir / "analysis-results-manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "provider": "local-command",
+                "model": "fake-llm",
+                "results": [
+                    {
+                        "batch_id": "analysis-batch-001",
+                        "path": str(result_path),
+                        "source_batch_path": str(result_payload["source_batch_path"]),
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    graph_path = tmp_path / ".understand-anything" / "knowledge-graph.json"
+    graph_path.parent.mkdir(parents=True, exist_ok=True)
+    graph_path.write_text(
+        json.dumps(
+            {
+                "kind": "knowledge",
+                "nodes": [
+                    {"id": "file:wiki/index.md", "type": "file", "name": "index.md", "filePath": "wiki/index.md"}
+                ],
+                "edges": [],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path, graph_path
+
+
+class AnalysisSynthesisTests(unittest.TestCase):
+    def test_synthesizes_markdown_summary_and_enriched_graph(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            manifest_path, graph_path = _write_analysis_result_fixture(tmp_path)
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(_SYNTH_SCRIPT),
+                    str(manifest_path),
+                    "--graph",
+                    str(graph_path),
+                    "--output-dir",
+                    str(tmp_path),
+                ],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            self.assertIn("[analysis-synthesis] markdown:", result.stdout)
+
+            markdown_path = tmp_path / "book-analysis.md"
+            self.assertTrue(markdown_path.is_file())
+            markdown = markdown_path.read_text(encoding="utf-8")
+            self.assertIn("# LLM 书籍分析", markdown)
+            self.assertIn("本章说明人工智能改变阅读方式。", markdown)
+            self.assertIn("人工智能改变阅读方式", markdown)
+            self.assertIn("`ch01:0-12`", markdown)
+            self.assertIn("作者没有说明评估方法。", markdown)
+
+            synthesis_path = tmp_path / ".understand-anything" / "intermediate" / "analysis-synthesis.json"
+            self.assertTrue(synthesis_path.is_file())
+            synthesis = json.loads(synthesis_path.read_text(encoding="utf-8"))
+            self.assertEqual(synthesis["version"], 1)
+            self.assertEqual(synthesis["result_count"], 1)
+            self.assertEqual(synthesis["claim_count"], 2)
+            self.assertEqual(synthesis["claims"][0]["chunk_id"], "ch01-c001")
+
+            enriched_graph_path = tmp_path / ".understand-anything" / "knowledge-graph.enriched.json"
+            self.assertTrue(enriched_graph_path.is_file())
+            graph = json.loads(enriched_graph_path.read_text(encoding="utf-8"))
+            node_ids = {node["id"] for node in graph["nodes"]}
+            self.assertIn("book-chunk:ch01-c001", node_ids)
+            self.assertIn("book-claim:ch01-c001:001", node_ids)
+            self.assertTrue(
+                any(
+                    edge["source"] == "book-chunk:ch01-c001"
+                    and edge["target"] == "book-claim:ch01-c001:001"
+                    and edge["type"] == "supports"
+                    for edge in graph["edges"]
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/skill/understand_book/test_epub_to_wiki.py
+++ b/tests/skill/understand_book/test_epub_to_wiki.py
@@ -151,6 +151,14 @@ class EpubToWikiTests(unittest.TestCase):
             wiki_graph_path = out_dir / "wiki" / ".understand-anything" / "knowledge-graph.json"
             self.assertTrue(wiki_graph_path.is_file())
 
+            report_path = out_dir / "book-report.md"
+            self.assertTrue(report_path.is_file())
+            report = report_path.read_text(encoding="utf-8")
+            self.assertIn("# 《Tiny Test Book》理解报告", report)
+            self.assertIn("## 章节导读", report)
+            self.assertIn("第一章 开端", report)
+            self.assertIn("第二章 回声", report)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/skill/understand_book/test_epub_to_wiki.py
+++ b/tests/skill/understand_book/test_epub_to_wiki.py
@@ -18,13 +18,9 @@ from pathlib import Path
 
 _HERE = Path(__file__).resolve().parent
 _REPO_ROOT = _HERE.parent.parent.parent
-_SCRIPT = (
-    _REPO_ROOT
-    / "understand-anything-plugin"
-    / "skills"
-    / "understand-book"
-    / "epub-to-wiki.py"
-)
+_SKILL_DIR = _REPO_ROOT / "understand-anything-plugin" / "skills" / "understand-book"
+_SCRIPT = _SKILL_DIR / "epub-to-wiki.py"
+_PIPELINE_SCRIPT = _SKILL_DIR / "run-understand-book.py"
 
 
 def _write_tiny_epub(path: Path) -> None:
@@ -120,6 +116,40 @@ class EpubToWikiTests(unittest.TestCase):
 
             raw_copy = out_dir / "raw" / "tiny.epub"
             self.assertTrue(raw_copy.is_file())
+
+    def test_pipeline_writes_root_knowledge_graph_and_meta(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            epub_path = tmp_path / "tiny.epub"
+            out_dir = tmp_path / "book-output"
+            _write_tiny_epub(epub_path)
+
+            result = subprocess.run(
+                ["python3", str(_PIPELINE_SCRIPT), str(epub_path), "--output", str(out_dir), "--language", "zh"],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+
+            root_graph_path = out_dir / ".understand-anything" / "knowledge-graph.json"
+            self.assertTrue(root_graph_path.is_file())
+            graph = json.loads(root_graph_path.read_text(encoding="utf-8"))
+            self.assertEqual(graph["kind"], "knowledge")
+            self.assertGreaterEqual(len(graph["nodes"]), 4)
+            self.assertGreaterEqual(len(graph["edges"]), 2)
+
+            meta_path = out_dir / ".understand-anything" / "meta.json"
+            self.assertTrue(meta_path.is_file())
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            self.assertEqual(meta["sourceType"], "epub")
+            self.assertEqual(meta["analyzedFiles"], 2)
+            self.assertIn("book", meta)
+
+            wiki_graph_path = out_dir / "wiki" / ".understand-anything" / "knowledge-graph.json"
+            self.assertTrue(wiki_graph_path.is_file())
 
 
 if __name__ == "__main__":

--- a/tests/skill/understand_book/test_epub_to_wiki.py
+++ b/tests/skill/understand_book/test_epub_to_wiki.py
@@ -261,6 +261,120 @@ class EpubToWikiTests(unittest.TestCase):
             self.assertNotIn("provider", first_batch)
             self.assertNotIn("model", first_batch)
 
+    def test_pipeline_rebuilds_invalid_chunk_cache(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            epub_path = tmp_path / "tiny.epub"
+            out_dir = tmp_path / "book-output"
+            _write_tiny_epub(epub_path)
+
+            first = subprocess.run(
+                [
+                    "python3",
+                    str(_PIPELINE_SCRIPT),
+                    str(epub_path),
+                    "--output",
+                    str(out_dir),
+                    "--language",
+                    "zh",
+                    "--chunk-size",
+                    "14",
+                ],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(first.returncode, 0, first.stderr + first.stdout)
+
+            chunk_manifest_path = out_dir / ".understand-anything" / "intermediate" / "chunks-manifest.json"
+            chunk_manifest_path.write_text("{broken json", encoding="utf-8")
+
+            second = subprocess.run(
+                [
+                    "python3",
+                    str(_PIPELINE_SCRIPT),
+                    str(epub_path),
+                    "--output",
+                    str(out_dir),
+                    "--language",
+                    "zh",
+                    "--chunk-size",
+                    "14",
+                ],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(second.returncode, 0, second.stderr + second.stdout)
+            self.assertIn("[cache] chunks invalid; rebuilding", second.stdout)
+            rebuilt = json.loads(chunk_manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(rebuilt["version"], 1)
+            self.assertEqual(rebuilt["chunk_size"], 14)
+            self.assertEqual(rebuilt["source_hash"], json.loads((out_dir / ".understand-anything" / "intermediate" / "book-manifest.json").read_text(encoding="utf-8"))["source"]["hash"])
+
+    def test_pipeline_rebuilds_invalid_analysis_batch_cache(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            epub_path = tmp_path / "tiny.epub"
+            out_dir = tmp_path / "book-output"
+            _write_tiny_epub(epub_path)
+
+            first = subprocess.run(
+                [
+                    "python3",
+                    str(_PIPELINE_SCRIPT),
+                    str(epub_path),
+                    "--output",
+                    str(out_dir),
+                    "--language",
+                    "zh",
+                    "--chunk-size",
+                    "14",
+                    "--batch-size",
+                    "2",
+                ],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(first.returncode, 0, first.stderr + first.stdout)
+
+            batch_manifest_path = out_dir / ".understand-anything" / "intermediate" / "analysis-batches-manifest.json"
+            batch_manifest_path.write_text('{"version": 1, "batch_size": 2, "batches": []}', encoding="utf-8")
+
+            second = subprocess.run(
+                [
+                    "python3",
+                    str(_PIPELINE_SCRIPT),
+                    str(epub_path),
+                    "--output",
+                    str(out_dir),
+                    "--language",
+                    "zh",
+                    "--chunk-size",
+                    "14",
+                    "--batch-size",
+                    "2",
+                ],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(second.returncode, 0, second.stderr + second.stdout)
+            self.assertIn("[cache] chunks valid; reusing", second.stdout)
+            self.assertIn("[cache] analysis batches invalid; rebuilding", second.stdout)
+            rebuilt = json.loads(batch_manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(rebuilt["version"], 1)
+            self.assertEqual(rebuilt["batch_size"], 2)
+            self.assertGreaterEqual(len(rebuilt["batches"]), 2)
+            self.assertEqual(rebuilt["chunk_ids"][0], "ch01-c001")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/skill/understand_book/test_epub_to_wiki.py
+++ b/tests/skill/understand_book/test_epub_to_wiki.py
@@ -74,6 +74,41 @@ def _write_tiny_epub(path: Path) -> None:
         zf.writestr("OEBPS/images/cover.png", b"\x89PNG\r\n\x1a\n")
 
 
+def _write_single_chapter_epub(path: Path) -> None:
+    """Create a tiny valid EPUB 3 archive with one spine chapter."""
+    container_xml = """<?xml version='1.0' encoding='utf-8'?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+"""
+    opf = """<?xml version='1.0' encoding='utf-8'?>
+<package version="3.0" unique-identifier="bookid" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="bookid">urn:uuid:single-book</dc:identifier>
+    <dc:title>Single Test Book</dc:title>
+    <dc:creator>Draco</dc:creator>
+    <dc:language>zh</dc:language>
+  </metadata>
+  <manifest>
+    <item id="ch1" href="chapters/ch1.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="ch1"/>
+  </spine>
+</package>
+"""
+    ch1 = """<!doctype html><html xmlns="http://www.w3.org/1999/xhtml"><head><title>唯一章节</title></head><body>
+<h1>唯一章节</h1><p>第二次运行应该清理旧章节。</p>
+</body></html>"""
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED)
+        zf.writestr("META-INF/container.xml", container_xml)
+        zf.writestr("OEBPS/content.opf", opf)
+        zf.writestr("OEBPS/chapters/ch1.xhtml", ch1)
+
+
 class EpubToWikiTests(unittest.TestCase):
     def test_epub_to_wiki_writes_manifest_chapters_and_index(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -374,6 +409,61 @@ class EpubToWikiTests(unittest.TestCase):
             self.assertEqual(rebuilt["batch_size"], 2)
             self.assertGreaterEqual(len(rebuilt["batches"]), 2)
             self.assertEqual(rebuilt["chunk_ids"][0], "ch01-c001")
+
+    def test_pipeline_rerun_cleans_stale_generated_chapters(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            first_epub = tmp_path / "tiny.epub"
+            second_epub = tmp_path / "single.epub"
+            out_dir = tmp_path / "book-output"
+            _write_tiny_epub(first_epub)
+            _write_single_chapter_epub(second_epub)
+
+            first = subprocess.run(
+                ["python3", str(_PIPELINE_SCRIPT), str(first_epub), "--output", str(out_dir), "--language", "zh"],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(first.returncode, 0, first.stderr + first.stdout)
+            self.assertTrue((out_dir / "wiki" / "chapters" / "ch02.md").is_file())
+
+            second = subprocess.run(
+                ["python3", str(_PIPELINE_SCRIPT), str(second_epub), "--output", str(out_dir), "--language", "zh"],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(second.returncode, 0, second.stderr + second.stdout)
+            self.assertFalse((out_dir / "wiki" / "chapters" / "ch02.md").exists())
+            manifest = json.loads((out_dir / ".understand-anything" / "intermediate" / "book-manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual([chapter["id"] for chapter in manifest["chapters"]], ["ch01"])
+            graph = json.loads((out_dir / ".understand-anything" / "knowledge-graph.json").read_text(encoding="utf-8"))
+            graph_text = json.dumps(graph, ensure_ascii=False)
+            self.assertNotIn("ch02", graph_text)
+            self.assertNotIn("第二章 回声", graph_text)
+
+    def test_epub_to_wiki_reports_invalid_zip_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            epub_path = tmp_path / "broken.epub"
+            out_dir = tmp_path / "book-output"
+            epub_path.write_text("not a real epub", encoding="utf-8")
+
+            result = subprocess.run(
+                ["python3", str(_SCRIPT), str(epub_path), "--output", str(out_dir), "--language", "zh"],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            combined = result.stderr + result.stdout
+            self.assertIn("ERR_EPUB_INVALID", combined)
+            self.assertNotIn("Traceback", combined)
 
 
 if __name__ == "__main__":

--- a/tests/skill/understand_book/test_epub_to_wiki.py
+++ b/tests/skill/understand_book/test_epub_to_wiki.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Tests for /understand-book deterministic EPUB ingestion.
+
+Run from repo root:
+    python -m unittest tests.skill.understand_book.test_epub_to_wiki -v
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent.parent.parent
+_SCRIPT = (
+    _REPO_ROOT
+    / "understand-anything-plugin"
+    / "skills"
+    / "understand-book"
+    / "epub-to-wiki.py"
+)
+
+
+def _write_tiny_epub(path: Path) -> None:
+    """Create a tiny valid EPUB 3 archive with two spine chapters."""
+    container_xml = """<?xml version='1.0' encoding='utf-8'?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+"""
+    opf = """<?xml version='1.0' encoding='utf-8'?>
+<package version="3.0" unique-identifier="bookid" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="bookid">urn:uuid:tiny-book</dc:identifier>
+    <dc:title>Tiny Test Book</dc:title>
+    <dc:creator>Draco</dc:creator>
+    <dc:language>zh</dc:language>
+    <dc:publisher>Hermes Press</dc:publisher>
+  </metadata>
+  <manifest>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    <item id="ch1" href="chapters/ch1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="ch2" href="chapters/ch2.xhtml" media-type="application/xhtml+xml"/>
+    <item id="cover" href="images/cover.png" media-type="image/png"/>
+  </manifest>
+  <spine>
+    <itemref idref="ch1"/>
+    <itemref idref="ch2"/>
+  </spine>
+</package>
+"""
+    nav = """<!doctype html><html xmlns="http://www.w3.org/1999/xhtml"><body><nav epub:type="toc"><ol>
+<li><a href="chapters/ch1.xhtml">第一章 开端</a></li>
+<li><a href="chapters/ch2.xhtml">第二章 回声</a></li>
+</ol></nav></body></html>"""
+    ch1 = """<!doctype html><html xmlns="http://www.w3.org/1999/xhtml"><head><title>第一章 开端</title></head><body>
+<h1>第一章 开端</h1><p>人工智能改变阅读方式。</p><p>知识图谱把概念连接起来。</p>
+</body></html>"""
+    ch2 = """<!doctype html><html xmlns="http://www.w3.org/1999/xhtml"><head><title>第二章 回声</title></head><body>
+<h1>第二章 回声</h1><p>人工智能再次出现。</p><p>证据必须绑定原文。</p>
+</body></html>"""
+
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED)
+        zf.writestr("META-INF/container.xml", container_xml)
+        zf.writestr("OEBPS/content.opf", opf)
+        zf.writestr("OEBPS/nav.xhtml", nav)
+        zf.writestr("OEBPS/chapters/ch1.xhtml", ch1)
+        zf.writestr("OEBPS/chapters/ch2.xhtml", ch2)
+        zf.writestr("OEBPS/images/cover.png", b"\x89PNG\r\n\x1a\n")
+
+
+class EpubToWikiTests(unittest.TestCase):
+    def test_epub_to_wiki_writes_manifest_chapters_and_index(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            epub_path = tmp_path / "tiny.epub"
+            out_dir = tmp_path / "book-output"
+            _write_tiny_epub(epub_path)
+
+            result = subprocess.run(
+                ["python3", str(_SCRIPT), str(epub_path), "--output", str(out_dir), "--language", "zh"],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+
+            manifest_path = out_dir / ".understand-anything" / "intermediate" / "book-manifest.json"
+            self.assertTrue(manifest_path.is_file())
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(manifest["book"]["title"], "Tiny Test Book")
+            self.assertEqual(manifest["book"]["authors"], ["Draco"])
+            self.assertEqual(manifest["book"]["language"], "zh")
+            self.assertEqual([c["id"] for c in manifest["chapters"]], ["ch01", "ch02"])
+            self.assertEqual(manifest["chapters"][0]["title"], "第一章 开端")
+            self.assertGreater(manifest["chapters"][0]["char_count"], 0)
+            self.assertEqual(len(manifest["assets"]), 1)
+
+            index = (out_dir / "wiki" / "index.md").read_text(encoding="utf-8")
+            self.assertIn("# Tiny Test Book", index)
+            self.assertIn("[[chapters/ch01|第一章 开端]]", index)
+            self.assertIn("[[chapters/ch02|第二章 回声]]", index)
+
+            ch01 = (out_dir / "wiki" / "chapters" / "ch01.md").read_text(encoding="utf-8")
+            self.assertIn("# 第一章 开端", ch01)
+            self.assertIn("人工智能改变阅读方式。", ch01)
+            self.assertIn("## Source", ch01)
+
+            raw_copy = out_dir / "raw" / "tiny.epub"
+            self.assertTrue(raw_copy.is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/skill/understand_book/test_epub_to_wiki.py
+++ b/tests/skill/understand_book/test_epub_to_wiki.py
@@ -159,6 +159,108 @@ class EpubToWikiTests(unittest.TestCase):
             self.assertIn("第一章 开端", report)
             self.assertIn("第二章 回声", report)
 
+    def test_pipeline_writes_stable_chapter_chunks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            epub_path = tmp_path / "tiny.epub"
+            out_dir = tmp_path / "book-output"
+            _write_tiny_epub(epub_path)
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(_PIPELINE_SCRIPT),
+                    str(epub_path),
+                    "--output",
+                    str(out_dir),
+                    "--language",
+                    "zh",
+                    "--chunk-size",
+                    "14",
+                ],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+
+            chunk_manifest_path = out_dir / ".understand-anything" / "intermediate" / "chunks-manifest.json"
+            self.assertTrue(chunk_manifest_path.is_file())
+            chunk_manifest = json.loads(chunk_manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(chunk_manifest["version"], 1)
+            self.assertEqual(chunk_manifest["chunk_size"], 14)
+            self.assertEqual(chunk_manifest["book"]["title"], "Tiny Test Book")
+            self.assertGreaterEqual(len(chunk_manifest["chunks"]), 4)
+
+            first = chunk_manifest["chunks"][0]
+            self.assertEqual(first["id"], "ch01-c001")
+            self.assertEqual(first["chapter_id"], "ch01")
+            self.assertEqual(first["chapter_title"], "第一章 开端")
+            self.assertEqual(first["order"], 1)
+            self.assertEqual(first["char_start"], 0)
+            self.assertGreater(first["char_end"], first["char_start"])
+            self.assertIn("evidence_anchor", first)
+
+            first_chunk = Path(first["path"])
+            self.assertTrue(first_chunk.is_file())
+            chunk_text = first_chunk.read_text(encoding="utf-8")
+            self.assertIn("# Chunk ch01-c001", chunk_text)
+            self.assertIn("Book: Tiny Test Book", chunk_text)
+            self.assertIn("Chapter: 第一章 开端", chunk_text)
+            self.assertIn("## Evidence", chunk_text)
+
+    def test_pipeline_writes_analysis_batches_without_llm_calls(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            epub_path = tmp_path / "tiny.epub"
+            out_dir = tmp_path / "book-output"
+            _write_tiny_epub(epub_path)
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(_PIPELINE_SCRIPT),
+                    str(epub_path),
+                    "--output",
+                    str(out_dir),
+                    "--language",
+                    "zh",
+                    "--chunk-size",
+                    "14",
+                    "--batch-size",
+                    "2",
+                ],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+
+            batches_dir = out_dir / ".understand-anything" / "intermediate" / "analysis-batches"
+            batch_manifest_path = out_dir / ".understand-anything" / "intermediate" / "analysis-batches-manifest.json"
+            self.assertTrue(batch_manifest_path.is_file())
+            batch_manifest = json.loads(batch_manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(batch_manifest["version"], 1)
+            self.assertEqual(batch_manifest["batch_size"], 2)
+            self.assertGreaterEqual(len(batch_manifest["batches"]), 2)
+
+            first_batch_path = batches_dir / "analysis-batch-001.json"
+            self.assertTrue(first_batch_path.is_file())
+            first_batch = json.loads(first_batch_path.read_text(encoding="utf-8"))
+            self.assertEqual(first_batch["kind"], "understand-book-analysis-batch")
+            self.assertEqual(first_batch["task"], "chapter_analysis")
+            self.assertEqual(first_batch["language"], "zh")
+            self.assertEqual(first_batch["book"]["title"], "Tiny Test Book")
+            self.assertEqual(len(first_batch["chunks"]), 2)
+            self.assertEqual(first_batch["chunks"][0]["id"], "ch01-c001")
+            self.assertIn("evidence", first_batch["chunks"][0])
+            self.assertNotIn("provider", first_batch)
+            self.assertNotIn("model", first_batch)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/skill/understand_book/test_llm_adapters.py
+++ b/tests/skill/understand_book/test_llm_adapters.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Tests for /understand-book LLM analysis adapters."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent.parent.parent
+_SKILL_DIR = _REPO_ROOT / "understand-anything-plugin" / "skills" / "understand-book"
+_ADAPTER_SCRIPT = _SKILL_DIR / "llm-adapters" / "run-analysis-batches.py"
+
+
+def _write_batch_fixture(tmp_path: Path) -> Path:
+    batches_dir = tmp_path / "analysis-batches"
+    batches_dir.mkdir(parents=True)
+    batch_path = batches_dir / "analysis-batch-001.json"
+    batch = {
+        "version": 1,
+        "kind": "understand-book-analysis-batch",
+        "task": "chapter_analysis",
+        "language": "zh",
+        "book": {"title": "Tiny Test Book"},
+        "instructions": ["只基于 evidence 输出 JSON。"],
+        "chunks": [
+            {
+                "id": "ch01-c001",
+                "order": 1,
+                "chapter_id": "ch01",
+                "chapter_title": "第一章 开端",
+                "evidence_anchor": "ch01:0-8",
+                "evidence": "人工智能改变阅读方式。",
+            }
+        ],
+    }
+    batch_path.write_text(json.dumps(batch, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    manifest_path = tmp_path / "analysis-batches-manifest.json"
+    manifest = {
+        "version": 1,
+        "batch_size": 1,
+        "source_hash": "abc123",
+        "chunk_ids": ["ch01-c001"],
+        "book": {"title": "Tiny Test Book"},
+        "batches": [
+            {
+                "id": "analysis-batch-001",
+                "path": str(batch_path),
+                "chunk_count": 1,
+                "chunk_ids": ["ch01-c001"],
+            }
+        ],
+    }
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return manifest_path
+
+
+class UnderstandBookLLMAdapterTests(unittest.TestCase):
+    def test_local_command_adapter_writes_analysis_results(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            manifest_path = _write_batch_fixture(tmp_path)
+            fake_llm = tmp_path / "fake_llm.py"
+            fake_llm.write_text(
+                """
+import json
+import sys
+batch = json.load(sys.stdin)
+print(json.dumps({
+    "summary": "本批次说明人工智能改变阅读。",
+    "chunk_insights": [
+        {"chunk_id": chunk["id"], "claim": "阅读方式变化", "evidence_anchor": chunk["evidence_anchor"]}
+        for chunk in batch["chunks"]
+    ]
+}, ensure_ascii=False))
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(_ADAPTER_SCRIPT),
+                    str(manifest_path),
+                    "--provider",
+                    "local-command",
+                    "--command",
+                    f"{sys.executable} {fake_llm}",
+                    "--model",
+                    "fake-llm",
+                ],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            self.assertIn("[llm-adapter] result:", result.stdout)
+            result_path = tmp_path / "analysis-results" / "analysis-batch-001.result.json"
+            self.assertTrue(result_path.is_file())
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["version"], 1)
+            self.assertEqual(payload["kind"], "understand-book-analysis-result")
+            self.assertEqual(payload["provider"], "local-command")
+            self.assertEqual(payload["model"], "fake-llm")
+            self.assertEqual(payload["batch_id"], "analysis-batch-001")
+            self.assertEqual(payload["analysis"]["summary"], "本批次说明人工智能改变阅读。")
+            self.assertEqual(payload["analysis"]["chunk_insights"][0]["chunk_id"], "ch01-c001")
+
+            results_manifest = tmp_path / "analysis-results-manifest.json"
+            self.assertTrue(results_manifest.is_file())
+            manifest = json.loads(results_manifest.read_text(encoding="utf-8"))
+            self.assertEqual(manifest["provider"], "local-command")
+            self.assertEqual(manifest["model"], "fake-llm")
+            self.assertEqual(manifest["results"][0]["batch_id"], "analysis-batch-001")
+
+    def test_deepseek_adapter_requires_api_key_without_network_call(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            manifest_path = _write_batch_fixture(tmp_path)
+            env = {"PATH": os.environ.get("PATH", ""), "PYTHONPATH": os.environ.get("PYTHONPATH", "")}
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(_ADAPTER_SCRIPT),
+                    str(manifest_path),
+                    "--provider",
+                    "deepseek",
+                    "--model",
+                    "deepseek-v4-flash",
+                ],
+                cwd=_REPO_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("ERR_DEEPSEEK_API_KEY_MISSING", result.stderr + result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/skill/understand_book/test_llm_adapters.py
+++ b/tests/skill/understand_book/test_llm_adapters.py
@@ -147,6 +147,38 @@ print(json.dumps({
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("ERR_DEEPSEEK_API_KEY_MISSING", result.stderr + result.stdout)
 
+    def test_adapter_rejects_unsafe_batch_ids(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            manifest_path = _write_batch_fixture(tmp_path)
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["batches"][0]["id"] = "../pwned"
+            manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+            fake_llm = tmp_path / "fake_llm.py"
+            fake_llm.write_text("import json; print(json.dumps({'summary': 'ok'}))\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(_ADAPTER_SCRIPT),
+                    str(manifest_path),
+                    "--provider",
+                    "local-command",
+                    "--command",
+                    f"{sys.executable} {fake_llm}",
+                    "--model",
+                    "fake-llm",
+                ],
+                cwd=_REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("ERR_BATCH_ID_INVALID", result.stderr + result.stdout)
+            self.assertFalse((tmp_path / "pwned.result.json").exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/understand-anything-plugin/skills/understand-book/SKILL.md
+++ b/understand-anything-plugin/skills/understand-book/SKILL.md
@@ -143,4 +143,6 @@ Run:
 - The deterministic path uses Python stdlib only: zip, XML, HTML parsing, JSON, subprocess.
 - This pipeline produces a structural book graph plus deterministic LLM-ready `analysis-batches/*.json`. It still does not call an LLM.
 - Evidence comes from generated chapter text in EPUB spine order, then from stable chunk files with `evidence_anchor`.
+- Re-running into the same output directory clears generated chapter/html/asset/wiki graph files before rebuilding, so stale EPUB chapters cannot leak into the graph.
 - Chunk and analysis-batch cache files are parsed and schema-validated before reuse; invalid cache is rebuilt instead of trusted blindly.
+- `local-command` executes the command you provide. Use it only with trusted local commands and sanitized manifests.

--- a/understand-anything-plugin/skills/understand-book/SKILL.md
+++ b/understand-anything-plugin/skills/understand-book/SKILL.md
@@ -90,6 +90,23 @@ output: <OUTPUT_DIR>/.understand-anything/intermediate/analysis-results/analysis
         <OUTPUT_DIR>/.understand-anything/intermediate/analysis-results-manifest.json
 ```
 
+Then synthesize analysis results into a human report and graph overlay:
+
+```bash
+python3 <SKILL_DIR>/llm-adapters/synthesize-analysis-results.py \
+  <OUTPUT_DIR>/.understand-anything/intermediate/analysis-results-manifest.json \
+  --graph <OUTPUT_DIR>/.understand-anything/knowledge-graph.json \
+  --output-dir <OUTPUT_DIR>
+```
+
+Synthesis outputs:
+
+```text
+<OUTPUT_DIR>/book-analysis.md
+<OUTPUT_DIR>/.understand-anything/intermediate/analysis-synthesis.json
+<OUTPUT_DIR>/.understand-anything/knowledge-graph.enriched.json
+```
+
 Do not write API keys into repo files. Use environment variables only.
 
 ### Phase 4: Verify output

--- a/understand-anything-plugin/skills/understand-book/SKILL.md
+++ b/understand-anything-plugin/skills/understand-book/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand-book
-description: Convert an EPUB book into a chapter-aware wiki scaffold, LLM-ready analysis batches, and root knowledge graph for the dashboard.
-argument-hint: [book.epub] [--language <lang>] [--output <dir>] [--chunk-size <chars>] [--batch-size <chunks>]
+description: Convert an EPUB book into a chapter-aware wiki scaffold, LLM-ready analysis batches, optional LLM analysis results, and root knowledge graph for the dashboard.
+argument-hint: [book.epub] [--language <lang>] [--output <dir>] [--chunk-size <chars>] [--batch-size <chunks>] [--llm-provider deepseek|local-command]
 ---
 
 # /understand-book
@@ -59,7 +59,40 @@ Expected progress output:
 Done.
 ```
 
-### Phase 3: Verify output
+### Phase 3: Optional LLM batch analysis
+
+The deterministic pipeline stops after writing `analysis-batches/*.json`. To run LLM analysis, use the adapter runner.
+
+DeepSeek example:
+
+```bash
+DEEPSEEK_API_KEY="$DEEPSEEK_API_KEY" python3 <SKILL_DIR>/llm-adapters/run-analysis-batches.py \
+  <OUTPUT_DIR>/.understand-anything/intermediate/analysis-batches-manifest.json \
+  --provider deepseek \
+  --model deepseek-v4-flash
+```
+
+Local command example for tests or private models:
+
+```bash
+python3 <SKILL_DIR>/llm-adapters/run-analysis-batches.py \
+  <OUTPUT_DIR>/.understand-anything/intermediate/analysis-batches-manifest.json \
+  --provider local-command \
+  --command "python3 my-batch-analyzer.py" \
+  --model local-json-analyzer
+```
+
+Adapter contract:
+
+```text
+input:  analysis-batch-XXX.json on stdin for local-command, or DeepSeek chat completion payload
+output: <OUTPUT_DIR>/.understand-anything/intermediate/analysis-results/analysis-batch-XXX.result.json
+        <OUTPUT_DIR>/.understand-anything/intermediate/analysis-results-manifest.json
+```
+
+Do not write API keys into repo files. Use environment variables only.
+
+### Phase 4: Verify output
 
 Check these files exist:
 
@@ -79,7 +112,7 @@ Check these files exist:
 
 If validation fails, report the exact `ERR_*` message from the script and stop.
 
-### Phase 4: Open dashboard
+### Phase 5: Open dashboard
 
 Run:
 

--- a/understand-anything-plugin/skills/understand-book/SKILL.md
+++ b/understand-anything-plugin/skills/understand-book/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: understand-book
-description: Convert an EPUB book into a chapter-aware wiki scaffold, then reuse /understand-knowledge and /understand-dashboard to generate an interactive book knowledge graph.
+description: Convert an EPUB book into a chapter-aware wiki scaffold and root knowledge graph for the dashboard.
 argument-hint: [book.epub] [--language <lang>] [--output <dir>]
 ---
 
 # /understand-book
 
-Analyze an EPUB book by first converting it into a deterministic Karpathy-style wiki scaffold.
+Analyze an EPUB book by converting it into a deterministic Karpathy-style wiki, reusing the existing knowledge graph parser/merger, and saving a dashboard-ready graph.
 
 ## Instructions
 
@@ -20,51 +20,56 @@ Analyze an EPUB book by first converting it into a deterministic Karpathy-style 
 3. Resolve relative paths against the current working directory.
 4. Verify the input exists and ends with `.epub`.
 
-### Phase 2: Convert EPUB to wiki scaffold
+### Phase 2: Run deterministic book pipeline
 
-Run the bundled deterministic converter:
-
-```bash
-python3 <SKILL_DIR>/epub-to-wiki.py <EPUB_PATH> --output <OUTPUT_DIR> --language <LANGUAGE>
-```
-
-This writes:
-
-```text
-<OUTPUT_DIR>/
-  raw/<book.epub>
-  wiki/index.md
-  wiki/chapters/ch01.md
-  wiki/chapters/ch02.md
-  .understand-anything/intermediate/book-manifest.json
-```
-
-Report:
-
-```text
-[understand-book] Manifest ready: N chapters, M assets
-```
-
-### Phase 3: Generate the knowledge graph
-
-Run `/understand-knowledge <OUTPUT_DIR>/wiki`.
-
-That command produces:
-
-```text
-<OUTPUT_DIR>/wiki/.understand-anything/knowledge-graph.json
-```
-
-### Phase 4: Save book-level outputs
-
-Copy the knowledge graph to the book output root for dashboard convenience:
+Run the bundled pipeline script:
 
 ```bash
-mkdir -p <OUTPUT_DIR>/.understand-anything
-cp <OUTPUT_DIR>/wiki/.understand-anything/knowledge-graph.json <OUTPUT_DIR>/.understand-anything/knowledge-graph.json
+python3 <SKILL_DIR>/run-understand-book.py <EPUB_PATH> --output <OUTPUT_DIR> --language <LANGUAGE>
 ```
 
-Then run:
+It performs:
+
+```text
+EPUB
+  → wiki scaffold
+  → understand-knowledge parse
+  → understand-knowledge merge
+  → <OUTPUT_DIR>/.understand-anything/knowledge-graph.json
+  → <OUTPUT_DIR>/.understand-anything/meta.json
+```
+
+Expected progress output:
+
+```text
+[understand-book] input: ...
+[understand-book] output: ...
+[1/4] Convert EPUB to wiki scaffold...
+[1/4] Manifest ready: N chapters, M assets
+[2/4] Parse wiki scaffold...
+[3/4] Merge knowledge graph...
+[4/4] Save root graph and metadata...
+Done.
+```
+
+### Phase 3: Verify output
+
+Check these files exist:
+
+```text
+<OUTPUT_DIR>/raw/<book.epub>
+<OUTPUT_DIR>/wiki/index.md
+<OUTPUT_DIR>/wiki/chapters/ch01.md
+<OUTPUT_DIR>/.understand-anything/intermediate/book-manifest.json
+<OUTPUT_DIR>/.understand-anything/knowledge-graph.json
+<OUTPUT_DIR>/.understand-anything/meta.json
+```
+
+If validation fails, report the exact `ERR_*` message from the script and stop.
+
+### Phase 4: Open dashboard
+
+Run:
 
 ```text
 /understand-dashboard <OUTPUT_DIR>
@@ -72,7 +77,7 @@ Then run:
 
 ## Notes
 
-- This first version is EPUB-only. Do not accept PDF/DOCX/OCR yet.
-- The converter is deterministic and uses Python stdlib only: zip, XML, and HTML parsing.
-- LLM analysis happens after conversion, through the existing `/understand-knowledge` path.
-- Evidence comes from chapter markdown pages generated from EPUB spine order.
+- EPUB only. Do not accept PDF/DOCX/OCR yet.
+- The deterministic path uses Python stdlib only: zip, XML, HTML parsing, JSON, subprocess.
+- This first pipeline produces a structural book graph from chapters/categories. Rich LLM chapter analysis can be layered in later via `analysis-batch-*.json` or a dedicated analyzer.
+- Evidence comes from generated chapter markdown pages in EPUB spine order.

--- a/understand-anything-plugin/skills/understand-book/SKILL.md
+++ b/understand-anything-plugin/skills/understand-book/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand-book
-description: Convert an EPUB book into a chapter-aware wiki scaffold and root knowledge graph for the dashboard.
-argument-hint: [book.epub] [--language <lang>] [--output <dir>]
+description: Convert an EPUB book into a chapter-aware wiki scaffold, LLM-ready analysis batches, and root knowledge graph for the dashboard.
+argument-hint: [book.epub] [--language <lang>] [--output <dir>] [--chunk-size <chars>] [--batch-size <chunks>]
 ---
 
 # /understand-book
@@ -16,6 +16,8 @@ Analyze an EPUB book by converting it into a deterministic Karpathy-style wiki, 
    - First non-flag token: EPUB input path.
    - `--language <lang>`: optional output language, defaults to EPUB metadata or `unknown`.
    - `--output <dir>`: optional output directory, defaults to `.understand-book`.
+   - `--chunk-size <chars>`: optional max characters per deterministic chunk, defaults to `6000`.
+   - `--batch-size <chunks>`: optional max chunks per analysis batch, defaults to `8`.
 2. If no EPUB path is provided, ask the user for one.
 3. Resolve relative paths against the current working directory.
 4. Verify the input exists and ends with `.epub`.
@@ -25,7 +27,7 @@ Analyze an EPUB book by converting it into a deterministic Karpathy-style wiki, 
 Run the bundled pipeline script:
 
 ```bash
-python3 <SKILL_DIR>/run-understand-book.py <EPUB_PATH> --output <OUTPUT_DIR> --language <LANGUAGE>
+python3 <SKILL_DIR>/run-understand-book.py <EPUB_PATH> --output <OUTPUT_DIR> --language <LANGUAGE> --chunk-size 6000 --batch-size 8
 ```
 
 It performs:
@@ -33,6 +35,8 @@ It performs:
 ```text
 EPUB
   → wiki scaffold
+  → deterministic chunks
+  → LLM-ready analysis-batch JSON files
   → understand-knowledge parse
   → understand-knowledge merge
   → <OUTPUT_DIR>/.understand-anything/knowledge-graph.json
@@ -45,11 +49,13 @@ Expected progress output:
 ```text
 [understand-book] input: ...
 [understand-book] output: ...
-[1/4] Convert EPUB to wiki scaffold...
-[1/4] Manifest ready: N chapters, M assets
-[2/4] Parse wiki scaffold...
-[3/4] Merge knowledge graph...
-[4/4] Save root graph and metadata...
+[1/6] Convert EPUB to wiki scaffold...
+[1/6] Manifest ready: N chapters, M assets
+[2/6] Write deterministic chapter chunks...
+[3/6] Write LLM-ready analysis batches...
+[4/6] Parse wiki scaffold...
+[5/6] Merge knowledge graph...
+[6/6] Save root graph and metadata...
 Done.
 ```
 
@@ -62,6 +68,10 @@ Check these files exist:
 <OUTPUT_DIR>/wiki/index.md
 <OUTPUT_DIR>/wiki/chapters/ch01.md
 <OUTPUT_DIR>/.understand-anything/intermediate/book-manifest.json
+<OUTPUT_DIR>/.understand-anything/intermediate/chunks-manifest.json
+<OUTPUT_DIR>/.understand-anything/intermediate/chunks/ch01-c001.md
+<OUTPUT_DIR>/.understand-anything/intermediate/analysis-batches-manifest.json
+<OUTPUT_DIR>/.understand-anything/intermediate/analysis-batches/analysis-batch-001.json
 <OUTPUT_DIR>/.understand-anything/knowledge-graph.json
 <OUTPUT_DIR>/.understand-anything/meta.json
 <OUTPUT_DIR>/book-report.md
@@ -81,5 +91,5 @@ Run:
 
 - EPUB only. Do not accept PDF/DOCX/OCR yet.
 - The deterministic path uses Python stdlib only: zip, XML, HTML parsing, JSON, subprocess.
-- This first pipeline produces a structural book graph from chapters/categories. Rich LLM chapter analysis can be layered in later via `analysis-batch-*.json` or a dedicated analyzer.
-- Evidence comes from generated chapter markdown pages in EPUB spine order.
+- This pipeline produces a structural book graph plus deterministic LLM-ready `analysis-batches/*.json`. It still does not call an LLM.
+- Evidence comes from generated chapter text in EPUB spine order, then from stable chunk files with `evidence_anchor`.

--- a/understand-anything-plugin/skills/understand-book/SKILL.md
+++ b/understand-anything-plugin/skills/understand-book/SKILL.md
@@ -37,6 +37,7 @@ EPUB
   → understand-knowledge merge
   → <OUTPUT_DIR>/.understand-anything/knowledge-graph.json
   → <OUTPUT_DIR>/.understand-anything/meta.json
+  → <OUTPUT_DIR>/book-report.md
 ```
 
 Expected progress output:
@@ -63,6 +64,7 @@ Check these files exist:
 <OUTPUT_DIR>/.understand-anything/intermediate/book-manifest.json
 <OUTPUT_DIR>/.understand-anything/knowledge-graph.json
 <OUTPUT_DIR>/.understand-anything/meta.json
+<OUTPUT_DIR>/book-report.md
 ```
 
 If validation fails, report the exact `ERR_*` message from the script and stop.

--- a/understand-anything-plugin/skills/understand-book/SKILL.md
+++ b/understand-anything-plugin/skills/understand-book/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: understand-book
+description: Convert an EPUB book into a chapter-aware wiki scaffold, then reuse /understand-knowledge and /understand-dashboard to generate an interactive book knowledge graph.
+argument-hint: [book.epub] [--language <lang>] [--output <dir>]
+---
+
+# /understand-book
+
+Analyze an EPUB book by first converting it into a deterministic Karpathy-style wiki scaffold.
+
+## Instructions
+
+### Phase 1: Resolve arguments
+
+1. Parse `$ARGUMENTS`:
+   - First non-flag token: EPUB input path.
+   - `--language <lang>`: optional output language, defaults to EPUB metadata or `unknown`.
+   - `--output <dir>`: optional output directory, defaults to `.understand-book`.
+2. If no EPUB path is provided, ask the user for one.
+3. Resolve relative paths against the current working directory.
+4. Verify the input exists and ends with `.epub`.
+
+### Phase 2: Convert EPUB to wiki scaffold
+
+Run the bundled deterministic converter:
+
+```bash
+python3 <SKILL_DIR>/epub-to-wiki.py <EPUB_PATH> --output <OUTPUT_DIR> --language <LANGUAGE>
+```
+
+This writes:
+
+```text
+<OUTPUT_DIR>/
+  raw/<book.epub>
+  wiki/index.md
+  wiki/chapters/ch01.md
+  wiki/chapters/ch02.md
+  .understand-anything/intermediate/book-manifest.json
+```
+
+Report:
+
+```text
+[understand-book] Manifest ready: N chapters, M assets
+```
+
+### Phase 3: Generate the knowledge graph
+
+Run `/understand-knowledge <OUTPUT_DIR>/wiki`.
+
+That command produces:
+
+```text
+<OUTPUT_DIR>/wiki/.understand-anything/knowledge-graph.json
+```
+
+### Phase 4: Save book-level outputs
+
+Copy the knowledge graph to the book output root for dashboard convenience:
+
+```bash
+mkdir -p <OUTPUT_DIR>/.understand-anything
+cp <OUTPUT_DIR>/wiki/.understand-anything/knowledge-graph.json <OUTPUT_DIR>/.understand-anything/knowledge-graph.json
+```
+
+Then run:
+
+```text
+/understand-dashboard <OUTPUT_DIR>
+```
+
+## Notes
+
+- This first version is EPUB-only. Do not accept PDF/DOCX/OCR yet.
+- The converter is deterministic and uses Python stdlib only: zip, XML, and HTML parsing.
+- LLM analysis happens after conversion, through the existing `/understand-knowledge` path.
+- Evidence comes from chapter markdown pages generated from EPUB spine order.

--- a/understand-anything-plugin/skills/understand-book/SKILL.md
+++ b/understand-anything-plugin/skills/understand-book/SKILL.md
@@ -93,3 +93,4 @@ Run:
 - The deterministic path uses Python stdlib only: zip, XML, HTML parsing, JSON, subprocess.
 - This pipeline produces a structural book graph plus deterministic LLM-ready `analysis-batches/*.json`. It still does not call an LLM.
 - Evidence comes from generated chapter text in EPUB spine order, then from stable chunk files with `evidence_anchor`.
+- Chunk and analysis-batch cache files are parsed and schema-validated before reuse; invalid cache is rebuilt instead of trusted blindly.

--- a/understand-anything-plugin/skills/understand-book/epub-to-wiki.py
+++ b/understand-anything-plugin/skills/understand-book/epub-to-wiki.py
@@ -164,7 +164,10 @@ def read_rootfile_path(zf: zipfile.ZipFile) -> str:
         data = zf.read(_CONTAINER)
     except KeyError as exc:
         raise EpubError("ERR_EPUB_PARSE_FAILED: META-INF/container.xml not found") from exc
-    root = ET.fromstring(data)
+    try:
+        root = ET.fromstring(data)
+    except ET.ParseError as exc:
+        raise EpubError("ERR_EPUB_PARSE_FAILED: META-INF/container.xml is not valid XML") from exc
     rootfile = root.find(f".//{_CONTAINER_NS}rootfile")
     if rootfile is None:
         rootfile = root.find(".//rootfile")
@@ -178,7 +181,10 @@ def parse_opf(zf: zipfile.ZipFile, opf_path: str) -> tuple[ET.Element, dict[str,
         opf_data = zf.read(opf_path)
     except KeyError as exc:
         raise EpubError(f"ERR_EPUB_PARSE_FAILED: OPF not found: {opf_path}") from exc
-    root = ET.fromstring(opf_data)
+    try:
+        root = ET.fromstring(opf_data)
+    except ET.ParseError as exc:
+        raise EpubError(f"ERR_EPUB_PARSE_FAILED: OPF is not valid XML: {opf_path}") from exc
     base = posixpath.dirname(opf_path)
 
     items: dict[str, ManifestItem] = {}
@@ -240,6 +246,12 @@ def write_markdown(path: Path, content: str) -> None:
     path.write_text(content.rstrip() + "\n", encoding="utf-8")
 
 
+def reset_generated_dir(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
 def ingest_epub(input_path: Path, output_dir: Path, language: str) -> dict[str, Any]:
     if not input_path.is_file():
         raise EpubError(f"ERR_INPUT_NOT_FOUND: {input_path}")
@@ -254,95 +266,104 @@ def ingest_epub(input_path: Path, output_dir: Path, language: str) -> dict[str, 
     chapter_html_dir = intermediate_dir / "html"
     asset_dir = raw_dir / "assets"
 
-    for directory in [raw_dir, chapter_wiki_dir, intermediate_dir, chapter_text_dir, chapter_html_dir, asset_dir]:
-        directory.mkdir(parents=True, exist_ok=True)
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    reset_generated_dir(chapter_wiki_dir)
+    reset_generated_dir(chapter_text_dir)
+    reset_generated_dir(chapter_html_dir)
+    reset_generated_dir(asset_dir)
+    shutil.rmtree(wiki_dir / ".understand-anything", ignore_errors=True)
+    intermediate_dir.mkdir(parents=True, exist_ok=True)
 
     raw_copy = raw_dir / input_path.name
     shutil.copy2(input_path, raw_copy)
 
-    with zipfile.ZipFile(input_path) as zf:
-        opf_path = read_rootfile_path(zf)
-        opf_root, items, spine = parse_opf(zf, opf_path)
-        toc = parse_nav_toc(zf, items)
+    try:
+        with zipfile.ZipFile(input_path) as zf:
+            opf_path = read_rootfile_path(zf)
+            opf_root, items, spine = parse_opf(zf, opf_path)
+            toc = parse_nav_toc(zf, items)
 
-        title = xml_text(opf_root, f"{_DC_NS}title") or xml_text(opf_root, "title") or input_path.stem
-        authors = xml_texts(opf_root, f"{_DC_NS}creator") or xml_texts(opf_root, "creator")
-        language = language or xml_text(opf_root, f"{_DC_NS}language") or xml_text(opf_root, "language") or "unknown"
-        publisher = xml_text(opf_root, f"{_DC_NS}publisher") or xml_text(opf_root, "publisher")
-        published_at = xml_text(opf_root, f"{_DC_NS}date") or xml_text(opf_root, "date")
-        identifier = xml_text(opf_root, f"{_DC_NS}identifier") or xml_text(opf_root, "identifier")
+            title = xml_text(opf_root, f"{_DC_NS}title") or xml_text(opf_root, "title") or input_path.stem
+            authors = xml_texts(opf_root, f"{_DC_NS}creator") or xml_texts(opf_root, "creator")
+            language = language or xml_text(opf_root, f"{_DC_NS}language") or xml_text(opf_root, "language") or "unknown"
+            publisher = xml_text(opf_root, f"{_DC_NS}publisher") or xml_text(opf_root, "publisher")
+            published_at = xml_text(opf_root, f"{_DC_NS}date") or xml_text(opf_root, "date")
+            identifier = xml_text(opf_root, f"{_DC_NS}identifier") or xml_text(opf_root, "identifier")
 
-        chapters: list[dict[str, Any]] = []
-        toc_by_href = {t["href"].split("#", 1)[0]: t["title"] for t in toc if t.get("href")}
+            chapters: list[dict[str, Any]] = []
+            toc_by_href = {t["href"].split("#", 1)[0]: t["title"] for t in toc if t.get("href")}
 
-        for index, idref in enumerate(spine, start=1):
-            item = items.get(idref)
-            if not item or "html" not in item.media_type:
-                continue
-            try:
-                html_text = zf.read(item.abs_path).decode("utf-8", errors="replace")
-            except KeyError:
-                continue
+            for index, idref in enumerate(spine, start=1):
+                item = items.get(idref)
+                if not item or "html" not in item.media_type:
+                    continue
+                try:
+                    html_text = zf.read(item.abs_path).decode("utf-8", errors="replace")
+                except KeyError:
+                    continue
 
-            text, h1 = extract_html_text(html_text)
-            if not text:
-                continue
+                text, h1 = extract_html_text(html_text)
+                if not text:
+                    continue
 
-            chapter_id = f"ch{len(chapters) + 1:02d}"
-            title_from_toc = toc_by_href.get(item.href) or toc_by_href.get(item.abs_path)
-            chapter_title = safe_title(h1 or title_from_toc or f"Chapter {len(chapters) + 1}", f"Chapter {len(chapters) + 1}")
+                chapter_id = f"ch{len(chapters) + 1:02d}"
+                title_from_toc = toc_by_href.get(item.href) or toc_by_href.get(item.abs_path)
+                chapter_title = safe_title(h1 or title_from_toc or f"Chapter {len(chapters) + 1}", f"Chapter {len(chapters) + 1}")
 
-            text_path = chapter_text_dir / f"{chapter_id}.txt"
-            html_path = chapter_html_dir / f"{chapter_id}.html"
-            wiki_path = chapter_wiki_dir / f"{chapter_id}.md"
-            text_path.write_text(text, encoding="utf-8")
-            html_path.write_text(html_text, encoding="utf-8")
-            write_markdown(
-                wiki_path,
-                f"# {chapter_title}\n\n"
-                f"## Source\n\n"
-                f"- Chapter ID: `{chapter_id}`\n"
-                f"- EPUB href: `{item.href}`\n\n"
-                f"## Text\n\n{text}",
-            )
+                text_path = chapter_text_dir / f"{chapter_id}.txt"
+                html_path = chapter_html_dir / f"{chapter_id}.html"
+                wiki_path = chapter_wiki_dir / f"{chapter_id}.md"
+                text_path.write_text(text, encoding="utf-8")
+                html_path.write_text(html_text, encoding="utf-8")
+                write_markdown(
+                    wiki_path,
+                    f"# {chapter_title}\n\n"
+                    f"## Source\n\n"
+                    f"- Chapter ID: `{chapter_id}`\n"
+                    f"- EPUB href: `{item.href}`\n\n"
+                    f"## Text\n\n{text}",
+                )
 
-            chapters.append(
-                {
-                    "id": chapter_id,
-                    "order": len(chapters) + 1,
-                    "title": chapter_title,
-                    "href": item.href,
-                    "text_path": str(text_path),
-                    "html_path": str(html_path),
-                    "wiki_path": str(wiki_path),
-                    "word_count": len(re.findall(r"\w+", text)),
-                    "char_count": len(text),
-                }
-            )
+                chapters.append(
+                    {
+                        "id": chapter_id,
+                        "order": len(chapters) + 1,
+                        "title": chapter_title,
+                        "href": item.href,
+                        "text_path": str(text_path),
+                        "html_path": str(html_path),
+                        "wiki_path": str(wiki_path),
+                        "word_count": len(re.findall(r"\w+", text)),
+                        "char_count": len(text),
+                    }
+                )
 
-        if not chapters:
-            raise EpubError("ERR_NO_CHAPTERS_FOUND: no readable spine XHTML chapters found")
+            if not chapters:
+                raise EpubError("ERR_NO_CHAPTERS_FOUND: no readable spine XHTML chapters found")
 
-        assets: list[dict[str, Any]] = []
-        for item in items.values():
-            if not item.media_type.startswith(_IMAGE_MEDIA_PREFIX):
-                continue
-            try:
-                data = zf.read(item.abs_path)
-            except KeyError:
-                continue
-            out_name = posixpath.basename(item.href) or f"asset-{len(assets) + 1}"
-            out_path = asset_dir / out_name
-            out_path.write_bytes(data)
-            assets.append(
-                {
-                    "type": "image",
-                    "href": item.href,
-                    "media_type": item.media_type,
-                    "output_path": str(out_path),
-                }
-            )
+            assets: list[dict[str, Any]] = []
+            for item in items.values():
+                if not item.media_type.startswith(_IMAGE_MEDIA_PREFIX):
+                    continue
+                try:
+                    data = zf.read(item.abs_path)
+                except KeyError:
+                    continue
+                out_name = posixpath.basename(item.href) or f"asset-{len(assets) + 1}"
+                out_path = asset_dir / out_name
+                out_path.write_bytes(data)
+                assets.append(
+                    {
+                        "type": "image",
+                        "href": item.href,
+                        "media_type": item.media_type,
+                        "output_path": str(out_path),
+                    }
+                )
 
+    except zipfile.BadZipFile as exc:
+        raise EpubError(f"ERR_EPUB_INVALID: not a valid EPUB zip: {input_path}") from exc
     index_lines = [
         f"# {title}",
         "",
@@ -361,6 +382,19 @@ def ingest_epub(input_path: Path, output_dir: Path, language: str) -> dict[str, 
         ]
     )
     write_markdown(wiki_dir / "index.md", "\n".join(index_lines))
+    write_markdown(
+        wiki_dir / "log.md",
+        "\n".join(
+            [
+                "# Book Ingestion Log",
+                "",
+                f"## [{datetime.now(timezone.utc).date().isoformat()}] ingest | {title}",
+                "",
+                f"- Source: `{input_path.name}`",
+                f"- Chapters: {len(chapters)}",
+            ]
+        ),
+    )
 
     manifest = {
         "version": 1,

--- a/understand-anything-plugin/skills/understand-book/epub-to-wiki.py
+++ b/understand-anything-plugin/skills/understand-book/epub-to-wiki.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""
+Convert an EPUB into a deterministic Karpathy-style wiki scaffold.
+
+Usage:
+    python epub-to-wiki.py book.epub --output .understand-book --language zh
+
+Outputs:
+    <output>/raw/<book.epub>
+    <output>/wiki/index.md
+    <output>/wiki/chapters/chNN.md
+    <output>/.understand-anything/intermediate/book-manifest.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import posixpath
+import re
+import shutil
+import sys
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+
+_CONTAINER = "META-INF/container.xml"
+_OPF_NS = "{http://www.idpf.org/2007/opf}"
+_DC_NS = "{http://purl.org/dc/elements/1.1/}"
+_CONTAINER_NS = "{urn:oasis:names:tc:opendocument:xmlns:container}"
+_XHTML_NS = "{http://www.w3.org/1999/xhtml}"
+_IMAGE_MEDIA_PREFIX = "image/"
+
+
+class EpubError(RuntimeError):
+    """Human-readable EPUB ingestion error."""
+
+
+@dataclass(frozen=True)
+class ManifestItem:
+    id: str
+    href: str
+    media_type: str
+    properties: str
+    abs_path: str
+
+
+class TextExtractor(HTMLParser):
+    """Small HTML-to-text extractor good enough for EPUB XHTML chapters."""
+
+    block_tags = {
+        "address",
+        "article",
+        "aside",
+        "blockquote",
+        "br",
+        "dd",
+        "div",
+        "dl",
+        "dt",
+        "figcaption",
+        "figure",
+        "footer",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "header",
+        "hr",
+        "li",
+        "main",
+        "nav",
+        "ol",
+        "p",
+        "pre",
+        "section",
+        "table",
+        "tr",
+        "ul",
+    }
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        self._skip_depth = 0
+        self.title = ""
+        self._heading_capture: list[str] | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if tag in {"script", "style"}:
+            self._skip_depth += 1
+            return
+        if tag in self.block_tags:
+            self.parts.append("\n")
+        if tag == "h1" and self._heading_capture is None:
+            self._heading_capture = []
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in {"script", "style"} and self._skip_depth:
+            self._skip_depth -= 1
+            return
+        if tag in self.block_tags:
+            self.parts.append("\n")
+        if tag == "h1" and self._heading_capture is not None:
+            title = "".join(self._heading_capture).strip()
+            if title and not self.title:
+                self.title = title
+            self._heading_capture = None
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth:
+            return
+        if self._heading_capture is not None:
+            self._heading_capture.append(data)
+        self.parts.append(data)
+
+    def text(self) -> str:
+        raw = html.unescape("".join(self.parts))
+        raw = raw.replace("\xa0", " ")
+        lines = [re.sub(r"[ \t]+", " ", line).strip() for line in raw.splitlines()]
+        collapsed: list[str] = []
+        previous_blank = True
+        for line in lines:
+            if not line:
+                if not previous_blank:
+                    collapsed.append("")
+                previous_blank = True
+                continue
+            collapsed.append(line)
+            previous_blank = False
+        return "\n\n".join([line for line in collapsed if line]).strip()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def xml_text(root: ET.Element, tag: str) -> str:
+    el = root.find(f".//{tag}")
+    return (el.text or "").strip() if el is not None else ""
+
+
+def xml_texts(root: ET.Element, tag: str) -> list[str]:
+    return [(el.text or "").strip() for el in root.findall(f".//{tag}") if (el.text or "").strip()]
+
+
+def read_rootfile_path(zf: zipfile.ZipFile) -> str:
+    try:
+        data = zf.read(_CONTAINER)
+    except KeyError as exc:
+        raise EpubError("ERR_EPUB_PARSE_FAILED: META-INF/container.xml not found") from exc
+    root = ET.fromstring(data)
+    rootfile = root.find(f".//{_CONTAINER_NS}rootfile")
+    if rootfile is None:
+        rootfile = root.find(".//rootfile")
+    if rootfile is None or not rootfile.attrib.get("full-path"):
+        raise EpubError("ERR_EPUB_PARSE_FAILED: package rootfile not found")
+    return rootfile.attrib["full-path"]
+
+
+def parse_opf(zf: zipfile.ZipFile, opf_path: str) -> tuple[ET.Element, dict[str, ManifestItem], list[str]]:
+    try:
+        opf_data = zf.read(opf_path)
+    except KeyError as exc:
+        raise EpubError(f"ERR_EPUB_PARSE_FAILED: OPF not found: {opf_path}") from exc
+    root = ET.fromstring(opf_data)
+    base = posixpath.dirname(opf_path)
+
+    items: dict[str, ManifestItem] = {}
+    for item in root.findall(f".//{_OPF_NS}manifest/{_OPF_NS}item") or root.findall(".//manifest/item"):
+        item_id = item.attrib.get("id", "")
+        href = item.attrib.get("href", "")
+        if not item_id or not href:
+            continue
+        abs_path = posixpath.normpath(posixpath.join(base, href))
+        items[item_id] = ManifestItem(
+            id=item_id,
+            href=href,
+            media_type=item.attrib.get("media-type", ""),
+            properties=item.attrib.get("properties", ""),
+            abs_path=abs_path,
+        )
+
+    spine: list[str] = []
+    for itemref in root.findall(f".//{_OPF_NS}spine/{_OPF_NS}itemref") or root.findall(".//spine/itemref"):
+        idref = itemref.attrib.get("idref")
+        if idref:
+            spine.append(idref)
+
+    return root, items, spine
+
+
+def parse_nav_toc(zf: zipfile.ZipFile, items: dict[str, ManifestItem]) -> list[dict[str, Any]]:
+    nav_item = next((i for i in items.values() if "nav" in i.properties.split()), None)
+    if not nav_item:
+        return []
+    try:
+        text = zf.read(nav_item.abs_path).decode("utf-8", errors="replace")
+        root = ET.fromstring(text)
+    except Exception:
+        return []
+
+    toc: list[dict[str, Any]] = []
+    for a in root.findall(f".//{_XHTML_NS}a") or root.findall(".//a"):
+        label = "".join(a.itertext()).strip()
+        href = a.attrib.get("href", "")
+        if label or href:
+            toc.append({"title": label, "href": href})
+    return toc
+
+
+def extract_html_text(html_text: str) -> tuple[str, str]:
+    parser = TextExtractor()
+    parser.feed(html_text)
+    return parser.text(), parser.title
+
+
+def safe_title(value: str, fallback: str) -> str:
+    value = re.sub(r"\s+", " ", value).strip()
+    return value or fallback
+
+
+def write_markdown(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.rstrip() + "\n", encoding="utf-8")
+
+
+def ingest_epub(input_path: Path, output_dir: Path, language: str) -> dict[str, Any]:
+    if not input_path.is_file():
+        raise EpubError(f"ERR_INPUT_NOT_FOUND: {input_path}")
+    if input_path.suffix.lower() != ".epub":
+        raise EpubError(f"ERR_INPUT_NOT_EPUB: {input_path}")
+
+    raw_dir = output_dir / "raw"
+    wiki_dir = output_dir / "wiki"
+    chapter_wiki_dir = wiki_dir / "chapters"
+    intermediate_dir = output_dir / ".understand-anything" / "intermediate"
+    chapter_text_dir = intermediate_dir / "chapters"
+    chapter_html_dir = intermediate_dir / "html"
+    asset_dir = raw_dir / "assets"
+
+    for directory in [raw_dir, chapter_wiki_dir, intermediate_dir, chapter_text_dir, chapter_html_dir, asset_dir]:
+        directory.mkdir(parents=True, exist_ok=True)
+
+    raw_copy = raw_dir / input_path.name
+    shutil.copy2(input_path, raw_copy)
+
+    with zipfile.ZipFile(input_path) as zf:
+        opf_path = read_rootfile_path(zf)
+        opf_root, items, spine = parse_opf(zf, opf_path)
+        toc = parse_nav_toc(zf, items)
+
+        title = xml_text(opf_root, f"{_DC_NS}title") or xml_text(opf_root, "title") or input_path.stem
+        authors = xml_texts(opf_root, f"{_DC_NS}creator") or xml_texts(opf_root, "creator")
+        language = language or xml_text(opf_root, f"{_DC_NS}language") or xml_text(opf_root, "language") or "unknown"
+        publisher = xml_text(opf_root, f"{_DC_NS}publisher") or xml_text(opf_root, "publisher")
+        published_at = xml_text(opf_root, f"{_DC_NS}date") or xml_text(opf_root, "date")
+        identifier = xml_text(opf_root, f"{_DC_NS}identifier") or xml_text(opf_root, "identifier")
+
+        chapters: list[dict[str, Any]] = []
+        toc_by_href = {t["href"].split("#", 1)[0]: t["title"] for t in toc if t.get("href")}
+
+        for index, idref in enumerate(spine, start=1):
+            item = items.get(idref)
+            if not item or "html" not in item.media_type:
+                continue
+            try:
+                html_text = zf.read(item.abs_path).decode("utf-8", errors="replace")
+            except KeyError:
+                continue
+
+            text, h1 = extract_html_text(html_text)
+            if not text:
+                continue
+
+            chapter_id = f"ch{len(chapters) + 1:02d}"
+            title_from_toc = toc_by_href.get(item.href) or toc_by_href.get(item.abs_path)
+            chapter_title = safe_title(h1 or title_from_toc or f"Chapter {len(chapters) + 1}", f"Chapter {len(chapters) + 1}")
+
+            text_path = chapter_text_dir / f"{chapter_id}.txt"
+            html_path = chapter_html_dir / f"{chapter_id}.html"
+            wiki_path = chapter_wiki_dir / f"{chapter_id}.md"
+            text_path.write_text(text, encoding="utf-8")
+            html_path.write_text(html_text, encoding="utf-8")
+            write_markdown(
+                wiki_path,
+                f"# {chapter_title}\n\n"
+                f"## Source\n\n"
+                f"- Chapter ID: `{chapter_id}`\n"
+                f"- EPUB href: `{item.href}`\n\n"
+                f"## Text\n\n{text}",
+            )
+
+            chapters.append(
+                {
+                    "id": chapter_id,
+                    "order": len(chapters) + 1,
+                    "title": chapter_title,
+                    "href": item.href,
+                    "text_path": str(text_path),
+                    "html_path": str(html_path),
+                    "wiki_path": str(wiki_path),
+                    "word_count": len(re.findall(r"\w+", text)),
+                    "char_count": len(text),
+                }
+            )
+
+        if not chapters:
+            raise EpubError("ERR_NO_CHAPTERS_FOUND: no readable spine XHTML chapters found")
+
+        assets: list[dict[str, Any]] = []
+        for item in items.values():
+            if not item.media_type.startswith(_IMAGE_MEDIA_PREFIX):
+                continue
+            try:
+                data = zf.read(item.abs_path)
+            except KeyError:
+                continue
+            out_name = posixpath.basename(item.href) or f"asset-{len(assets) + 1}"
+            out_path = asset_dir / out_name
+            out_path.write_bytes(data)
+            assets.append(
+                {
+                    "type": "image",
+                    "href": item.href,
+                    "media_type": item.media_type,
+                    "output_path": str(out_path),
+                }
+            )
+
+    index_lines = [
+        f"# {title}",
+        "",
+        "## Chapters",
+        "",
+    ]
+    for chapter in chapters:
+        index_lines.append(f"- [[chapters/{chapter['id']}|{chapter['title']}]]")
+    index_lines.extend(
+        [
+            "",
+            "## Source",
+            "",
+            f"- EPUB: `../raw/{input_path.name}`",
+            f"- Language: `{language}`",
+        ]
+    )
+    write_markdown(wiki_dir / "index.md", "\n".join(index_lines))
+
+    manifest = {
+        "version": 1,
+        "source": {
+            "type": "epub",
+            "input_path": str(input_path),
+            "copied_path": str(raw_copy),
+            "file_name": input_path.name,
+            "file_size": input_path.stat().st_size,
+            "hash": sha256_file(input_path),
+        },
+        "book": {
+            "title": title,
+            "authors": authors,
+            "language": language,
+            "publisher": publisher,
+            "published_at": published_at,
+            "identifier": identifier,
+        },
+        "toc": toc,
+        "chapters": chapters,
+        "assets": assets,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    (intermediate_dir / "book-manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert EPUB to an Understand Anything book wiki scaffold")
+    parser.add_argument("input", help="Path to .epub file")
+    parser.add_argument("--output", default=".understand-book", help="Output directory")
+    parser.add_argument("--language", default="", help="Output language override")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        manifest = ingest_epub(Path(args.input).resolve(), Path(args.output).resolve(), args.language)
+    except EpubError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(
+        f"[understand-book] Manifest ready: {len(manifest['chapters'])} chapters, "
+        f"{len(manifest['assets'])} assets"
+    )
+    print(f"[understand-book] Wiki: {Path(args.output).resolve() / 'wiki'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/understand-anything-plugin/skills/understand-book/llm-adapters/run-analysis-batches.py
+++ b/understand-anything-plugin/skills/understand-book/llm-adapters/run-analysis-batches.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -22,6 +23,9 @@ from typing import Any
 
 class AdapterError(RuntimeError):
     """Human-readable adapter error."""
+
+
+_SAFE_BATCH_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 def read_json(path: Path) -> dict[str, Any]:
@@ -44,8 +48,11 @@ def validate_batches_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     for batch in batches:
         if not isinstance(batch, dict):
             raise AdapterError("ERR_BATCHES_MANIFEST_INVALID: batch must be an object")
-        if not isinstance(batch.get("id"), str) or not batch["id"]:
+        batch_id = batch.get("id")
+        if not isinstance(batch_id, str) or not batch_id:
             raise AdapterError("ERR_BATCHES_MANIFEST_INVALID: batch id missing")
+        if not _SAFE_BATCH_ID.fullmatch(batch_id):
+            raise AdapterError(f"ERR_BATCH_ID_INVALID: {batch_id}")
         batch_path = Path(batch.get("path", ""))
         if not batch_path.is_file():
             raise AdapterError(f"ERR_BATCH_NOT_FOUND: {batch_path}")

--- a/understand-anything-plugin/skills/understand-book/llm-adapters/run-analysis-batches.py
+++ b/understand-anything-plugin/skills/understand-book/llm-adapters/run-analysis-batches.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Run optional LLM analysis over /understand-book analysis batches.
+
+Core EPUB pipeline remains deterministic. This adapter consumes
+analysis-batches-manifest.json and writes analysis-results/*.result.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class AdapterError(RuntimeError):
+    """Human-readable adapter error."""
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AdapterError(f"ERR_JSON_INVALID: {path}") from exc
+    if not isinstance(data, dict):
+        raise AdapterError(f"ERR_JSON_INVALID: {path}")
+    return data
+
+
+def validate_batches_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    if manifest.get("version") != 1:
+        raise AdapterError("ERR_BATCHES_MANIFEST_INVALID: version must be 1")
+    batches = manifest.get("batches")
+    if not isinstance(batches, list) or not batches:
+        raise AdapterError("ERR_BATCHES_MANIFEST_INVALID: batches must be a non-empty list")
+    valid: list[dict[str, Any]] = []
+    for batch in batches:
+        if not isinstance(batch, dict):
+            raise AdapterError("ERR_BATCHES_MANIFEST_INVALID: batch must be an object")
+        if not isinstance(batch.get("id"), str) or not batch["id"]:
+            raise AdapterError("ERR_BATCHES_MANIFEST_INVALID: batch id missing")
+        batch_path = Path(batch.get("path", ""))
+        if not batch_path.is_file():
+            raise AdapterError(f"ERR_BATCH_NOT_FOUND: {batch_path}")
+        valid.append(batch)
+    return valid
+
+
+def validate_batch_payload(batch: dict[str, Any], batch_path: Path) -> None:
+    if batch.get("kind") != "understand-book-analysis-batch":
+        raise AdapterError(f"ERR_BATCH_INVALID: {batch_path}")
+    chunks = batch.get("chunks")
+    if not isinstance(chunks, list) or not chunks:
+        raise AdapterError(f"ERR_BATCH_INVALID: {batch_path} has no chunks")
+    for chunk in chunks:
+        if not isinstance(chunk, dict) or not isinstance(chunk.get("id"), str):
+            raise AdapterError(f"ERR_BATCH_INVALID: {batch_path} chunk id missing")
+        if not isinstance(chunk.get("evidence_anchor"), str):
+            raise AdapterError(f"ERR_BATCH_INVALID: {batch_path} evidence anchor missing")
+        if not isinstance(chunk.get("evidence"), str) or not chunk["evidence"].strip():
+            raise AdapterError(f"ERR_BATCH_INVALID: {batch_path} evidence missing")
+
+
+def build_result(
+    *,
+    batch_record: dict[str, Any],
+    batch_path: Path,
+    provider: str,
+    model: str,
+    analysis: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "version": 1,
+        "kind": "understand-book-analysis-result",
+        "provider": provider,
+        "model": model,
+        "batch_id": batch_record["id"],
+        "source_batch_path": str(batch_path),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "analysis": analysis,
+    }
+
+
+def run_local_command(batch: dict[str, Any], command: str) -> dict[str, Any]:
+    if not command.strip():
+        raise AdapterError("ERR_LOCAL_COMMAND_MISSING: --command is required for local-command")
+    args = shlex.split(command)
+    result = subprocess.run(
+        args,
+        input=json.dumps(batch, ensure_ascii=False),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AdapterError(f"ERR_LOCAL_COMMAND_FAILED: exit {result.returncode}: {result.stderr.strip()}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AdapterError("ERR_LOCAL_COMMAND_INVALID_JSON: stdout must be a JSON object") from exc
+    if not isinstance(payload, dict):
+        raise AdapterError("ERR_LOCAL_COMMAND_INVALID_JSON: stdout must be a JSON object")
+    return payload
+
+
+def build_deepseek_messages(batch: dict[str, Any]) -> list[dict[str, str]]:
+    system = (
+        "你是严谨的书籍理解分析器。只基于用户提供的 JSON batch 中的 evidence 分析。"
+        "不要编造。必须输出合法 JSON，不要 Markdown。"
+    )
+    user = {
+        "task": "chapter_analysis",
+        "output_schema": {
+            "summary": "string，全批次摘要",
+            "key_points": ["string，关键观点"],
+            "chunk_insights": [
+                {
+                    "chunk_id": "string",
+                    "claim": "string",
+                    "evidence_anchor": "string",
+                }
+            ],
+            "open_questions": ["string，无法从证据确定的问题"],
+        },
+        "batch": batch,
+    }
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": json.dumps(user, ensure_ascii=False)},
+    ]
+
+
+def extract_json_object(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].startswith("```"):
+            lines = lines[:-1]
+        stripped = "\n".join(lines).strip()
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        raise AdapterError("ERR_LLM_RESPONSE_INVALID_JSON: model response must be JSON") from exc
+    if not isinstance(payload, dict):
+        raise AdapterError("ERR_LLM_RESPONSE_INVALID_JSON: model response must be a JSON object")
+    return payload
+
+
+def run_deepseek(batch: dict[str, Any], model: str, timeout_seconds: int) -> dict[str, Any]:
+    api_key = os.environ.get("DEEPSEEK_API_KEY")
+    if not api_key:
+        raise AdapterError("ERR_DEEPSEEK_API_KEY_MISSING: set DEEPSEEK_API_KEY in the environment")
+    base_url = os.environ.get("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
+    url = base_url.rstrip("/") + "/chat/completions"
+    body = {
+        "model": model,
+        "messages": build_deepseek_messages(batch),
+        "temperature": 0.2,
+        "response_format": {"type": "json_object"},
+    }
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body, ensure_ascii=False).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            response_payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:500]
+        raise AdapterError(f"ERR_DEEPSEEK_HTTP_FAILED: {exc.code} {detail}") from exc
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise AdapterError(f"ERR_DEEPSEEK_REQUEST_FAILED: {exc}") from exc
+
+    try:
+        content = response_payload["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise AdapterError("ERR_DEEPSEEK_RESPONSE_INVALID: missing choices[0].message.content") from exc
+    if not isinstance(content, str):
+        raise AdapterError("ERR_DEEPSEEK_RESPONSE_INVALID: content must be string")
+    return extract_json_object(content)
+
+
+def run_adapter(
+    manifest_path: Path,
+    provider: str,
+    model: str,
+    command: str,
+    output_dir: Path | None,
+    timeout_seconds: int,
+) -> Path:
+    manifest = read_json(manifest_path)
+    batches = validate_batches_manifest(manifest)
+    results_dir = output_dir or (manifest_path.parent / "analysis-results")
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    records: list[dict[str, Any]] = []
+    for batch_record in batches:
+        batch_path = Path(batch_record["path"])
+        batch = read_json(batch_path)
+        validate_batch_payload(batch, batch_path)
+        if provider == "local-command":
+            analysis = run_local_command(batch, command)
+        elif provider == "deepseek":
+            analysis = run_deepseek(batch, model, timeout_seconds)
+        else:
+            raise AdapterError(f"ERR_PROVIDER_UNSUPPORTED: {provider}")
+
+        result_payload = build_result(
+            batch_record=batch_record,
+            batch_path=batch_path,
+            provider=provider,
+            model=model,
+            analysis=analysis,
+        )
+        result_path = results_dir / f"{batch_record['id']}.result.json"
+        result_path.write_text(json.dumps(result_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        print(f"[llm-adapter] result: {result_path}")
+        records.append(
+            {
+                "batch_id": batch_record["id"],
+                "path": str(result_path),
+                "source_batch_path": str(batch_path),
+            }
+        )
+
+    results_manifest = results_dir.parent / "analysis-results-manifest.json"
+    results_manifest.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "provider": provider,
+                "model": model,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "results": records,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"[llm-adapter] manifest: {results_manifest}")
+    return results_manifest
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run LLM analysis over understand-book batches")
+    parser.add_argument("manifest", help="Path to analysis-batches-manifest.json")
+    parser.add_argument("--provider", choices=["local-command", "deepseek"], required=True)
+    parser.add_argument("--model", default="deepseek-v4-flash", help="LLM model name")
+    parser.add_argument("--command", default="", help="Command for local-command provider; reads batch JSON stdin, writes JSON stdout")
+    parser.add_argument("--output-dir", default="", help="Output directory for *.result.json files")
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        output_dir = Path(args.output_dir) if args.output_dir else None
+        run_adapter(Path(args.manifest), args.provider, args.model, args.command, output_dir, args.timeout_seconds)
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/understand-anything-plugin/skills/understand-book/llm-adapters/synthesize-analysis-results.py
+++ b/understand-anything-plugin/skills/understand-book/llm-adapters/synthesize-analysis-results.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Synthesize /understand-book LLM analysis results into report + enriched graph."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class SynthesisError(RuntimeError):
+    """Human-readable synthesis error."""
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SynthesisError(f"ERR_JSON_INVALID: {path}") from exc
+    if not isinstance(data, dict):
+        raise SynthesisError(f"ERR_JSON_INVALID: {path}")
+    return data
+
+
+def validate_results_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    if manifest.get("version") != 1:
+        raise SynthesisError("ERR_RESULTS_MANIFEST_INVALID: version must be 1")
+    results = manifest.get("results")
+    if not isinstance(results, list) or not results:
+        raise SynthesisError("ERR_RESULTS_MANIFEST_INVALID: results must be a non-empty list")
+    valid: list[dict[str, Any]] = []
+    for record in results:
+        if not isinstance(record, dict):
+            raise SynthesisError("ERR_RESULTS_MANIFEST_INVALID: result record must be an object")
+        if not isinstance(record.get("batch_id"), str) or not record["batch_id"]:
+            raise SynthesisError("ERR_RESULTS_MANIFEST_INVALID: batch_id missing")
+        result_path = Path(record.get("path", ""))
+        if not result_path.is_file():
+            raise SynthesisError(f"ERR_RESULT_NOT_FOUND: {result_path}")
+        valid.append(record)
+    return valid
+
+
+def validate_result_payload(payload: dict[str, Any], path: Path) -> None:
+    if payload.get("kind") != "understand-book-analysis-result":
+        raise SynthesisError(f"ERR_RESULT_INVALID: {path}")
+    if not isinstance(payload.get("batch_id"), str) or not payload["batch_id"]:
+        raise SynthesisError(f"ERR_RESULT_INVALID: {path} batch_id missing")
+    if not isinstance(payload.get("analysis"), dict):
+        raise SynthesisError(f"ERR_RESULT_INVALID: {path} analysis missing")
+
+
+def normalize_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def collect_results(manifest_path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    manifest = read_json(manifest_path)
+    records = validate_results_manifest(manifest)
+    payloads: list[dict[str, Any]] = []
+    for record in records:
+        result_path = Path(record["path"])
+        payload = read_json(result_path)
+        validate_result_payload(payload, result_path)
+        payloads.append(payload)
+    return manifest, payloads
+
+
+def extract_claims(payloads: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    claims: list[dict[str, Any]] = []
+    per_chunk_counts: dict[str, int] = {}
+    for payload in payloads:
+        analysis = payload["analysis"]
+        insights = analysis.get("chunk_insights")
+        if not isinstance(insights, list):
+            continue
+        for insight in insights:
+            if not isinstance(insight, dict):
+                continue
+            chunk_id = insight.get("chunk_id")
+            claim = insight.get("claim")
+            evidence_anchor = insight.get("evidence_anchor")
+            if not isinstance(chunk_id, str) or not chunk_id.strip():
+                continue
+            if not isinstance(claim, str) or not claim.strip():
+                continue
+            if not isinstance(evidence_anchor, str) or not evidence_anchor.strip():
+                evidence_anchor = ""
+            count = per_chunk_counts.get(chunk_id, 0) + 1
+            per_chunk_counts[chunk_id] = count
+            claims.append(
+                {
+                    "id": f"book-claim:{chunk_id}:{count:03d}",
+                    "chunk_node_id": f"book-chunk:{chunk_id}",
+                    "chunk_id": chunk_id,
+                    "claim": claim.strip(),
+                    "evidence_anchor": evidence_anchor.strip(),
+                    "batch_id": payload["batch_id"],
+                    "provider": payload.get("provider", ""),
+                    "model": payload.get("model", ""),
+                }
+            )
+    return claims
+
+
+def write_markdown(output_dir: Path, payloads: list[dict[str, Any]], claims: list[dict[str, Any]]) -> Path:
+    lines = [
+        "# LLM 书籍分析",
+        "",
+        f"生成时间：{datetime.now(timezone.utc).isoformat()}",
+        "",
+        "## 批次摘要",
+        "",
+    ]
+    for payload in payloads:
+        analysis = payload["analysis"]
+        summary = analysis.get("summary")
+        if isinstance(summary, str) and summary.strip():
+            lines.append(f"### {payload['batch_id']}")
+            lines.append("")
+            lines.append(summary.strip())
+            lines.append("")
+        key_points = normalize_string_list(analysis.get("key_points"))
+        if key_points:
+            lines.append("关键点：")
+            lines.append("")
+            for point in key_points:
+                lines.append(f"- {point}")
+            lines.append("")
+
+    lines.extend(["## 证据化观点", ""])
+    for claim in claims:
+        anchor = f"，证据：`{claim['evidence_anchor']}`" if claim["evidence_anchor"] else ""
+        lines.append(f"- `{claim['chunk_id']}`：{claim['claim']}{anchor}")
+    if not claims:
+        lines.append("- 暂无可用观点。")
+    lines.append("")
+
+    open_questions: list[str] = []
+    for payload in payloads:
+        open_questions.extend(normalize_string_list(payload["analysis"].get("open_questions")))
+    if open_questions:
+        lines.extend(["## 待确认问题", ""])
+        for question in open_questions:
+            lines.append(f"- {question}")
+        lines.append("")
+
+    markdown_path = output_dir / "book-analysis.md"
+    markdown_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    return markdown_path
+
+
+def write_synthesis_json(output_dir: Path, manifest: dict[str, Any], payloads: list[dict[str, Any]], claims: list[dict[str, Any]]) -> Path:
+    intermediate_dir = output_dir / ".understand-anything" / "intermediate"
+    intermediate_dir.mkdir(parents=True, exist_ok=True)
+    path = intermediate_dir / "analysis-synthesis.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "provider": manifest.get("provider", ""),
+                "model": manifest.get("model", ""),
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "result_count": len(payloads),
+                "claim_count": len(claims),
+                "claims": claims,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def add_unique_node(nodes: list[dict[str, Any]], node: dict[str, Any], seen: set[str]) -> None:
+    node_id = node.get("id")
+    if isinstance(node_id, str) and node_id not in seen:
+        nodes.append(node)
+        seen.add(node_id)
+
+
+def edge_key(edge: dict[str, Any]) -> tuple[Any, Any, Any]:
+    return edge.get("source"), edge.get("target"), edge.get("type")
+
+
+def write_enriched_graph(output_dir: Path, graph_path: Path, claims: list[dict[str, Any]]) -> Path:
+    graph = read_json(graph_path)
+    nodes = graph.get("nodes")
+    edges = graph.get("edges")
+    if not isinstance(nodes, list) or not isinstance(edges, list):
+        raise SynthesisError(f"ERR_GRAPH_INVALID: {graph_path}")
+
+    node_ids: set[str] = set()
+    for node in nodes:
+        if isinstance(node, dict) and isinstance(node.get("id"), str):
+            node_ids.add(node["id"])
+    edge_keys = {edge_key(edge) for edge in edges if isinstance(edge, dict)}
+
+    for claim in claims:
+        chunk_node = {
+            "id": claim["chunk_node_id"],
+            "type": "chunk",
+            "name": claim["chunk_id"],
+            "summary": f"Book analysis chunk {claim['chunk_id']}",
+            "tags": ["understand-book", "analysis-chunk"],
+        }
+        add_unique_node(nodes, chunk_node, node_ids)
+        claim_node = {
+            "id": claim["id"],
+            "type": "claim",
+            "name": claim["claim"][:60],
+            "summary": claim["claim"],
+            "evidence_anchor": claim["evidence_anchor"],
+            "source_batch_id": claim["batch_id"],
+            "tags": ["understand-book", "llm-analysis"],
+        }
+        add_unique_node(nodes, claim_node, node_ids)
+        edge = {"source": claim["chunk_node_id"], "target": claim["id"], "type": "supports"}
+        key = edge_key(edge)
+        if key not in edge_keys:
+            edges.append(edge)
+            edge_keys.add(key)
+
+    enriched = dict(graph)
+    enriched["nodes"] = nodes
+    enriched["edges"] = edges
+    output_path = output_dir / ".understand-anything" / "knowledge-graph.enriched.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(enriched, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return output_path
+
+
+def synthesize(manifest_path: Path, graph_path: Path, output_dir: Path) -> dict[str, Path]:
+    manifest, payloads = collect_results(manifest_path)
+    claims = extract_claims(payloads)
+    markdown_path = write_markdown(output_dir, payloads, claims)
+    synthesis_path = write_synthesis_json(output_dir, manifest, payloads, claims)
+    enriched_graph_path = write_enriched_graph(output_dir, graph_path, claims)
+    print(f"[analysis-synthesis] markdown: {markdown_path}")
+    print(f"[analysis-synthesis] synthesis: {synthesis_path}")
+    print(f"[analysis-synthesis] graph: {enriched_graph_path}")
+    return {
+        "markdown": markdown_path,
+        "synthesis": synthesis_path,
+        "graph": enriched_graph_path,
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Synthesize understand-book LLM analysis results")
+    parser.add_argument("manifest", help="Path to analysis-results-manifest.json")
+    parser.add_argument("--graph", required=True, help="Path to base knowledge-graph.json")
+    parser.add_argument("--output-dir", default="", help="Book output directory; defaults to manifest ../../../")
+    return parser.parse_args(argv)
+
+
+def default_output_dir(manifest_path: Path) -> Path:
+    # <output>/.understand-anything/intermediate/analysis-results-manifest.json
+    try:
+        return manifest_path.parent.parent.parent
+    except IndexError:
+        return manifest_path.parent
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    manifest_path = Path(args.manifest)
+    output_dir = Path(args.output_dir) if args.output_dir else default_output_dir(manifest_path)
+    try:
+        synthesize(manifest_path, Path(args.graph), output_dir)
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/understand-anything-plugin/skills/understand-book/run-understand-book.py
+++ b/understand-anything-plugin/skills/understand-book/run-understand-book.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Run the first deterministic /understand-book pipeline.
+
+Pipeline:
+    EPUB → wiki scaffold → understand-knowledge deterministic scan/merge
+         → root .understand-anything/knowledge-graph.json + meta.json
+
+This intentionally avoids provider-specific LLM calls. The existing
+/understand-knowledge skill can still add analysis-batch-*.json later.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+_SKILL_DIR = Path(__file__).resolve().parent
+_KNOWLEDGE_SKILL_DIR = _SKILL_DIR.parent / "understand-knowledge"
+_EPUB_TO_WIKI = _SKILL_DIR / "epub-to-wiki.py"
+_PARSE_KNOWLEDGE = _KNOWLEDGE_SKILL_DIR / "parse-knowledge-base.py"
+_MERGE_KNOWLEDGE = _KNOWLEDGE_SKILL_DIR / "merge-knowledge-graph.py"
+
+
+class PipelineError(RuntimeError):
+    """Human-readable pipeline error."""
+
+
+def _load_epub_module() -> Any:
+    spec = importlib.util.spec_from_file_location("understand_book_epub_to_wiki", _EPUB_TO_WIKI)
+    if spec is None or spec.loader is None:
+        raise PipelineError(f"ERR_PIPELINE_IMPORT_FAILED: {_EPUB_TO_WIKI}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["understand_book_epub_to_wiki"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_command(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    printable = " ".join(command)
+    print(f"[understand-book] $ {printable}")
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.stdout:
+        print(result.stdout.rstrip())
+    if result.stderr:
+        print(result.stderr.rstrip(), file=sys.stderr)
+    if result.returncode != 0:
+        raise PipelineError(f"ERR_PIPELINE_COMMAND_FAILED: {printable}")
+    return result
+
+
+def validate_graph(graph: dict[str, Any]) -> None:
+    nodes = graph.get("nodes")
+    edges = graph.get("edges")
+    if not isinstance(nodes, list) or not nodes:
+        raise PipelineError("ERR_GRAPH_EMPTY: graph has no nodes")
+    if not isinstance(edges, list):
+        raise PipelineError("ERR_GRAPH_INVALID: graph edges must be a list")
+
+    node_ids = {node.get("id") for node in nodes if isinstance(node, dict)}
+    dangling = [
+        edge
+        for edge in edges
+        if isinstance(edge, dict)
+        and (edge.get("source") not in node_ids or edge.get("target") not in node_ids)
+    ]
+    if dangling:
+        raise PipelineError(f"ERR_GRAPH_DANGLING_EDGES: {len(dangling)} dangling edges")
+
+
+def write_root_outputs(output_dir: Path, manifest: dict[str, Any]) -> tuple[Path, Path]:
+    wiki_dir = output_dir / "wiki"
+    wiki_intermediate = wiki_dir / ".understand-anything" / "intermediate"
+    assembled_graph_path = wiki_intermediate / "assembled-graph.json"
+    if not assembled_graph_path.is_file():
+        raise PipelineError(f"ERR_GRAPH_NOT_FOUND: {assembled_graph_path}")
+
+    graph = json.loads(assembled_graph_path.read_text(encoding="utf-8"))
+    validate_graph(graph)
+
+    wiki_graph_dir = wiki_dir / ".understand-anything"
+    wiki_graph_dir.mkdir(parents=True, exist_ok=True)
+    wiki_graph_path = wiki_graph_dir / "knowledge-graph.json"
+    wiki_graph_path.write_text(json.dumps(graph, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    root_graph_dir = output_dir / ".understand-anything"
+    root_graph_dir.mkdir(parents=True, exist_ok=True)
+    root_graph_path = root_graph_dir / "knowledge-graph.json"
+    shutil.copy2(wiki_graph_path, root_graph_path)
+
+    meta = {
+        "lastAnalyzedAt": datetime.now(timezone.utc).isoformat(),
+        "gitCommitHash": "",
+        "version": "1.0.0",
+        "sourceType": "epub",
+        "analyzedFiles": len(manifest.get("chapters", [])),
+        "book": manifest.get("book", {}),
+        "manifestPath": str(output_dir / ".understand-anything" / "intermediate" / "book-manifest.json"),
+        "wikiGraphPath": str(wiki_graph_path),
+    }
+    meta_path = root_graph_dir / "meta.json"
+    meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    return root_graph_path, meta_path
+
+
+def run_pipeline(input_path: Path, output_dir: Path, language: str) -> dict[str, Any]:
+    epub_module = _load_epub_module()
+
+    print(f"[understand-book] input: {input_path}")
+    print(f"[understand-book] output: {output_dir}")
+    print("[1/4] Convert EPUB to wiki scaffold...")
+    manifest = epub_module.ingest_epub(input_path.resolve(), output_dir.resolve(), language)
+    print(
+        f"[1/4] Manifest ready: {len(manifest['chapters'])} chapters, "
+        f"{len(manifest.get('assets', []))} assets"
+    )
+
+    wiki_dir = output_dir / "wiki"
+    print("[2/4] Parse wiki scaffold...")
+    run_command([sys.executable, str(_PARSE_KNOWLEDGE), str(wiki_dir)], cwd=output_dir)
+
+    print("[3/4] Merge knowledge graph...")
+    run_command([sys.executable, str(_MERGE_KNOWLEDGE), str(wiki_dir)], cwd=output_dir)
+
+    print("[4/4] Save root graph and metadata...")
+    graph_path, meta_path = write_root_outputs(output_dir, manifest)
+    print(f"[4/4] Graph: {graph_path}")
+    print(f"[4/4] Meta: {meta_path}")
+    print("Done.")
+    return {"manifest": manifest, "graphPath": str(graph_path), "metaPath": str(meta_path)}
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run deterministic EPUB book understanding pipeline")
+    parser.add_argument("input", help="Path to .epub file")
+    parser.add_argument("--output", default=".understand-book", help="Output directory")
+    parser.add_argument("--language", default="", help="Output language override")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        run_pipeline(Path(args.input), Path(args.output), args.language)
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/understand-anything-plugin/skills/understand-book/run-understand-book.py
+++ b/understand-anything-plugin/skills/understand-book/run-understand-book.py
@@ -82,7 +82,66 @@ def validate_graph(graph: dict[str, Any]) -> None:
         raise PipelineError(f"ERR_GRAPH_DANGLING_EDGES: {len(dangling)} dangling edges")
 
 
-def write_root_outputs(output_dir: Path, manifest: dict[str, Any]) -> tuple[Path, Path]:
+def write_book_report(output_dir: Path, manifest: dict[str, Any], graph: dict[str, Any]) -> Path:
+    book = manifest.get("book", {})
+    title = book.get("title") or "未知书名"
+    authors = book.get("authors") or []
+    chapters = manifest.get("chapters", [])
+    nodes = graph.get("nodes", []) if isinstance(graph.get("nodes"), list) else []
+    edges = graph.get("edges", []) if isinstance(graph.get("edges"), list) else []
+
+    lines = [
+        f"# 《{title}》理解报告",
+        "",
+        "## 一句话总结",
+        "",
+        f"这是一本包含 {len(chapters)} 个章节的 EPUB 书籍，已转换为可浏览 wiki 和知识图谱。",
+        "",
+        "## 书籍信息",
+        "",
+        f"- 书名：{title}",
+        f"- 作者：{', '.join(authors) if authors else 'unknown'}",
+        f"- 语言：{book.get('language') or 'unknown'}",
+        f"- 出版方：{book.get('publisher') or 'unknown'}",
+        "",
+        "## 全书结构",
+        "",
+        f"- 章节数：{len(chapters)}",
+        f"- 图谱节点数：{len(nodes)}",
+        f"- 图谱边数：{len(edges)}",
+        "",
+        "## 章节导读",
+        "",
+    ]
+
+    for chapter in chapters:
+        lines.append(f"### {chapter.get('title') or chapter.get('id')}")
+        lines.append("")
+        lines.append(f"- 章节 ID：`{chapter.get('id')}`")
+        lines.append(f"- 字符数：{chapter.get('char_count', 0)}")
+        lines.append(f"- Wiki：`wiki/chapters/{chapter.get('id')}.md`")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## 知识图谱解读",
+            "",
+            "当前版本生成章节级结构图谱；后续可叠加 LLM 章节分析，抽取概念、实体、论点、证据与跨章节关系。",
+            "",
+            "## 输出文件",
+            "",
+            "- `wiki/index.md`：书籍 wiki 入口",
+            "- `.understand-anything/knowledge-graph.json`：dashboard 图谱",
+            "- `.understand-anything/intermediate/book-manifest.json`：EPUB 解析清单",
+        ]
+    )
+
+    report_path = output_dir / "book-report.md"
+    report_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    return report_path
+
+
+def write_root_outputs(output_dir: Path, manifest: dict[str, Any]) -> tuple[Path, Path, Path]:
     wiki_dir = output_dir / "wiki"
     wiki_intermediate = wiki_dir / ".understand-anything" / "intermediate"
     assembled_graph_path = wiki_intermediate / "assembled-graph.json"
@@ -115,7 +174,8 @@ def write_root_outputs(output_dir: Path, manifest: dict[str, Any]) -> tuple[Path
     meta_path = root_graph_dir / "meta.json"
     meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
-    return root_graph_path, meta_path
+    report_path = write_book_report(output_dir, manifest, graph)
+    return root_graph_path, meta_path, report_path
 
 
 def run_pipeline(input_path: Path, output_dir: Path, language: str) -> dict[str, Any]:
@@ -138,11 +198,17 @@ def run_pipeline(input_path: Path, output_dir: Path, language: str) -> dict[str,
     run_command([sys.executable, str(_MERGE_KNOWLEDGE), str(wiki_dir)], cwd=output_dir)
 
     print("[4/4] Save root graph and metadata...")
-    graph_path, meta_path = write_root_outputs(output_dir, manifest)
+    graph_path, meta_path, report_path = write_root_outputs(output_dir, manifest)
     print(f"[4/4] Graph: {graph_path}")
     print(f"[4/4] Meta: {meta_path}")
+    print(f"[4/4] Report: {report_path}")
     print("Done.")
-    return {"manifest": manifest, "graphPath": str(graph_path), "metaPath": str(meta_path)}
+    return {
+        "manifest": manifest,
+        "graphPath": str(graph_path),
+        "metaPath": str(meta_path),
+        "reportPath": str(report_path),
+    }
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/understand-anything-plugin/skills/understand-book/run-understand-book.py
+++ b/understand-anything-plugin/skills/understand-book/run-understand-book.py
@@ -82,6 +82,87 @@ def validate_graph(graph: dict[str, Any]) -> None:
         raise PipelineError(f"ERR_GRAPH_DANGLING_EDGES: {len(dangling)} dangling edges")
 
 
+def read_json_cache(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def validate_chunks_cache(cache: dict[str, Any], manifest: dict[str, Any], chunk_size: int) -> bool:
+    if cache.get("version") != 1:
+        return False
+    if cache.get("chunk_size") != chunk_size:
+        return False
+    if cache.get("source_hash") != manifest.get("source", {}).get("hash"):
+        return False
+    chunks = cache.get("chunks")
+    if not isinstance(chunks, list) or not chunks:
+        return False
+    required_ids = {chapter.get("id") for chapter in manifest.get("chapters", [])}
+    seen_ids: set[str] = set()
+    for chunk in chunks:
+        if not isinstance(chunk, dict):
+            return False
+        if not isinstance(chunk.get("id"), str) or not chunk["id"]:
+            return False
+        if chunk.get("chapter_id") not in required_ids:
+            return False
+        if not isinstance(chunk.get("order"), int) or chunk["order"] < 1:
+            return False
+        if not isinstance(chunk.get("char_start"), int) or not isinstance(chunk.get("char_end"), int):
+            return False
+        if chunk["char_end"] <= chunk["char_start"]:
+            return False
+        if not isinstance(chunk.get("evidence_anchor"), str) or not chunk["evidence_anchor"]:
+            return False
+        chunk_path = Path(chunk.get("path", ""))
+        if not chunk_path.is_file():
+            return False
+        seen_ids.add(chunk["chapter_id"])
+    return required_ids.issubset(seen_ids)
+
+
+def validate_analysis_batches_cache(cache: dict[str, Any], chunks_manifest: dict[str, Any], batch_size: int) -> bool:
+    if cache.get("version") != 1:
+        return False
+    if cache.get("batch_size") != batch_size:
+        return False
+    if cache.get("source_hash") != chunks_manifest.get("source_hash"):
+        return False
+    expected_chunk_ids = [chunk.get("id") for chunk in chunks_manifest.get("chunks", [])]
+    if cache.get("chunk_ids") != expected_chunk_ids:
+        return False
+    batches = cache.get("batches")
+    if not isinstance(batches, list) or not batches:
+        return False
+    seen: list[str] = []
+    for batch in batches:
+        if not isinstance(batch, dict):
+            return False
+        batch_path = Path(batch.get("path", ""))
+        if not batch_path.is_file():
+            return False
+        payload = read_json_cache(batch_path)
+        if payload is None:
+            return False
+        if payload.get("kind") != "understand-book-analysis-batch":
+            return False
+        payload_chunks = payload.get("chunks")
+        if not isinstance(payload_chunks, list) or not payload_chunks:
+            return False
+        ids: list[str] = []
+        for chunk in payload_chunks:
+            if not isinstance(chunk, dict) or not isinstance(chunk.get("id"), str):
+                return False
+            ids.append(chunk["id"])
+        if ids != batch.get("chunk_ids"):
+            return False
+        seen.extend(ids)
+    return seen == expected_chunk_ids
+
+
 def split_text_into_chunks(text: str, chunk_size: int) -> list[tuple[int, int, str]]:
     if chunk_size < 1:
         raise PipelineError("ERR_CHUNK_SIZE_INVALID: chunk size must be positive")
@@ -99,6 +180,16 @@ def write_chapter_chunks(output_dir: Path, manifest: dict[str, Any], chunk_size:
     intermediate_dir = output_dir / ".understand-anything" / "intermediate"
     chunks_dir = intermediate_dir / "chunks"
     chunks_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = intermediate_dir / "chunks-manifest.json"
+
+    existing = read_json_cache(manifest_path) if manifest_path.is_file() else None
+    if existing is not None and validate_chunks_cache(existing, manifest, chunk_size):
+        print("[cache] chunks valid; reusing")
+        return manifest_path
+    if manifest_path.is_file():
+        print("[cache] chunks invalid; rebuilding")
+        shutil.rmtree(chunks_dir, ignore_errors=True)
+        chunks_dir.mkdir(parents=True, exist_ok=True)
 
     book = manifest.get("book", {})
     chunks: list[dict[str, Any]] = []
@@ -156,10 +247,10 @@ def write_chapter_chunks(output_dir: Path, manifest: dict[str, Any], chunk_size:
     chunk_manifest = {
         "version": 1,
         "chunk_size": chunk_size,
+        "source_hash": manifest.get("source", {}).get("hash"),
         "book": book,
         "chunks": chunks,
     }
-    manifest_path = intermediate_dir / "chunks-manifest.json"
     manifest_path.write_text(json.dumps(chunk_manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return manifest_path
 
@@ -170,10 +261,24 @@ def write_analysis_batches(output_dir: Path, chunks_manifest_path: Path, languag
     intermediate_dir = output_dir / ".understand-anything" / "intermediate"
     batches_dir = intermediate_dir / "analysis-batches"
     batches_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = intermediate_dir / "analysis-batches-manifest.json"
 
-    chunks_manifest = json.loads(chunks_manifest_path.read_text(encoding="utf-8"))
+    chunks_manifest = read_json_cache(chunks_manifest_path)
+    if chunks_manifest is None:
+        raise PipelineError(f"ERR_CHUNKS_MANIFEST_INVALID: {chunks_manifest_path}")
+
+    existing = read_json_cache(manifest_path) if manifest_path.is_file() else None
+    if existing is not None and validate_analysis_batches_cache(existing, chunks_manifest, batch_size):
+        print("[cache] analysis batches valid; reusing")
+        return manifest_path
+    if manifest_path.is_file():
+        print("[cache] analysis batches invalid; rebuilding")
+        shutil.rmtree(batches_dir, ignore_errors=True)
+        batches_dir.mkdir(parents=True, exist_ok=True)
+
     chunks = chunks_manifest.get("chunks", [])
     book = chunks_manifest.get("book", {})
+    all_chunk_ids = [chunk.get("id") for chunk in chunks]
     batch_records: list[dict[str, Any]] = []
 
     for batch_index, start in enumerate(range(0, len(chunks), batch_size), start=1):
@@ -223,10 +328,11 @@ def write_analysis_batches(output_dir: Path, chunks_manifest_path: Path, languag
     manifest = {
         "version": 1,
         "batch_size": batch_size,
+        "source_hash": chunks_manifest.get("source_hash"),
+        "chunk_ids": all_chunk_ids,
         "book": book,
         "batches": batch_records,
     }
-    manifest_path = intermediate_dir / "analysis-batches-manifest.json"
     manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return manifest_path
 

--- a/understand-anything-plugin/skills/understand-book/run-understand-book.py
+++ b/understand-anything-plugin/skills/understand-book/run-understand-book.py
@@ -82,6 +82,155 @@ def validate_graph(graph: dict[str, Any]) -> None:
         raise PipelineError(f"ERR_GRAPH_DANGLING_EDGES: {len(dangling)} dangling edges")
 
 
+def split_text_into_chunks(text: str, chunk_size: int) -> list[tuple[int, int, str]]:
+    if chunk_size < 1:
+        raise PipelineError("ERR_CHUNK_SIZE_INVALID: chunk size must be positive")
+    chunks: list[tuple[int, int, str]] = []
+    cursor = 0
+    while cursor < len(text):
+        end = min(cursor + chunk_size, len(text))
+        piece = text[cursor:end]
+        chunks.append((cursor, end, piece))
+        cursor = end
+    return chunks
+
+
+def write_chapter_chunks(output_dir: Path, manifest: dict[str, Any], chunk_size: int) -> Path:
+    intermediate_dir = output_dir / ".understand-anything" / "intermediate"
+    chunks_dir = intermediate_dir / "chunks"
+    chunks_dir.mkdir(parents=True, exist_ok=True)
+
+    book = manifest.get("book", {})
+    chunks: list[dict[str, Any]] = []
+    global_order = 1
+    for chapter in manifest.get("chapters", []):
+        chapter_id = chapter.get("id") or f"ch{global_order:02d}"
+        chapter_title = chapter.get("title") or chapter_id
+        text_path = Path(chapter.get("text_path", ""))
+        if not text_path.is_file():
+            raise PipelineError(f"ERR_CHAPTER_TEXT_NOT_FOUND: {text_path}")
+        text = text_path.read_text(encoding="utf-8")
+        for chunk_index, (char_start, char_end, piece) in enumerate(split_text_into_chunks(text, chunk_size), start=1):
+            chunk_id = f"{chapter_id}-c{chunk_index:03d}"
+            chunk_path = chunks_dir / f"{chunk_id}.md"
+            evidence_anchor = f"{chapter_id}:{char_start}-{char_end}"
+            chunk_path.write_text(
+                "\n".join(
+                    [
+                        f"# Chunk {chunk_id}",
+                        "",
+                        "## Metadata",
+                        "",
+                        f"- Book: {book.get('title') or '未知书名'}",
+                        f"- Chapter: {chapter_title}",
+                        f"- Chapter ID: `{chapter_id}`",
+                        f"- Order: {global_order}",
+                        f"- Char range: `{char_start}-{char_end}`",
+                        f"- Evidence anchor: `{evidence_anchor}`",
+                        "",
+                        "## Evidence",
+                        "",
+                        piece,
+                    ]
+                ).rstrip()
+                + "\n",
+                encoding="utf-8",
+            )
+            chunks.append(
+                {
+                    "id": chunk_id,
+                    "order": global_order,
+                    "chapter_id": chapter_id,
+                    "chapter_title": chapter_title,
+                    "chapter_order": chapter.get("order"),
+                    "char_start": char_start,
+                    "char_end": char_end,
+                    "char_count": len(piece),
+                    "path": str(chunk_path),
+                    "source_text_path": str(text_path),
+                    "evidence_anchor": evidence_anchor,
+                }
+            )
+            global_order += 1
+
+    chunk_manifest = {
+        "version": 1,
+        "chunk_size": chunk_size,
+        "book": book,
+        "chunks": chunks,
+    }
+    manifest_path = intermediate_dir / "chunks-manifest.json"
+    manifest_path.write_text(json.dumps(chunk_manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return manifest_path
+
+
+def write_analysis_batches(output_dir: Path, chunks_manifest_path: Path, language: str, batch_size: int) -> Path:
+    if batch_size < 1:
+        raise PipelineError("ERR_BATCH_SIZE_INVALID: batch size must be positive")
+    intermediate_dir = output_dir / ".understand-anything" / "intermediate"
+    batches_dir = intermediate_dir / "analysis-batches"
+    batches_dir.mkdir(parents=True, exist_ok=True)
+
+    chunks_manifest = json.loads(chunks_manifest_path.read_text(encoding="utf-8"))
+    chunks = chunks_manifest.get("chunks", [])
+    book = chunks_manifest.get("book", {})
+    batch_records: list[dict[str, Any]] = []
+
+    for batch_index, start in enumerate(range(0, len(chunks), batch_size), start=1):
+        selected = chunks[start : start + batch_size]
+        batch_id = f"analysis-batch-{batch_index:03d}"
+        batch_path = batches_dir / f"{batch_id}.json"
+        payload_chunks: list[dict[str, Any]] = []
+        for chunk in selected:
+            chunk_path = Path(chunk.get("path", ""))
+            if not chunk_path.is_file():
+                raise PipelineError(f"ERR_CHUNK_NOT_FOUND: {chunk_path}")
+            payload_chunks.append(
+                {
+                    "id": chunk.get("id"),
+                    "order": chunk.get("order"),
+                    "chapter_id": chunk.get("chapter_id"),
+                    "chapter_title": chunk.get("chapter_title"),
+                    "char_start": chunk.get("char_start"),
+                    "char_end": chunk.get("char_end"),
+                    "evidence_anchor": chunk.get("evidence_anchor"),
+                    "evidence": chunk_path.read_text(encoding="utf-8"),
+                }
+            )
+        payload = {
+            "version": 1,
+            "kind": "understand-book-analysis-batch",
+            "task": "chapter_analysis",
+            "language": language or book.get("language") or "zh",
+            "book": book,
+            "instructions": [
+                "基于 evidence 原文做章节理解，不要编造未出现的信息。",
+                "输出应保留 chunk id 和 evidence_anchor，方便回链校验。",
+                "后续结果文件应写入 analysis-results/analysis-batch-XXX.result.json。",
+            ],
+            "chunks": payload_chunks,
+        }
+        batch_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        batch_records.append(
+            {
+                "id": batch_id,
+                "path": str(batch_path),
+                "chunk_count": len(payload_chunks),
+                "chunk_ids": [chunk.get("id") for chunk in selected],
+            }
+        )
+
+    manifest = {
+        "version": 1,
+        "batch_size": batch_size,
+        "book": book,
+        "batches": batch_records,
+    }
+    manifest_path = intermediate_dir / "analysis-batches-manifest.json"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return manifest_path
+
+
 def write_book_report(output_dir: Path, manifest: dict[str, Any], graph: dict[str, Any]) -> Path:
     book = manifest.get("book", {})
     title = book.get("title") or "未知书名"
@@ -131,6 +280,8 @@ def write_book_report(output_dir: Path, manifest: dict[str, Any], graph: dict[st
             "## 输出文件",
             "",
             "- `wiki/index.md`：书籍 wiki 入口",
+            "- `.understand-anything/intermediate/chunks-manifest.json`：稳定分块清单",
+            "- `.understand-anything/intermediate/analysis-batches/`：LLM-ready 分析输入，不包含模型调用",
             "- `.understand-anything/knowledge-graph.json`：dashboard 图谱",
             "- `.understand-anything/intermediate/book-manifest.json`：EPUB 解析清单",
         ]
@@ -178,33 +329,43 @@ def write_root_outputs(output_dir: Path, manifest: dict[str, Any]) -> tuple[Path
     return root_graph_path, meta_path, report_path
 
 
-def run_pipeline(input_path: Path, output_dir: Path, language: str) -> dict[str, Any]:
+def run_pipeline(input_path: Path, output_dir: Path, language: str, chunk_size: int, batch_size: int) -> dict[str, Any]:
     epub_module = _load_epub_module()
 
     print(f"[understand-book] input: {input_path}")
     print(f"[understand-book] output: {output_dir}")
-    print("[1/4] Convert EPUB to wiki scaffold...")
+    print("[1/6] Convert EPUB to wiki scaffold...")
     manifest = epub_module.ingest_epub(input_path.resolve(), output_dir.resolve(), language)
     print(
-        f"[1/4] Manifest ready: {len(manifest['chapters'])} chapters, "
+        f"[1/6] Manifest ready: {len(manifest['chapters'])} chapters, "
         f"{len(manifest.get('assets', []))} assets"
     )
 
+    print("[2/6] Write deterministic chapter chunks...")
+    chunks_manifest_path = write_chapter_chunks(output_dir, manifest, chunk_size)
+    print(f"[2/6] Chunks: {chunks_manifest_path}")
+
+    print("[3/6] Write LLM-ready analysis batches...")
+    batches_manifest_path = write_analysis_batches(output_dir, chunks_manifest_path, language, batch_size)
+    print(f"[3/6] Analysis batches: {batches_manifest_path}")
+
     wiki_dir = output_dir / "wiki"
-    print("[2/4] Parse wiki scaffold...")
+    print("[4/6] Parse wiki scaffold...")
     run_command([sys.executable, str(_PARSE_KNOWLEDGE), str(wiki_dir)], cwd=output_dir)
 
-    print("[3/4] Merge knowledge graph...")
+    print("[5/6] Merge knowledge graph...")
     run_command([sys.executable, str(_MERGE_KNOWLEDGE), str(wiki_dir)], cwd=output_dir)
 
-    print("[4/4] Save root graph and metadata...")
+    print("[6/6] Save root graph and metadata...")
     graph_path, meta_path, report_path = write_root_outputs(output_dir, manifest)
-    print(f"[4/4] Graph: {graph_path}")
-    print(f"[4/4] Meta: {meta_path}")
-    print(f"[4/4] Report: {report_path}")
+    print(f"[6/6] Graph: {graph_path}")
+    print(f"[6/6] Meta: {meta_path}")
+    print(f"[6/6] Report: {report_path}")
     print("Done.")
     return {
         "manifest": manifest,
+        "chunksManifestPath": str(chunks_manifest_path),
+        "analysisBatchesManifestPath": str(batches_manifest_path),
         "graphPath": str(graph_path),
         "metaPath": str(meta_path),
         "reportPath": str(report_path),
@@ -216,13 +377,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("input", help="Path to .epub file")
     parser.add_argument("--output", default=".understand-book", help="Output directory")
     parser.add_argument("--language", default="", help="Output language override")
+    parser.add_argument("--chunk-size", type=int, default=6000, help="Maximum characters per deterministic analysis chunk")
+    parser.add_argument("--batch-size", type=int, default=8, help="Maximum chunks per LLM-ready analysis batch")
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     try:
-        run_pipeline(Path(args.input), Path(args.output), args.language)
+        run_pipeline(Path(args.input), Path(args.output), args.language, args.chunk_size, args.batch_size)
     except Exception as exc:
         print(str(exc), file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

Adds a deterministic EPUB `/understand-book` pipeline:

- Converts EPUB spine chapters into a wiki scaffold
- Writes dashboard-compatible `.understand-anything/knowledge-graph.json` and `meta.json`
- Generates deterministic chapter chunks and LLM-ready analysis batches
- Validates chunk and analysis-batch caches before reuse; invalid caches rebuild
- Adds optional LLM adapters: `local-command` and DeepSeek-compatible chat completions
- Synthesizes LLM analysis results into `book-analysis.md`, `analysis-synthesis.json`, and `knowledge-graph.enriched.json`
- Hardens reruns so stale generated chapters/assets cannot leak into later graphs
- Reports invalid EPUB zip/XML issues as `ERR_*` messages instead of raw tracebacks

## Test Plan

```bash
python -m py_compile \
  understand-anything-plugin/skills/understand-book/epub-to-wiki.py \
  understand-anything-plugin/skills/understand-book/run-understand-book.py \
  understand-anything-plugin/skills/understand-book/llm-adapters/run-analysis-batches.py \
  understand-anything-plugin/skills/understand-book/llm-adapters/synthesize-analysis-results.py \
  tests/skill/understand_book/test_epub_to_wiki.py \
  tests/skill/understand_book/test_llm_adapters.py \
  tests/skill/understand_book/test_analysis_synthesis.py

python -m unittest \
  tests.skill.understand_book.test_epub_to_wiki \
  tests.skill.understand_book.test_llm_adapters \
  tests.skill.understand_book.test_analysis_synthesis \
  tests.skill.understand.test_merge_batch_graphs -q
```

Result: `Ran 81 tests — OK`.

## Security

- No API keys committed.
- DeepSeek uses `DEEPSEEK_API_KEY` from environment only.
- Branch diff scanned for `sk-*`, bearer tokens, assigned secrets, and the exact provided key fragment: 0 hits.
