### PR TITLE
feat: add oh-my-pi (omp) platform to install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,7 @@ Understand-Anything works across multiple AI coding platforms.
 /plugin install understand-anything
 ```
 
-
-### One-line install (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Trae / Nanobot / Kiro)
-
+### One-line install (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / omp / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Trae / Nanobot / Kiro)
 
 **macOS / Linux:**
 ```bash
@@ -217,7 +215,7 @@ The installer clones the repo to `~/.understand-anything/repo` and creates the r
 
 > **Note on invoking skills:** the invocation prefix differs per platform. Most platforms use slash commands (`/understand`), but **Codex uses `$` instead** — type `$understand`, not `/understand`. If neither prefix is recognized on your platform, just ask in plain language: *"Use the understand skill to analyze this project."*
 
-- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`, `nanobot`, `kiro`
+- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `omp`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`, `nanobot`, `kiro`
 - Update later: `./install.sh --update`
 - Uninstall: `./install.sh --uninstall <platform>`
 
@@ -265,6 +263,7 @@ For personal skills (available across all projects), run the `install.sh` above 
 | Antigravity | ✅ Supported | `install.sh antigravity` |
 | Gemini CLI | ✅ Supported | `install.sh gemini` |
 | Pi Agent | ✅ Supported | `install.sh pi` |
+| oh-my-pi / omp | ✅ Supported | `install.sh omp` |
 | Vibe CLI | ✅ Supported | `install.sh vibe` |
 | Hermes | ✅ Supported | `install.sh hermes` |
 | Cline | ✅ Supported | `install.sh cline` |

