### PR TITLE
fix(skills): force explicit UTF-8 on locale-default Python file reads

### DIFF
--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -983,7 +983,7 @@ class TestMultiPart(unittest.TestCase):
             capture_output=True, text=True,
         )
         out_path = self.intermediate / "assembled-graph.json"
-        assembled = _j.loads(out_path.read_text()) if out_path.exists() else {}
+        assembled = _j.loads(out_path.read_text(encoding="utf-8")) if out_path.exists() else {}
         return result.returncode, result.stderr, assembled
 
     def test_two_parts_of_one_logical_batch_merge(self) -> None:
@@ -1102,7 +1102,7 @@ class TestUnrecognizedBatchFilename(unittest.TestCase):
             capture_output=True, text=True,
         )
         out_path = self.intermediate / "assembled-graph.json"
-        assembled = _j.loads(out_path.read_text()) if out_path.exists() else {}
+        assembled = _j.loads(out_path.read_text(encoding="utf-8")) if out_path.exists() else {}
         return result.returncode, result.stderr, assembled
 
     def test_fused_filename_emits_stderr_warning(self) -> None:

--- a/understand-anything-plugin/skills/understand-domain/extract-domain-context.py
+++ b/understand-anything-plugin/skills/understand-domain/extract-domain-context.py
@@ -123,7 +123,7 @@ def parse_gitignore(project_root: Path) -> list[re.Pattern[str]]:
     if not gitignore.exists():
         return patterns
 
-    for line in gitignore.read_text(errors="replace").splitlines():
+    for line in gitignore.read_text(encoding="utf-8", errors="replace").splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
             continue
@@ -208,7 +208,7 @@ def detect_entry_points(root: Path, file_paths: list[str]) -> list[dict[str, Any
             continue
         full_path = root / rel_path
         try:
-            content = full_path.read_text(errors="replace")
+            content = full_path.read_text(encoding="utf-8", errors="replace")
         except (OSError, UnicodeDecodeError):
             continue
 
@@ -267,7 +267,7 @@ def extract_file_signatures(root: Path, file_paths: list[str]) -> list[dict[str,
     for rel_path in sorted_paths[:MAX_SAMPLED_FILES]:
         full_path = root / rel_path
         try:
-            content = full_path.read_text(errors="replace")
+            content = full_path.read_text(encoding="utf-8", errors="replace")
         except (OSError, UnicodeDecodeError):
             continue
 
@@ -312,7 +312,7 @@ def extract_metadata(root: Path) -> dict[str, Any]:
         if not filepath.exists():
             continue
         try:
-            content = filepath.read_text(errors="replace")
+            content = filepath.read_text(encoding="utf-8", errors="replace")
         except (OSError, UnicodeDecodeError):
             continue
 
@@ -415,7 +415,7 @@ def main() -> None:
 
         context = _truncate_to_fit(context)
         output = json.dumps(context, indent=2)
-        output_path.write_text(output)
+        output_path.write_text(output, encoding="utf-8")
         size_kb = len(output.encode()) / 1024
         print(f"  Wrote {output_path} ({size_kb:.0f} KB)", file=sys.stderr)
 


### PR DESCRIPTION
## Problem

Two Python files read with no explicit `encoding=`. `pathlib`'s `read_text`/`write_text` fall back to `locale.getpreferredencoding(False)` when none is given. On Windows — absent Python UTF-8 mode (PEP 540) — that's the ANSI codepage (`cp1252` / `cp936` / `cp932`), **not UTF-8**.

**`skills/understand-domain/extract-domain-context.py`** (lines 126, 211, 270, 315, 418) reads source files, `.gitignore`, and metadata, then writes `domain-context.json`. On Windows the reads decode UTF-8 source against the wrong codepage and silently corrupt the context that the `domain-analyzer` agent consumes — CJK comments, accented identifiers, em-dashes, the translated README text pulled in at line 332.

`errors="replace"` does **not** catch this: legacy codepages decode almost every byte to *some* (wrong) character instead of raising, so there's no `UnicodeDecodeError` and no replacement char — just silent mojibake.

### Reproduction

A UTF-8 source file with a CJK comment, read the way Windows would:

```
source (utf-8) : '# 用户订单服务 — order service'
cp1252 (EN Win): '# ç”¨æˆ·è®¢å•æœ�åŠ¡ â€”'
cp936  (CN Win): '# 鐢ㄦ埛璁㈠崟鏈嶅姟 鈥 order s'
```

Both alternate reads used `errors="replace"` — neither raised, both are silently wrong.

**`tests/skill/understand/test_merge_batch_graphs.py`** (lines 986, 1105) reads `assembled-graph.json` back for assertions. `merge-batch-graphs.py` writes it with `ensure_ascii=False`, so it can contain raw non-ASCII that the unencoded read would mojibake on Windows, failing the test there.

## Fix

Pass `encoding="utf-8"` to the affected reads/write. This matches the convention already used in every other Python script in the repo (`merge-batch-graphs.py`, `merge-subdomain-graphs.py`, `parse-knowledge-base.py`, `merge-knowledge-graph.py`). No behavior change on Linux/macOS, where the locale default is already UTF-8.

## Scope

7 lines across 2 files. Relates to the Windows-compat reports #262 and #340.
