### PR TITLE
fix(skills): quote argument-hint values so YAML parses them as strings

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": {
     "name": "Egonex"
   },

--- a/.copilot-plugin/plugin.json
+++ b/.copilot-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": {
     "name": "Egonex"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "understand-anything",
   "displayName": "Understand Anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": {
     "name": "Egonex"
   },

--- a/understand-anything-plugin/.claude-plugin/plugin.json
+++ b/understand-anything-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": {
     "name": "Egonex"
   },

--- a/understand-anything-plugin/package.json
+++ b/understand-anything-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understand-anything/skill",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/understand-anything-plugin/skills/understand-chat/SKILL.md
+++ b/understand-anything-plugin/skills/understand-chat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand-chat
 description: Use when you need to ask questions about a codebase or understand code using a knowledge graph
-argument-hint: [query]
+argument-hint: "[query]"
 ---
 
 # /understand-chat

--- a/understand-anything-plugin/skills/understand-dashboard/SKILL.md
+++ b/understand-anything-plugin/skills/understand-dashboard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand-dashboard
 description: Launch the interactive web dashboard to visualize a codebase's knowledge graph
-argument-hint: [project-path]
+argument-hint: "[project-path]"
 ---
 
 # /understand-dashboard

--- a/understand-anything-plugin/skills/understand-domain/SKILL.md
+++ b/understand-anything-plugin/skills/understand-domain/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand-domain
 description: Extract business domain knowledge from a codebase and generate an interactive domain flow graph. Works standalone (lightweight scan) or derives from an existing /understand knowledge graph.
-argument-hint: [--full]
+argument-hint: "[--full]"
 ---
 
 # /understand-domain

--- a/understand-anything-plugin/skills/understand-explain/SKILL.md
+++ b/understand-anything-plugin/skills/understand-explain/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand-explain
 description: Use when you need a deep-dive explanation of a specific file, function, or module in the codebase
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 # /understand-explain

--- a/understand-anything-plugin/skills/understand-knowledge/SKILL.md
+++ b/understand-anything-plugin/skills/understand-knowledge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand-knowledge
 description: Analyze a Karpathy-pattern LLM wiki knowledge base and generate an interactive knowledge graph with entity extraction, implicit relationships, and topic clustering.
-argument-hint: [wiki-directory]
+argument-hint: "[wiki-directory]"
 ---
 
 # /understand-knowledge

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand
 description: Analyze a codebase to produce an interactive knowledge graph for understanding architecture, components, and relationships
-argument-hint: ["[path] [--full|--auto-update|--no-auto-update|--review|--language <lang>]"]
+argument-hint: "[path] [--full|--auto-update|--no-auto-update|--review|--language <lang>]"
 ---
 
 # /understand


### PR DESCRIPTION
## Summary

Fixes #506.

Six skills fail to load with `argument-hint must be a string` because the `argument-hint` values use bare YAML bracket syntax which YAML parses as arrays instead of strings.

## Changes

**2 commits:**

1. **`fix(skills)`** — Quote all `argument-hint` values in the 6 affected `SKILL.md` files so YAML treats them as strings:

| File | Before | After |
|------|--------|-------|
| `understand/SKILL.md` | `["[path] [--full\|...]"]` | `"[path] [--full\|...]"` |
| `understand-chat/SKILL.md` | `[query]` | `"[query]"` |
| `understand-dashboard/SKILL.md` | `[project-path]` | `"[project-path]"` |
| `understand-domain/SKILL.md` | `[--full]` | `"[--full]"` |
| `understand-explain/SKILL.md` | `[file-path]` | `"[file-path]"` |
| `understand-knowledge/SKILL.md` | `[wiki-directory]` | `"[wiki-directory]"` |

Skills without `argument-hint` (`understand-diff`, `understand-onboard`) are unaffected and already load correctly.

2. **`chore`** — Bump version `2.8.1 → 2.8.2` across all 5 version files per CLAUDE.md convention.

## PR Checklist

- [x] Commit messages follow convention (`fix:` / `chore:`)
- [x] Branch name follows convention (`fix/skill-argument-hint-yaml-string`)
- [x] PR description explains what changed and why
- [x] Linked to issue #506
- [x] Version bumped in all 5 files (2.8.1 → 2.8.2)
- [x] Tests/lint: this change is **pure YAML frontmatter** in `SKILL.md` files — no TypeScript code was modified. ESLint and Vitest only cover `.ts`/`.tsx` files; neither will flag this change. CI will confirm.
- [x] No debug code, no console.log
- [x] Branch is up to date with main