### PR TITLE
fix: repair Windows skill test failures

### DIFF
--- a/understand-anything-plugin/skills/understand/extract-structure-result.mjs
+++ b/understand-anything-plugin/skills/understand/extract-structure-result.mjs
@@ -1,0 +1,145 @@
+// Pure result mapping for extract-structure.mjs.
+// Kept separate from the CLI entrypoint so unit tests do not import a shebang script.
+export function buildResult(file, totalLines, nonEmptyLines, analysis, callGraph, batchImportData) {
+  const base = {
+    path: file.path,
+    language: file.language,
+    fileCategory: file.fileCategory,
+    totalLines,
+    nonEmptyLines,
+  };
+
+  if (!analysis) {
+    base.metrics = {};
+    return base;
+  }
+
+  if (analysis.functions && analysis.functions.length > 0) {
+    base.functions = analysis.functions.map(fn => ({
+      name: fn.name,
+      startLine: fn.lineRange[0],
+      endLine: fn.lineRange[1],
+      params: fn.params || [],
+    }));
+  }
+
+  if (analysis.classes && analysis.classes.length > 0) {
+    base.classes = analysis.classes.map(cls => ({
+      name: cls.name,
+      startLine: cls.lineRange[0],
+      endLine: cls.lineRange[1],
+      methods: cls.methods || [],
+      properties: cls.properties || [],
+    }));
+  }
+
+  if (analysis.exports && analysis.exports.length > 0) {
+    base.exports = analysis.exports.map(exp => ({
+      name: exp.name,
+      line: exp.lineNumber,
+      isDefault: exp.isDefault === true,
+    }));
+  }
+
+  if (analysis.sections && analysis.sections.length > 0) {
+    base.sections = analysis.sections.map(s => ({
+      heading: s.name,
+      level: s.level,
+      line: s.lineRange[0],
+    }));
+  }
+
+  if (analysis.definitions && analysis.definitions.length > 0) {
+    base.definitions = analysis.definitions.map(d => ({
+      name: d.name,
+      kind: d.kind,
+      fields: d.fields || [],
+      startLine: d.lineRange[0],
+      endLine: d.lineRange[1],
+    }));
+  }
+
+  if (analysis.services && analysis.services.length > 0) {
+    base.services = analysis.services.map(s => ({
+      name: s.name,
+      image: s.image,
+      ports: s.ports || [],
+      ...(s.lineRange ? { startLine: s.lineRange[0], endLine: s.lineRange[1] } : {}),
+    }));
+  }
+
+  if (analysis.endpoints && analysis.endpoints.length > 0) {
+    base.endpoints = analysis.endpoints.map(e => ({
+      method: e.method,
+      path: e.path,
+      startLine: e.lineRange[0],
+      endLine: e.lineRange[1],
+    }));
+  }
+
+  if (analysis.steps && analysis.steps.length > 0) {
+    base.steps = analysis.steps.map(s => ({
+      name: s.name,
+      startLine: s.lineRange[0],
+      endLine: s.lineRange[1],
+    }));
+  }
+
+  if (analysis.resources && analysis.resources.length > 0) {
+    base.resources = analysis.resources.map(r => ({
+      name: r.name,
+      kind: r.kind,
+      startLine: r.lineRange[0],
+      endLine: r.lineRange[1],
+    }));
+  }
+
+  if (callGraph && callGraph.length > 0) {
+    base.callGraph = callGraph;
+  }
+
+  const metrics = {};
+
+  const importPaths = batchImportData?.[file.path];
+  if (importPaths && importPaths.length > 0) {
+    metrics.importCount = importPaths.length;
+  } else if (analysis.imports) {
+    const internal = analysis.imports.filter(imp => {
+      const src = imp?.source ?? '';
+      return src.startsWith('.');
+    });
+    metrics.importCount = internal.length;
+  }
+
+  if (analysis.exports) {
+    metrics.exportCount = analysis.exports.length;
+  }
+  if (analysis.functions) {
+    metrics.functionCount = analysis.functions.length;
+  }
+  if (analysis.classes) {
+    metrics.classCount = analysis.classes.length;
+  }
+  if (analysis.sections) {
+    metrics.sectionCount = analysis.sections.length;
+  }
+  if (analysis.definitions) {
+    metrics.definitionCount = analysis.definitions.length;
+  }
+  if (analysis.services) {
+    metrics.serviceCount = analysis.services.length;
+  }
+  if (analysis.endpoints) {
+    metrics.endpointCount = analysis.endpoints.length;
+  }
+  if (analysis.steps) {
+    metrics.stepCount = analysis.steps.length;
+  }
+  if (analysis.resources) {
+    metrics.resourceCount = analysis.resources.length;
+  }
+
+  base.metrics = metrics;
+
+  return base;
+}

--- a/understand-anything-plugin/skills/understand/extract-structure.mjs
+++ b/understand-anything-plugin/skills/understand/extract-structure.mjs
@@ -20,6 +20,9 @@ import { createRequire } from 'node:module';
 import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { buildResult as buildExtractResult } from './extract-structure-result.mjs';
