### PR TITLE
test: make Windows test runs portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,19 @@ concurrency:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
       - uses: actions/setup-node@v4
         with:
@@ -48,3 +56,6 @@ jobs:
 
       - name: Test skill
         run: pnpm test
+
+      - name: Test Python skill helpers
+        run: python -m unittest tests.skill.understand.test_merge_batch_graphs -v

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,18 @@ packages:
   - 'understand-anything-plugin/packages/*'
   - 'understand-anything-plugin'
   - 'homepage'
+allowBuilds:
+  '@tree-sitter-grammars/tree-sitter-kotlin': true
+  esbuild: true
+  sharp: true
+  tree-sitter-c: true
+  tree-sitter-c-sharp: true
+  tree-sitter-cpp: true
+  tree-sitter-go: true
+  tree-sitter-java: true
+  tree-sitter-javascript: true
+  tree-sitter-php: true
+  tree-sitter-python: true
+  tree-sitter-ruby: true
+  tree-sitter-rust: true
+  tree-sitter-typescript: true

--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = resolve(__dirname, '../../../understand-anything-plugin/skills/understand/extract-import-map.mjs');
@@ -1722,7 +1722,7 @@ describe('extract-import-map.mjs — tree-sitter init graceful failure', () => {
           { path: 'src/lib.ts', language: 'typescript', fileCategory: 'code' },
         ],
       },
-      ['--import', loaderPath],
+      ['--import', pathToFileURL(loaderPath).href],
     );
 
     expect(result.status).toBe(0);

--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -979,7 +979,7 @@ class TestMultiPart(unittest.TestCase):
         import subprocess
         import json as _j
         result = subprocess.run(
-            ["python3", str(_MODULE_PATH), str(self.tmp)],
+            [sys.executable, str(_MODULE_PATH), str(self.tmp)],
             capture_output=True, text=True,
         )
         out_path = self.intermediate / "assembled-graph.json"
@@ -1098,7 +1098,7 @@ class TestUnrecognizedBatchFilename(unittest.TestCase):
         import subprocess
         import json as _j
         result = subprocess.run(
-            ["python3", str(_MODULE_PATH), str(self.tmp)],
+            [sys.executable, str(_MODULE_PATH), str(self.tmp)],
             capture_output=True, text=True,
         )
         out_path = self.intermediate / "assembled-graph.json"

--- a/understand-anything-plugin/pnpm-workspace.yaml
+++ b/understand-anything-plugin/pnpm-workspace.yaml
@@ -1,2 +1,16 @@
 packages:
   - "packages/*"
+allowBuilds:
+  '@tree-sitter-grammars/tree-sitter-kotlin': true
+  esbuild: true
+  tree-sitter-c: true
+  tree-sitter-c-sharp: true
+  tree-sitter-cpp: true
+  tree-sitter-go: true
+  tree-sitter-java: true
+  tree-sitter-javascript: true
+  tree-sitter-php: true
+  tree-sitter-python: true
+  tree-sitter-ruby: true
+  tree-sitter-rust: true
+  tree-sitter-typescript: true

--- a/understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs
+++ b/understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs
@@ -8,12 +8,28 @@ import { dirname, resolve } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MERGE_SCRIPT = resolve(__dirname, "../../skills/understand/merge-batch-graphs.py");
+const PYTHON = findPython();
 
 let projectRoot;
 let intermediateDir;
 
