### PR TITLE
Fix Windows test compatibility

### DIFF
--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -30,14 +30,14 @@ function setupTree(files) {
  * `extraNodeArgs` is prepended to the node argv before the script path, so
  * tests can pass `--import` loader hooks to force specific failure modes.
  */
-function runScript(projectRoot, input, extraNodeArgs = []) {
+function runScript(projectRoot, input, extraNodeArgs = [], extraEnv = {}) {
   const inputPath = join(projectRoot, 'ua-eim-input.json');
   const outputPath = join(projectRoot, 'ua-eim-output.json');
   writeFileSync(inputPath, JSON.stringify(input), 'utf-8');
   const result = spawnSync(
     'node',
     [...extraNodeArgs, SCRIPT, inputPath, outputPath],
-    { encoding: 'utf-8' },
+    { encoding: 'utf-8', env: { ...process.env, ...extraEnv } },
   );
   let output = null;
   try {
@@ -1692,27 +1692,6 @@ describe('extract-import-map.mjs — tree-sitter init graceful failure', () => {
       'src/lib.ts': `export const x = 1;\n`,
     });
 
-    // Write the loader hook + register module to the temp project root.
-    const hookPath = join(projectRoot, 'ua-eim-fail-hook.mjs');
-    const loaderPath = join(projectRoot, 'ua-eim-fail-loader.mjs');
-    writeFileSync(
-      hookPath,
-      `export async function resolve(specifier, ctx, nextResolve) {\n` +
-      `  if (specifier === 'web-tree-sitter') {\n` +
-      `    throw new Error('synthetic: web-tree-sitter unavailable in test');\n` +
-      `  }\n` +
-      `  return nextResolve(specifier, ctx);\n` +
-      `}\n`,
-      'utf-8',
-    );
-    writeFileSync(
-      loaderPath,
-      `import { register } from 'node:module';\n` +
-      `import { pathToFileURL } from 'node:url';\n` +
-      `register(pathToFileURL(${JSON.stringify(hookPath)}).href);\n`,
-      'utf-8',
-    );
-
     const result = runScript(
       projectRoot,
       {
@@ -1722,7 +1701,8 @@ describe('extract-import-map.mjs — tree-sitter init graceful failure', () => {
           { path: 'src/lib.ts', language: 'typescript', fileCategory: 'code' },
         ],
       },
-      ['--import', loaderPath],
+      [],
+      { UA_EXTRACT_IMPORT_MAP_FORCE_TREE_SITTER_THROW: '1' },
     );
 
     expect(result.status).toBe(0);

--- a/understand-anything-plugin/skills/understand-domain/SKILL.md
+++ b/understand-anything-plugin/skills/understand-domain/SKILL.md
@@ -23,11 +23,12 @@ Set `PROJECT_ROOT` to the current working directory.
 **Worktree redirect.** If `PROJECT_ROOT` is inside a git worktree (not the main checkout), redirect output to the main repository root. Worktrees managed by Claude Code are ephemeral — `.understand-anything/` written there is destroyed when the session ends, taking the domain graph with it (issue #133). Detect a worktree by comparing `git rev-parse --git-dir` against `git rev-parse --git-common-dir`; in a normal checkout or submodule they resolve to the same path, in a worktree they differ and the parent of `--git-common-dir` is the main repo root.
 
 ```bash
+ua_pwd_p() { pwd -W 2>/dev/null || pwd -P; }
 COMMON_DIR=$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)
 GIT_DIR=$(git -C "$PROJECT_ROOT" rev-parse --git-dir 2>/dev/null)
 if [ -n "$COMMON_DIR" ] && [ -n "$GIT_DIR" ]; then
-  COMMON_ABS=$(cd "$PROJECT_ROOT" && cd "$COMMON_DIR" 2>/dev/null && pwd -P)
-  GIT_ABS=$(cd "$PROJECT_ROOT" && cd "$GIT_DIR" 2>/dev/null && pwd -P)
+  COMMON_ABS=$(cd "$PROJECT_ROOT" && cd "$COMMON_DIR" 2>/dev/null && ua_pwd_p)
+  GIT_ABS=$(cd "$PROJECT_ROOT" && cd "$GIT_DIR" 2>/dev/null && ua_pwd_p)
   if [ -n "$COMMON_ABS" ] && [ "$COMMON_ABS" != "$GIT_ABS" ]; then
     MAIN_ROOT=$(dirname "$COMMON_ABS")
     if [ -d "$MAIN_ROOT" ] && [ "${UNDERSTAND_NO_WORKTREE_REDIRECT:-0}" != "1" ]; then

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -52,11 +52,12 @@ Determine whether to run a full analysis or incremental update.
    - **Worktree redirect.** If `PROJECT_ROOT` is inside a git worktree (not the main checkout), redirect output to the main repository root. Worktrees managed by Claude Code are ephemeral — `.understand-anything/` written there is destroyed when the session ends, taking the knowledge graph with it (issue #133). Detect a worktree by comparing `git rev-parse --git-dir` against `git rev-parse --git-common-dir`; in a normal checkout or submodule they resolve to the same path, in a worktree they differ and the parent of `--git-common-dir` is the main repo root.
 
      ```bash
+     ua_pwd_p() { pwd -W 2>/dev/null || pwd -P; }
      COMMON_DIR=$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)
      GIT_DIR=$(git -C "$PROJECT_ROOT" rev-parse --git-dir 2>/dev/null)
      if [ -n "$COMMON_DIR" ] && [ -n "$GIT_DIR" ]; then
-       COMMON_ABS=$(cd "$PROJECT_ROOT" && cd "$COMMON_DIR" 2>/dev/null && pwd -P)
-       GIT_ABS=$(cd "$PROJECT_ROOT" && cd "$GIT_DIR" 2>/dev/null && pwd -P)
+       COMMON_ABS=$(cd "$PROJECT_ROOT" && cd "$COMMON_DIR" 2>/dev/null && ua_pwd_p)
+       GIT_ABS=$(cd "$PROJECT_ROOT" && cd "$GIT_DIR" 2>/dev/null && ua_pwd_p)
        if [ -n "$COMMON_ABS" ] && [ "$COMMON_ABS" != "$GIT_ABS" ]; then
          MAIN_ROOT=$(dirname "$COMMON_ABS")
          if [ -d "$MAIN_ROOT" ] && [ "${UNDERSTAND_NO_WORKTREE_REDIRECT:-0}" != "1" ]; then

--- a/understand-anything-plugin/skills/understand/extract-import-map.mjs
+++ b/understand-anything-plugin/skills/understand/extract-import-map.mjs
@@ -1504,6 +1504,9 @@ async function main() {
   let registry = null;
   let treeSitterReady = false;
   try {
+    if (process.env.UA_EXTRACT_IMPORT_MAP_FORCE_TREE_SITTER_THROW === '1') {
+      throw new Error('forced throw via UA_EXTRACT_IMPORT_MAP_FORCE_TREE_SITTER_THROW');
+    }
     const tsConfigs = builtinLanguageConfigs.filter(c => c.treeSitter);
     const tsPlugin = new TreeSitterPlugin(tsConfigs);
     await tsPlugin.init();

--- a/understand-anything-plugin/skills/understand/extract-structure-result.mjs
+++ b/understand-anything-plugin/skills/understand/extract-structure-result.mjs
@@ -1,0 +1,126 @@
+// Result builder: maps StructuralAnalysis to the expected output schema.
+// Pure function, no I/O; shared by the CLI and unit tests.
+export function buildResult(file, totalLines, nonEmptyLines, analysis, callGraph, batchImportData) {
+  const base = {
+    path: file.path,
+    language: file.language,
+    fileCategory: file.fileCategory,
+    totalLines,
+    nonEmptyLines,
+  };
+
+  if (!analysis) {
+    base.metrics = {};
+    return base;
+  }
+
+  if (analysis.functions && analysis.functions.length > 0) {
+    base.functions = analysis.functions.map(fn => ({
+      name: fn.name,
+      startLine: fn.lineRange[0],
+      endLine: fn.lineRange[1],
+      params: fn.params || [],
+    }));
+  }
+
+  if (analysis.classes && analysis.classes.length > 0) {
+    base.classes = analysis.classes.map(cls => ({
+      name: cls.name,
+      startLine: cls.lineRange[0],
+      endLine: cls.lineRange[1],
+      methods: cls.methods || [],
+      properties: cls.properties || [],
+    }));
+  }
+
+  if (analysis.exports && analysis.exports.length > 0) {
+    base.exports = analysis.exports.map(exp => ({
+      name: exp.name,
+      line: exp.lineNumber,
+      isDefault: exp.isDefault === true,
+    }));
+  }
+
+  if (analysis.sections && analysis.sections.length > 0) {
+    base.sections = analysis.sections.map(s => ({
+      heading: s.name,
+      level: s.level,
+      line: s.lineRange[0],
+    }));
+  }
+
+  if (analysis.definitions && analysis.definitions.length > 0) {
+    base.definitions = analysis.definitions.map(d => ({
+      name: d.name,
+      kind: d.kind,
+      fields: d.fields || [],
+      startLine: d.lineRange[0],
+      endLine: d.lineRange[1],
+    }));
+  }
+
+  if (analysis.services && analysis.services.length > 0) {
+    base.services = analysis.services.map(s => ({
+      name: s.name,
+      image: s.image,
+      ports: s.ports || [],
+      ...(s.lineRange ? { startLine: s.lineRange[0], endLine: s.lineRange[1] } : {}),
+    }));
+  }
+
+  if (analysis.endpoints && analysis.endpoints.length > 0) {
+    base.endpoints = analysis.endpoints.map(e => ({
+      method: e.method,
+      path: e.path,
+      startLine: e.lineRange[0],
+      endLine: e.lineRange[1],
+    }));
+  }
+
+  if (analysis.steps && analysis.steps.length > 0) {
+    base.steps = analysis.steps.map(s => ({
+      name: s.name,
+      startLine: s.lineRange[0],
+      endLine: s.lineRange[1],
+    }));
+  }
+
+  if (analysis.resources && analysis.resources.length > 0) {
+    base.resources = analysis.resources.map(r => ({
+      name: r.name,
+      kind: r.kind,
+      startLine: r.lineRange[0],
+      endLine: r.lineRange[1],
+    }));
+  }
+
+  if (callGraph && callGraph.length > 0) {
+    base.callGraph = callGraph;
+  }
+
+  const metrics = {};
+  const importPaths = batchImportData?.[file.path];
+  if (importPaths && importPaths.length > 0) {
+    metrics.importCount = importPaths.length;
+  } else if (analysis.imports) {
+    const internal = analysis.imports.filter(imp => {
+      const src = imp?.source ?? '';
+      return src.startsWith('.');
+    });
+    metrics.importCount = internal.length;
+  }
+
+  if (analysis.exports) metrics.exportCount = analysis.exports.length;
+  if (analysis.functions) metrics.functionCount = analysis.functions.length;
+  if (analysis.classes) metrics.classCount = analysis.classes.length;
+  if (analysis.sections) metrics.sectionCount = analysis.sections.length;
+  if (analysis.definitions) metrics.definitionCount = analysis.definitions.length;
+  if (analysis.services) metrics.serviceCount = analysis.services.length;
+  if (analysis.endpoints) metrics.endpointCount = analysis.endpoints.length;
+  if (analysis.steps) metrics.stepCount = analysis.steps.length;
+  if (analysis.resources) metrics.resourceCount = analysis.resources.length;
+
+  base.metrics = metrics;
+
+  return base;
+}

--- a/understand-anything-plugin/skills/understand/extract-structure.mjs
+++ b/understand-anything-plugin/skills/understand/extract-structure.mjs
@@ -20,6 +20,7 @@ import { createRequire } from 'node:module';
 import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { buildResult as buildResultShared } from './extract-structure-result.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // skills/understand/ -> plugin root is two dirs up
@@ -120,7 +121,7 @@ async function main() {
     }
 
     // Build result object
-    const result = buildResult(file, totalLines, nonEmptyLines, analysis, callGraph, batchImportData);
+    const result = buildResultShared(file, totalLines, nonEmptyLines, analysis, callGraph, batchImportData);
     results.push(result);
   }
 

--- a/understand-anything-plugin/src/__tests__/extract-structure.test.mjs
+++ b/understand-anything-plugin/src/__tests__/extract-structure.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildResult } from "../../skills/understand/extract-structure.mjs";
+import { buildResult } from "../../skills/understand/extract-structure-result.mjs";
 
 const file = (overrides = {}) => ({
   path: "src/foo.py",

--- a/understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs
+++ b/understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs
@@ -8,12 +8,13 @@ import { dirname, resolve } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MERGE_SCRIPT = resolve(__dirname, "../../skills/understand/merge-batch-graphs.py");
+const PYTHON = process.platform === "win32" ? "python" : "python3";
 
 let projectRoot;
 let intermediateDir;
 
 function runMerge() {
-  const result = spawnSync("python3", [MERGE_SCRIPT, projectRoot], {
+  const result = spawnSync(PYTHON, [MERGE_SCRIPT, projectRoot], {
     encoding: "utf-8",
   });
   if (result.status !== 0) {
@@ -163,7 +164,7 @@ describe("merge-batch-graphs.py imports recovery", () => {
 
     const { assembled, stderr } = runMerge();
     expect(assembled.edges.filter((e) => e.type === "imports")).toHaveLength(1);
-    expect(stderr).toContain("importMap recovery skipped — scan-result.json not found");
+    expect(stderr).toMatch(/importMap recovery skipped .* scan-result\.json not found/);
   });
 
   it("never produces self-import edges", () => {

--- a/understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs
+++ b/understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs
@@ -11,12 +11,17 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync, realpathSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+function normalizePathForAssert(path) {
+  return path.replaceAll("\\", "/");
+}
+
 const RESOLVE_SNIPPET = `
+ua_pwd_p() { pwd -W 2>/dev/null || pwd -P; }
 COMMON_DIR=$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)
 GIT_DIR=$(git -C "$PROJECT_ROOT" rev-parse --git-dir 2>/dev/null)
 if [ -n "$COMMON_DIR" ] && [ -n "$GIT_DIR" ]; then
-  COMMON_ABS=$(cd "$PROJECT_ROOT" && cd "$COMMON_DIR" 2>/dev/null && pwd -P)
-  GIT_ABS=$(cd "$PROJECT_ROOT" && cd "$GIT_DIR" 2>/dev/null && pwd -P)
+  COMMON_ABS=$(cd "$PROJECT_ROOT" && cd "$COMMON_DIR" 2>/dev/null && ua_pwd_p)
+  GIT_ABS=$(cd "$PROJECT_ROOT" && cd "$GIT_DIR" 2>/dev/null && ua_pwd_p)
   if [ -n "$COMMON_ABS" ] && [ "$COMMON_ABS" != "$GIT_ABS" ]; then
     MAIN_ROOT=$(dirname "$COMMON_ABS")
     if [ -d "$MAIN_ROOT" ] && [ "\${UNDERSTAND_NO_WORKTREE_REDIRECT:-0}" != "1" ]; then
@@ -64,19 +69,19 @@ afterAll(() => {
 
 describe("worktree-redirect snippet (issue #133)", () => {
   it("leaves PROJECT_ROOT alone in a normal checkout", () => {
-    expect(runResolve(mainRepo)).toBe(mainRepo);
+    expect(normalizePathForAssert(runResolve(mainRepo))).toBe(normalizePathForAssert(mainRepo));
   });
 
   it("redirects PROJECT_ROOT to the main repo when started in a worktree", () => {
-    expect(runResolve(worktree)).toBe(mainRepo);
+    expect(normalizePathForAssert(runResolve(worktree))).toBe(normalizePathForAssert(mainRepo));
   });
 
   it("redirects from a subdirectory inside a worktree", () => {
-    expect(runResolve(subdir)).toBe(mainRepo);
+    expect(normalizePathForAssert(runResolve(subdir))).toBe(normalizePathForAssert(mainRepo));
   });
 
   it("respects UNDERSTAND_NO_WORKTREE_REDIRECT=1", () => {
-    expect(runResolve(worktree, { UNDERSTAND_NO_WORKTREE_REDIRECT: "1" })).toBe(worktree);
+    expect(normalizePathForAssert(runResolve(worktree, { UNDERSTAND_NO_WORKTREE_REDIRECT: "1" }))).toBe(normalizePathForAssert(worktree));
   });
 
   it("leaves PROJECT_ROOT alone when not inside a git repo", () => {
@@ -84,6 +89,6 @@ describe("worktree-redirect snippet (issue #133)", () => {
     // inside a parent git repo (e.g. when /tmp is symlinked into one).
     const nonGit = join(tmpRoot, "no-git");
     mkdirSync(nonGit, { recursive: true });
-    expect(runResolve(nonGit)).toBe(nonGit);
+    expect(normalizePathForAssert(runResolve(nonGit))).toBe(normalizePathForAssert(nonGit));
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ import { defineConfig } from 'vitest/config';
 // files are excluded here to avoid double-counting.
 export default defineConfig({
   test: {
+    testTimeout: process.platform === 'win32' ? 60000 : 5000,
     include: [
       'tests/**/*.test.{js,mjs,ts}',
       'understand-anything-plugin/src/**/*.test.{js,mjs,ts}',


### PR DESCRIPTION
Summary:
- Make Windows test timeouts less brittle
- Normalize worktree path handling across Windows/Git Bash
- Avoid loader-hook fragility in import-map fallback tests
- Add a side-effect-free structure-result helper for tests

Verification:
- pnpm.cmd test
- pnpm.cmd build
- pnpm.cmd lint