+
+export { buildResult } from './extract-structure-result.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // skills/understand/ -> plugin root is two dirs up
@@ -120,7 +123,7 @@ async function main() {
     }
 
     // Build result object
-    const result = buildResult(file, totalLines, nonEmptyLines, analysis, callGraph, batchImportData);
+    const result = buildExtractResult(file, totalLines, nonEmptyLines, analysis, callGraph, batchImportData);
     results.push(result);
   }
 
@@ -137,170 +140,6 @@ async function main() {
   if (!existsSync(outputPath)) {
     throw new Error(`output file missing after write: ${outputPath}`);
   }
-}
-
-// ---------------------------------------------------------------------------
-// Result builder: maps StructuralAnalysis to the expected output schema.
-// Exported for unit tests; pure function, no I/O.
-// ---------------------------------------------------------------------------
-export function buildResult(file, totalLines, nonEmptyLines, analysis, callGraph, batchImportData) {
-  const base = {
-    path: file.path,
-    language: file.language,
-    fileCategory: file.fileCategory,
-    totalLines,
-    nonEmptyLines,
-  };
-
-  if (!analysis) {
-    // No parser matched — return basic metrics only
-    base.metrics = {};
-    return base;
-  }
-
-  // Functions (code files)
-  if (analysis.functions && analysis.functions.length > 0) {
-    base.functions = analysis.functions.map(fn => ({
-      name: fn.name,
-      startLine: fn.lineRange[0],
-      endLine: fn.lineRange[1],
-      params: fn.params || [],
-    }));
-  }
-
-  // Classes (code files)
-  if (analysis.classes && analysis.classes.length > 0) {
-    base.classes = analysis.classes.map(cls => ({
-      name: cls.name,
-      startLine: cls.lineRange[0],
-      endLine: cls.lineRange[1],
-      methods: cls.methods || [],
-      properties: cls.properties || [],
-    }));
-  }
-
-  // Exports (code files)
-  if (analysis.exports && analysis.exports.length > 0) {
-    base.exports = analysis.exports.map(exp => ({
-      name: exp.name,
-      line: exp.lineNumber,
-      isDefault: exp.isDefault === true,
-    }));
-  }
-
-  // Non-code structural data: pass through directly
-  if (analysis.sections && analysis.sections.length > 0) {
-    base.sections = analysis.sections.map(s => ({
-      heading: s.name,
-      level: s.level,
-      line: s.lineRange[0],
-    }));
-  }
-
-  if (analysis.definitions && analysis.definitions.length > 0) {
-    base.definitions = analysis.definitions.map(d => ({
-      name: d.name,
-      kind: d.kind,
-      fields: d.fields || [],
-      startLine: d.lineRange[0],
-      endLine: d.lineRange[1],
-    }));
-  }
-
-  if (analysis.services && analysis.services.length > 0) {
-    base.services = analysis.services.map(s => ({
-      name: s.name,
-      image: s.image,
-      ports: s.ports || [],
-      ...(s.lineRange ? { startLine: s.lineRange[0], endLine: s.lineRange[1] } : {}),
-    }));
-  }
-
-  if (analysis.endpoints && analysis.endpoints.length > 0) {
-    base.endpoints = analysis.endpoints.map(e => ({
-      method: e.method,
-      path: e.path,
-      startLine: e.lineRange[0],
-      endLine: e.lineRange[1],
-    }));
-  }
-
-  if (analysis.steps && analysis.steps.length > 0) {
-    base.steps = analysis.steps.map(s => ({
-      name: s.name,
-      startLine: s.lineRange[0],
-      endLine: s.lineRange[1],
-    }));
-  }
-
-  if (analysis.resources && analysis.resources.length > 0) {
-    base.resources = analysis.resources.map(r => ({
-      name: r.name,
-      kind: r.kind,
-      startLine: r.lineRange[0],
-      endLine: r.lineRange[1],
-    }));
-  }
-
-  // Call graph
-  if (callGraph && callGraph.length > 0) {
-    base.callGraph = callGraph;
-  }
-
-  // Metrics
-  const metrics = {};
-
-  // Import count from batchImportData (pre-resolved by project scanner).
-  // Empty arrays are truthy, so explicitly check length so we fall back to the
-  // parser's own import list when the scanner could not resolve any imports
-  // (e.g. Python absolute imports the scanner doesn't follow).
-  //
-  // The fallback counts only relative-style imports (those starting with `.`)
-  // so the metric stays *internal-import* in semantics rather than mixing in
-  // every external package import seen by the parser. Resolved external imports
-  // can never produce edges anyway, so counting them would be misleading.
-  const importPaths = batchImportData?.[file.path];
-  if (importPaths && importPaths.length > 0) {
-    metrics.importCount = importPaths.length;
-  } else if (analysis.imports) {
-    const internal = analysis.imports.filter(imp => {
-      const src = imp?.source ?? '';
-      return src.startsWith('.');
-    });
-    metrics.importCount = internal.length;
-  }
-
-  if (analysis.exports) {
-    metrics.exportCount = analysis.exports.length;
-  }
-  if (analysis.functions) {
-    metrics.functionCount = analysis.functions.length;
-  }
-  if (analysis.classes) {
-    metrics.classCount = analysis.classes.length;
-  }
-  if (analysis.sections) {
-    metrics.sectionCount = analysis.sections.length;
-  }
-  if (analysis.definitions) {
-    metrics.definitionCount = analysis.definitions.length;
-  }
-  if (analysis.services) {
-    metrics.serviceCount = analysis.services.length;
-  }
-  if (analysis.endpoints) {
-    metrics.endpointCount = analysis.endpoints.length;
-  }
-  if (analysis.steps) {
-    metrics.stepCount = analysis.steps.length;
-  }
-  if (analysis.resources) {
-    metrics.resourceCount = analysis.resources.length;
-  }
-
-  base.metrics = metrics;
-
-  return base;
 }
 
 // ---------------------------------------------------------------------------

