### PR TITLE
fix(install): check LASTEXITCODE after git commands in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -87,11 +87,17 @@ function Clone-Or-Update {
     if (Test-Path (Join-Path $RepoDir '.git')) {
         Write-Host "→ Updating existing checkout at $RepoDir"
         git -C $RepoDir pull --ff-only
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "git pull failed (exit code $LASTEXITCODE). Check your network and try again."
+        }
     } else {
         Write-Host "→ Cloning $RepoUrl → $RepoDir"
         $parent = Split-Path -Parent $RepoDir
         if (-not (Test-Path $parent)) { New-Item -ItemType Directory -Path $parent | Out-Null }
         git clone $RepoUrl $RepoDir
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "git clone failed (exit code $LASTEXITCODE). Check your network and try again."
+        }
     }
 }
 
@@ -225,6 +231,9 @@ function Cmd-Update {
         Write-Error "No installation found at $RepoDir. Run install first."
     }
     git -C $RepoDir pull --ff-only
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "git pull failed (exit code $LASTEXITCODE). Check your network and try again."
+    }
     Write-Host '✓ Updated.'
 }
 


### PR DESCRIPTION
PowerShell's $ErrorActionPreference = 'Stop' only applies to cmdlets, not external commands like git. When git clone or git pull fails (e.g. network timeout), the script continued executing and crashed at Get-SkillNames because the repo directory didn't exist.

Add explicit $LASTEXITCODE checks after all git invocations (Clone-Or-Update and Cmd-Update) to halt immediately on failure.

## Summary

<!-- One or two sentences on what this PR changes and why. -->

## Linked issue(s)

<!-- e.g. Closes #123, Refs #456. Leave empty if there's no tracking issue. -->

## How I tested this

<!-- Concrete steps. "Ran the test suite" is fine; "Ran /understand on a 3k-file
Swift repo and verified the dashboard shows non-empty edges" is better. -->

- [ ] unlink the network which you prepare to executing install processing
- [ ] `install.ps1`

## Versioning

<!-- If this PR ships a user-visible behavior change, bump the version in ALL
five manifests per CLAUDE.md. If it's docs/tests/internal-only, leave them
alone and the maintainer will bump on merge. -->

- [ ] main branch