+function findPython() {
+  const candidates = [
+    { command: "python3", args: [] },
+    { command: "python", args: [] },
+    { command: "py", args: ["-3"] },
+  ];
+  for (const candidate of candidates) {
+    const probe = spawnSync(candidate.command, [...candidate.args, "--version"], {
+      encoding: "utf-8",
+    });
+    if (!probe.error && probe.status === 0) return candidate;
+  }
+  throw new Error("Python 3 is required to run merge-batch-graphs.py tests");
+}
+
 function runMerge() {
-  const result = spawnSync("python3", [MERGE_SCRIPT, projectRoot], {
+  const result = spawnSync(PYTHON.command, [...PYTHON.args, MERGE_SCRIPT, projectRoot], {
     encoding: "utf-8",
   });
   if (result.status !== 0) {
@@ -163,7 +179,8 @@ describe("merge-batch-graphs.py imports recovery", () => {
 
     const { assembled, stderr } = runMerge();
     expect(assembled.edges.filter((e) => e.type === "imports")).toHaveLength(1);
-    expect(stderr).toContain("importMap recovery skipped — scan-result.json not found");
+    expect(stderr).toContain("importMap recovery skipped");
+    expect(stderr).toContain("scan-result.json not found");
   });
 
   it("never produces self-import edges", () => {

--- a/understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs
+++ b/understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs
@@ -6,7 +6,7 @@
 // below — there is no shared script to source (per-skill convention in this repo).
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -27,6 +27,10 @@ fi
 echo "$PROJECT_ROOT"
 `;
 
+const bashProbe = spawnSync("bash", ["--version"], { encoding: "utf8" });
+const hasBash = !bashProbe.error && bashProbe.status === 0;
+const describeWithBash = hasBash ? describe : describe.skip;
+
 function runResolve(projectRoot, env = {}) {
   // No `set -e` — the snippet relies on `git ... 2>/dev/null` returning empty
   // strings when not in a git repo; `set -e` would short-circuit instead.
@@ -42,27 +46,27 @@ let mainRepo;
 let worktree;
 let subdir;
 
-beforeAll(() => {
-  tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), "ua-wt-")));
-  mainRepo = join(tmpRoot, "main");
-  worktree = join(tmpRoot, "wt");
-  subdir = join(worktree, "src", "deep");
+describeWithBash("worktree-redirect snippet (issue #133)", () => {
+  beforeAll(() => {
+    tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), "ua-wt-")));
+    mainRepo = join(tmpRoot, "main");
+    worktree = join(tmpRoot, "wt");
+    subdir = join(worktree, "src", "deep");
 
-  execFileSync("git", ["init", "-q", "-b", "main", mainRepo]);
-  execFileSync("git", ["-C", mainRepo, "config", "user.email", "t@t"]);
-  execFileSync("git", ["-C", mainRepo, "config", "user.name", "t"]);
-  writeFileSync(join(mainRepo, "README.md"), "main\n");
-  execFileSync("git", ["-C", mainRepo, "add", "."]);
-  execFileSync("git", ["-C", mainRepo, "commit", "-q", "-m", "init"]);
-  execFileSync("git", ["-C", mainRepo, "worktree", "add", "-q", worktree]);
-  mkdirSync(subdir, { recursive: true });
-});
+    execFileSync("git", ["init", "-q", "-b", "main", mainRepo]);
+    execFileSync("git", ["-C", mainRepo, "config", "user.email", "t@t"]);
+    execFileSync("git", ["-C", mainRepo, "config", "user.name", "t"]);
+    writeFileSync(join(mainRepo, "README.md"), "main\n");
+    execFileSync("git", ["-C", mainRepo, "add", "."]);
+    execFileSync("git", ["-C", mainRepo, "commit", "-q", "-m", "init"]);
+    execFileSync("git", ["-C", mainRepo, "worktree", "add", "-q", worktree]);
+    mkdirSync(subdir, { recursive: true });
+  });
 
-afterAll(() => {
-  if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
-});
+  afterAll(() => {
+    if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+  });
 
-describe("worktree-redirect snippet (issue #133)", () => {
   it("leaves PROJECT_ROOT alone in a normal checkout", () => {
     expect(runResolve(mainRepo)).toBe(mainRepo);
   });


### PR DESCRIPTION
## What changed
- Resolve Python subprocesses without assuming `python3` exists on Windows.
- Pass Node `--import` loader paths as `file://` URLs so Windows paths load correctly.
- Skip Bash-specific worktree tests when Bash is unavailable.
- Add Windows CI coverage and run Python skill helper tests in CI.
- Add pnpm 11 build allow-lists for workspace installs.

## Why
This fixes the Windows portability failures reported in #530 while keeping the existing Linux path covered by CI.

Closes #530

## Screenshots
N/A. This PR only changes tests, CI, and package-manager configuration; it does not change the dashboard or any user-facing UI.

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm --filter @understand-anything/core build`
- `pnpm --filter @understand-anything/skill build`
- `pnpm --filter @understand-anything/core test`
- `pnpm test`
- `python -m unittest tests.skill.understand.test_merge_batch_graphs -v`
- `pnpm vitest run understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs --reporter=verbose`
- `pnpm vitest run understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs --reporter=verbose` (skipped locally because Bash is unavailable)
- `pnpm vitest run tests/skill/understand/test_extract_import_map.test.mjs -t "tree-sitter init graceful failure" --reporter=verbose`

## Contributor checklist
- [x] PR title clearly describes the change.
- [x] Linked to the related issue: #530.
- [x] Branch is based on the current `main` branch (`54754a6`).
- [x] Tests, lint, and builds pass locally.
- [x] No debug statements were added.
- [x] Screenshots are not applicable because this is a test/CI-only change.
- [x] Documentation updates are not needed for this test/CI-only change.