--- a/understand-anything-plugin/src/__tests__/extract-structure.test.mjs
+++ b/understand-anything-plugin/src/__tests__/extract-structure.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildResult } from "../../skills/understand/extract-structure.mjs";
+import { buildResult } from "../../skills/understand/extract-structure-result.mjs";
 
 const file = (overrides = {}) => ({
   path: "src/foo.py",

--- a/understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs
+++ b/understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs
@@ -30,6 +30,7 @@ echo "$PROJECT_ROOT"
 const bashProbe = spawnSync("bash", ["--version"], { encoding: "utf8" });
 const hasBash = !bashProbe.error && bashProbe.status === 0;
 const describeWithBash = hasBash ? describe : describe.skip;
+const itOnWindows = process.platform === "win32" ? it : it.skip;
 
 function runResolve(projectRoot, env = {}) {
   // No `set -e` — the snippet relies on `git ... 2>/dev/null` returning empty
@@ -39,6 +40,20 @@ function runResolve(projectRoot, env = {}) {
     env: { ...process.env, ...env },
     encoding: "utf8",
   }).trim();
+}
+
+function toNativePath(pathValue) {
+  if (process.platform !== "win32") {
+    return pathValue;
+  }
+  const nativePath = execFileSync("bash", ["-lc", 'cygpath -w "$1"', "_", pathValue], {
+    encoding: "utf8",
+  }).trim();
+  return realpathSync.native(nativePath);
+}
+
+function expectSamePath(actual, expected) {
+  expect(toNativePath(actual)).toBe(toNativePath(expected));
 }
 
 let tmpRoot;
@@ -67,20 +82,24 @@ describeWithBash("worktree-redirect snippet (issue #133)", () => {
     if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
   });
 
+  itOnWindows("treats Windows short and long path names as the same directory", () => {
+    expectSamePath("C:/PROGRA~1", "C:/Program Files");
+  });
+
   it("leaves PROJECT_ROOT alone in a normal checkout", () => {
-    expect(runResolve(mainRepo)).toBe(mainRepo);
+    expectSamePath(runResolve(mainRepo), mainRepo);
   });
 
   it("redirects PROJECT_ROOT to the main repo when started in a worktree", () => {
-    expect(runResolve(worktree)).toBe(mainRepo);
+    expectSamePath(runResolve(worktree), mainRepo);
   });
 
   it("redirects from a subdirectory inside a worktree", () => {
-    expect(runResolve(subdir)).toBe(mainRepo);
+    expectSamePath(runResolve(subdir), mainRepo);
   });
 
   it("respects UNDERSTAND_NO_WORKTREE_REDIRECT=1", () => {
-    expect(runResolve(worktree, { UNDERSTAND_NO_WORKTREE_REDIRECT: "1" })).toBe(worktree);
+    expectSamePath(runResolve(worktree, { UNDERSTAND_NO_WORKTREE_REDIRECT: "1" }), worktree);
   });
 
   it("leaves PROJECT_ROOT alone when not inside a git repo", () => {
@@ -88,6 +107,6 @@ describeWithBash("worktree-redirect snippet (issue #133)", () => {
     // inside a parent git repo (e.g. when /tmp is symlinked into one).
     const nonGit = join(tmpRoot, "no-git");
     mkdirSync(nonGit, { recursive: true });
-    expect(runResolve(nonGit)).toBe(nonGit);
+    expectSamePath(runResolve(nonGit), nonGit);
   });
 });


### PR DESCRIPTION
## What changed
- Normalize Bash/MSYS and Windows path formats in the worktree redirect tests before comparing paths.
- Move extract-structure result mapping into a shebang-free module so unit tests do not import the CLI entrypoint directly.
- Keep the existing extract-structure CLI buildResult export as a re-export for compatibility.

## Testing
- pnpm lint
- pnpm --filter @understand-anything/core build
- pnpm --filter @understand-anything/skill build
- pnpm --filter @understand-anything/core test
- pnpm test
- python -m unittest tests.skill.understand.test_merge_batch_graphs -v