--- a/READMEs/README.es-ES.md
+++ b/READMEs/README.es-ES.md
@@ -251,6 +251,7 @@ Para habilidades personales (disponibles en todos los proyectos), ejecuta el `in
 | Antigravity | ✅ Soportado | `install.sh antigravity` |
 | Gemini CLI | ✅ Soportado | `install.sh gemini` |
 | Pi Agent | ✅ Soportado | `install.sh pi` |
+| oh-my-pi / omp | ✅ Soportado | `install.sh omp` |
 | Vibe CLI | ✅ Soportado | `install.sh vibe` |
 | Hermes | ✅ Soportado | `install.sh hermes` |
 | Cline | ✅ Soportado | `install.sh cline` |

--- a/READMEs/README.ja-JP.md
+++ b/READMEs/README.ja-JP.md
@@ -263,6 +263,7 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 | Antigravity | ✅ サポート | `install.sh antigravity` |
 | Gemini CLI | ✅ サポート | `install.sh gemini` |
 | Pi Agent | ✅ サポート | `install.sh pi` |
+| oh-my-pi / omp | ✅ サポート | `install.sh omp` |
 | Vibe CLI | ✅ サポート | `install.sh vibe` |
 | Hermes | ✅ サポート | `install.sh hermes` |
 | Cline | ✅ サポート | `install.sh cline` |

--- a/READMEs/README.ko-KR.md
+++ b/READMEs/README.ko-KR.md
@@ -251,6 +251,7 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 | Antigravity | ✅ 지원 | `install.sh antigravity` |
 | Gemini CLI | ✅ 지원 | `install.sh gemini` |
 | Pi Agent | ✅ 지원 | `install.sh pi` |
+| oh-my-pi / omp | ✅ 지원 | `install.sh omp` |
 | Vibe CLI | ✅ 지원 | `install.sh vibe` |
 | Hermes | ✅ 지원 | `install.sh hermes` |
 | Cline | ✅ 지원 | `install.sh cline` |

--- a/READMEs/README.ru-RU.md
+++ b/READMEs/README.ru-RU.md
@@ -252,6 +252,7 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 | Antigravity | ✅ Поддерживается | `install.sh antigravity` |
 | Gemini CLI | ✅ Поддерживается | `install.sh gemini` |
 | Pi Agent | ✅ Поддерживается | `install.sh pi` |
+| oh-my-pi / omp | ✅ Поддерживается | `install.sh omp` |
 | Vibe CLI | ✅ Поддерживается | `install.sh vibe` |
 | Hermes | ✅ Поддерживается | `install.sh hermes` |
 | Cline | ✅ Поддерживается | `install.sh cline` |

--- a/READMEs/README.tr-TR.md
+++ b/READMEs/README.tr-TR.md
@@ -252,6 +252,7 @@ Tüm projelerde kullanmak için kişisel beceri olarak kurmak istersen yukarıda
 | Antigravity | ✅ Destekleniyor | `install.sh antigravity` |
 | Gemini CLI | ✅ Destekleniyor | `install.sh gemini` |
 | Pi Agent | ✅ Destekleniyor | `install.sh pi` |
+| oh-my-pi / omp | ✅ Destekleniyor | `install.sh omp` |
 | Vibe CLI | ✅ Destekleniyor | `install.sh vibe` |
 | Hermes | ✅ Destekleniyor | `install.sh hermes` |
 | Cline | ✅ Destekleniyor | `install.sh cline` |

--- a/READMEs/README.zh-CN.md
+++ b/READMEs/README.zh-CN.md
@@ -251,6 +251,7 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 | Antigravity | ✅ 支持 | `install.sh antigravity` |
 | Gemini CLI | ✅ 支持 | `install.sh gemini` |
 | Pi Agent | ✅ 支持 | `install.sh pi` |
+| oh-my-pi / omp | ✅ 支持 | `install.sh omp` |
 | Vibe CLI | ✅ 支持 | `install.sh vibe` |
 | Hermes | ✅ 支持 | `install.sh hermes` |
 | Cline | ✅ 支持 | `install.sh cline` |

--- a/READMEs/README.zh-TW.md
+++ b/READMEs/README.zh-TW.md
@@ -251,6 +251,7 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 | Antigravity | ✅ 支援 | `install.sh antigravity` |
 | Gemini CLI | ✅ 支援 | `install.sh gemini` |
 | Pi Agent | ✅ 支援 | `install.sh pi` |
+| oh-my-pi / omp | ✅ 支援 | `install.sh omp` |
 | Vibe CLI | ✅ 支援 | `install.sh vibe` |
 | Hermes | ✅ 支援 | `install.sh hermes` |
 | Cline | ✅ 支援 | `install.sh cline` |

--- a/install.ps1
+++ b/install.ps1
@@ -32,6 +32,7 @@ $Platforms = [ordered]@{
     codex       = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     opencode    = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     pi          = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
+    omp         = @{ Target = (Join-Path $HOME '.omp\agent\skills');          Style = 'per-skill' }
     openclaw    = @{ Target = (Join-Path $HOME '.openclaw\skills');           Style = 'folder' }
     antigravity = @{ Target = (Join-Path $HOME '.gemini\antigravity\skills'); Style = 'folder' }
     vibe        = @{ Target = (Join-Path $HOME '.vibe\skills');               Style = 'per-skill' }

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,7 @@ gemini|$HOME/.agents/skills|per-skill
 codex|$HOME/.agents/skills|per-skill
 opencode|$HOME/.agents/skills|per-skill
 pi|$HOME/.agents/skills|per-skill
+omp|$HOME/.omp/agent/skills|per-skill
 openclaw|$HOME/.openclaw/skills|folder
 antigravity|$HOME/.gemini/antigravity/skills|folder
 vibe|$HOME/.vibe/skills|per-skill
@@ -282,6 +283,12 @@ $(platform_ids | sed 's/^/  - /')
 Environment:
   UA_REPO_URL  Override clone URL (default: official repo)
   UA_DIR       Override clone destination (default: \$HOME/.understand-anything/repo)
+
+Notes:
+  omp (oh-my-pi) is a fork of Pi. Skills installed for pi
+  (under ~/.agents/skills) are also discovered by omp automatically.
+  The dedicated 'omp' platform installs to omp's native path
+  (~/.omp/agent/skills) for better isolation.
 USAGE
 }
 


### PR DESCRIPTION
## Summary

Add a dedicated `omp` platform entry to both installers, targeting oh-my-pi's native user-level skills directory (`~/.omp/agent/skills`). oh-my-pi (`omp`) is a fork of Pi (11.6k+ stars) at https://github.com/can1357/oh-my-pi.

omp already discovers skills from `~/.agents/skills` (the existing `pi` target), so `install.sh pi` technically works, but is non-obvious for omp users. This PR adds a dedicated `omp` platform using omp's native path for better isolation and discoverability.

## Linked issue(s)

Closes #424

## How I tested this

- [ ] `pnpm lint`
- [ ] `pnpm --filter @understand-anything/core test`
- [ ] `pnpm test`
- [x] Manual smoke test: verified platform table formatting, confirmed new entry appears in `platforms_table()`, `platform_ids()`, and usage output

## Versioning

- [ ] Version bumped in all five manifests, OR
- [x] N/A — internal/docs-only change
