### PR TITLE
feat: add understand-dash CLI for launching dashboard without AI agent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -177,6 +177,26 @@ link_plugin_root() {
   fi
 }
 
+link_dashboard_cli() {
+  local bin_dir="$HOME/.local/bin"
+  local cli_src="$REPO_DIR/understand-anything-plugin/packages/dashboard/bin/understand-dash.mjs"
+  local cli_link="$bin_dir/understand-dash"
+
+  mkdir -p "$bin_dir"
+  if [[ -L "$cli_link" || -f "$cli_link" ]]; then
+    rm -f "$cli_link"
+  fi
+  ln -s "$cli_src" "$cli_link"
+  chmod +x "$cli_src"
+  printf '  ✓ %s → %s\n' "$cli_link" "$cli_src"
+
+  # Suggest adding ~/.local/bin to PATH if not already present
+  case ":${PATH:-}:" in
+    *:"$bin_dir":*) ;;
+    *) printf '  • Add %s to your PATH:\n    export PATH="%s:$PATH"\n' "$bin_dir" "$bin_dir" ;;
+  esac
+}
+
 cmd_install() {
   local id="$1"
   local row target style
@@ -189,6 +209,8 @@ cmd_install() {
   link_skills "$target" "$style"
   printf -- '→ Linking universal plugin root\n'
   link_plugin_root
+  printf -- '→ Installing dashboard CLI\n'
+  link_dashboard_cli
 
   printf '\n✓ Installed Understand-Anything for %s\n' "$id"
   printf '  Restart your CLI or IDE to pick up the skills.\n'
@@ -210,6 +232,11 @@ cmd_uninstall() {
   if [[ -L "$PLUGIN_LINK" ]]; then
     rm -f "$PLUGIN_LINK"
     printf '  ✓ removed %s\n' "$PLUGIN_LINK"
+  fi
+  local cli_link="$HOME/.local/bin/understand-dash"
+  if [[ -L "$cli_link" ]]; then
+    rm -f "$cli_link"
+    printf '  ✓ removed %s\n' "$cli_link"
   fi
   if [[ -d "$REPO_DIR" ]]; then
     printf '\nThe checkout at %s was kept (other platforms may still use it).\n' "$REPO_DIR"

--- a/understand-anything-plugin/packages/dashboard/bin/understand-dash.mjs
+++ b/understand-anything-plugin/packages/dashboard/bin/understand-dash.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * understand-dash — Launch the Understand Anything knowledge-graph dashboard.
+ *
+ * Usage:
+ *   understand-dash                          # uses current directory
+ *   understand-dash /path/to/project          # specific project
+ *   ACCESS_TOKEN=my-token understand-dash     # custom access token
+ *
+ * Environment:
+ *   ACCESS_TOKEN  Override the dashboard access token (default: "dev")
+ */
+
+import { existsSync, realpathSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DASHBOARD_DIR = resolve(__dirname, "..");
+const DEFAULT_TOKEN = "dev";
+
+function printUsage() {
+  console.error("Usage: understand-dash [project-directory]");
+  console.error("  If no directory is given, uses the current working directory.");
+}
+
+function printError(message) {
+  console.error(`\n  Error: ${message}\n`);
+}
+
+// ── Resolve project directory ──────────────────────────────────────────────
+
+const projectArg = process.argv[2];
+
+if (projectArg === "--help" || projectArg === "-h") {
+  printUsage();
+  process.exit(0);
+}
+
+const rawProjectDir = projectArg || process.cwd();
+
+let projectDir;
+try {
+  projectDir = realpathSync(rawProjectDir);
+} catch {
+  printError(`Cannot resolve path: ${rawProjectDir}`);
+  printUsage();
+  process.exit(1);
+}
+
+// ── Validate knowledge graph ────────────────────────────────────────────────
+
+const graphFile = resolve(projectDir, ".understand-anything", "knowledge-graph.json");
+
+if (!existsSync(graphFile)) {
+  printError(`No knowledge graph found at ${graphFile}`);
+  console.error("  Run 'understand' first to analyze this project.");
+  console.error("");
+  process.exit(1);
+}
+
+// ── Validate dashboard dependencies ─────────────────────────────────────────
+
+const viteBin = resolve(DASHBOARD_DIR, "node_modules", ".bin", "vite");
+
+if (!existsSync(viteBin)) {
+  printError("Dashboard dependencies not installed.");
+  console.error("  Run the following from the repo root:");
+  console.error("");
+  console.error("    pnpm install && pnpm --filter @understand-anything/core build");
+  console.error("");
+  process.exit(1);
+}
+
+// ── Start the dev server ────────────────────────────────────────────────────
+
+const token = process.env.ACCESS_TOKEN || DEFAULT_TOKEN;
+
+const url = `http://127.0.0.1:5173/?token=${token}`;
+
+console.error(`\n  📊  Dashboard for: ${projectDir}`);
+console.error(`     Token: ${token}`);
+console.error(`     URL:   ${url}`);
+console.error(`\n     Open the URL in your browser. Ctrl+C to stop.\n`);
+
+const server = spawn(viteBin, ["--host", "127.0.0.1"], {
+  cwd: DASHBOARD_DIR,
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    ACCESS_TOKEN: token,
+    GRAPH_DIR: projectDir,
+  },
+});
+
+process.on("SIGINT", () => {
+  server.kill("SIGINT");
+});
+
+process.on("SIGTERM", () => {
+  server.kill("SIGTERM");
+});
+
+const exitCode = await new Promise((resolveExit) => {
+  server.on("exit", resolveExit);
+});
+
+process.exit(exitCode);

--- a/understand-anything-plugin/packages/dashboard/package.json
+++ b/understand-anything-plugin/packages/dashboard/package.json
@@ -3,8 +3,10 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "bin": "./bin/understand-dash.mjs",
   "scripts": {
     "dev": "vite",
+    "dashboard": "node bin/understand-dash.mjs",
     "build": "tsc -b && vite build",
     "build:demo": "tsc -b && vite build --config vite.config.demo.ts",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary

Adds a standalone CLI command (`understand-dash`) that launches the knowledge-graph dashboard directly, enabling users to visualize analyzed projects without going through an AI agent. No more copying random access tokens from server output.

## How it works

- `understand-dash` — uses current directory
- `understand-dash /path/to/project` — specific project
- `ACCESS_TOKEN=my-token understand-dash` — custom token (defaults to `dev`)

The script resolves the dashboard dir relative to its own location (works via symlink), validates the knowledge graph exists, checks deps are installed, then starts Vite with `GRAPH_DIR` and `ACCESS_TOKEN` set.

## Changes

1. **`packages/dashboard/bin/understand-dash.mjs`** — the CLI script (109 lines, ESM, zero runtime deps)
2. **`packages/dashboard/package.json`** — added `"bin"` entry + `"dashboard"` pnpm script
3. **`install.sh`** — added `link_dashboard_cli` (symlinks script to `~/.local/bin/understand-dash`) + cleanup in `cmd_uninstall`

## How I tested this

- `node --check` syntax validation
- `--help` flag prints usage
- Error path: missing knowledge graph → helpful message
- Error path: missing node_modules → instructions to run `pnpm install && pnpm --filter @understand-anything/core build`
- `bash -n install.sh` syntax check
- Manual symlink to `~/.local/bin/understand-dash` and all above tests via the symlink

- [ ] `pnpm lint`
- [ ] `pnpm --filter @understand-anything/core test`
- [ ] `pnpm test`
- [x] Manual smoke test (describe above)

## Versioning

- [ ] Version bumped in all five manifests, OR
- [x] N/A — internal-only change (dashboard is `private: true`, install.sh is a tooling script)