### PR TITLE
fix(skills): quote argument-hint YAML values so Copilot CLI 1.0.65 loads all skills (fixes #526)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": {
     "name": "Egonex"
   },

--- a/.copilot-plugin/plugin.json
+++ b/.copilot-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": {
     "name": "Egonex"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "understand-anything",
   "displayName": "Understand Anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": {
     "name": "Egonex"
   },

--- a/understand-anything-plugin/.claude-plugin/plugin.json
+++ b/understand-anything-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": {
     "name": "Egonex"
   },

--- a/understand-anything-plugin/package.json
+++ b/understand-anything-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understand-anything/skill",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/understand-anything-plugin/skills/understand-chat/SKILL.md
+++ b/understand-anything-plugin/skills/understand-chat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand-chat
 description: Use when you need to ask questions about a codebase or understand code using a knowledge graph
-argument-hint: [query]
+argument-hint: "[query]"
 ---
 
 # /understand-chat

--- a/understand-anything-plugin/skills/understand-dashboard/SKILL.md
+++ b/understand-anything-plugin/skills/understand-dashboard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand-dashboard
 description: Launch the interactive web dashboard to visualize a codebase's knowledge graph
-argument-hint: [project-path]
+argument-hint: "[project-path]"
 ---
 
 # /understand-dashboard

--- a/understand-anything-plugin/skills/understand-domain/SKILL.md
+++ b/understand-anything-plugin/skills/understand-domain/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand-domain
 description: Extract business domain knowledge from a codebase and generate an interactive domain flow graph. Works standalone (lightweight scan) or derives from an existing /understand knowledge graph.
-argument-hint: [--full]
+argument-hint: "[--full]"
 ---
 
 # /understand-domain

--- a/understand-anything-plugin/skills/understand-explain/SKILL.md
+++ b/understand-anything-plugin/skills/understand-explain/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand-explain
 description: Use when you need a deep-dive explanation of a specific file, function, or module in the codebase
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 # /understand-explain

--- a/understand-anything-plugin/skills/understand-knowledge/SKILL.md
+++ b/understand-anything-plugin/skills/understand-knowledge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand-knowledge
 description: Analyze a Karpathy-pattern LLM wiki knowledge base and generate an interactive knowledge graph with entity extraction, implicit relationships, and topic clustering.
-argument-hint: [wiki-directory]
+argument-hint: "[wiki-directory]"
 ---
 
 # /understand-knowledge

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand
 description: Analyze a codebase to produce an interactive knowledge graph for understanding architecture, components, and relationships
-argument-hint: ["[path] [--full|--auto-update|--no-auto-update|--review|--language <lang>]"]
+argument-hint: "[path] [--full|--auto-update|--no-auto-update|--review|--language <lang>]"
 ---
 
 # /understand


### PR DESCRIPTION
## Summary

Fixes #526 (dup of #506): after upgrading GitHub Copilot CLI to **1.0.65**, `/understand` and its sibling commands vanish from the CLI. The new skill loader validates `argument-hint` as a **string**, and 6 of the plugin's SKILL.md files declared it with bare YAML brackets — which YAML parses as an **array**. The loader silently rejects them.

    argument-hint: [query]        →   parses as `["query"]` (list)  ❌
    argument-hint: "[query]"      →   parses as `"[query]"` (string) ✅

## What changed

6 SKILL.md frontmatters + 5 manifest version bumps.

| File | Before | After |
|------|--------|-------|
| `skills/understand/SKILL.md` | `["[path] [--full\|...]"]` | `"[path] [--full\|...]"` |
| `skills/understand-chat/SKILL.md` | `[query]` | `"[query]"` |
| `skills/understand-dashboard/SKILL.md` | `[project-path]` | `"[project-path]"` |
| `skills/understand-domain/SKILL.md` | `[--full]` | `"[--full]"` |
| `skills/understand-explain/SKILL.md` | `[file-path]` | `"[file-path]"` |
| `skills/understand-knowledge/SKILL.md` | `[wiki-directory]` | `"[wiki-directory]"` |

`understand-diff` and `understand-onboard` don't declare `argument-hint` and don't need touching — confirming the loader itself is fine, only the bracket syntax was wrong.

Also bumps 2.8.1 → 2.8.2 across the 5 manifests so users upgrading Copilot CLI can pin `≥2.8.2`.

## Why this shape

Both **VS Code Agent Skills** and **GitHub Copilot CLI** document `argument-hint` as a **string** — the loader change in Copilot CLI 1.0.65 just enforces the pre-existing contract. The double-quoted-string form is exactly what the reference docs show. See sources below.

## Commits (split for reviewability)

1. `fix(skills): quote argument-hint in /understand — Copilot CLI 1.0.65 requires string` — the primary command, most complex value
2. `fix(skills): quote argument-hint in query/file-path skills` — `understand-chat` + `understand-explain`
3. `fix(skills): quote argument-hint in directory-path skills` — `understand-dashboard` + `understand-knowledge`
4. `fix(skills): quote argument-hint in /understand-domain — flag-style hint` — leading `--` called out separately
5. `chore: bump 2.8.1 → 2.8.2 for Copilot CLI 1.0.65 skill-loader fix` — version bump across 5 manifests

## Verification

Independently reviewed by four review passes before opening this PR:

1. **YAML correctness** — every value now parses as a string via PyYAML round-trip; `|` and `<lang>` are safe inside a double-quoted flow scalar (`|` only triggers block-scalar mode when it's the value indicator, e.g. `key: |`).
2. **Copilot CLI 1.0.65 contract** — confirmed against release notes and the [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) (`argument-hint` is documented as a string — string form is exactly what the docs show).
3. **Repo-wide regression sweep** — no repo-internal parser reads `argument-hint`; `parse-knowledge-base.py` only parses user-supplied wiki files, not SKILL.md; version bump consistent across all 5 manifests, no stale `2.8.1` references.
4. **Cross-platform compatibility across every platform in the README** — all 17 supported platforms accept the quoted-string form:
   - **Claude Code / VS Code Copilot / Copilot CLI** — document `argument-hint` as a string (rendered in UI)
   - **Agent Skills spec platforms** (Cursor, Codex, OpenCode, Kiro, Gemini CLI, Antigravity, Trae, Nanobot, Pi, Vibe, Cline, KIMI, Hermes, OpenClaw) — `argument-hint` is not in the [Agent Skills base spec](https://agentskills.io/specification); spec-conformant loaders ignore unknown fields, so the type change is inert to them
   - **No platform documented anywhere as requiring the array form.**

## Sources

- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — `argument-hint` documented as a string
- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` example values `[issue-number]`, `[filename] [format]` (rendered as strings)
- [Agent Skills specification](https://agentskills.io/specification) — base spec doesn't include `argument-hint`; unknown fields ignored

## Test plan

- [x] `pnpm --filter @understand-anything/core build` passes (verified locally — no core changes, tsc clean)
- [x] On Copilot CLI 1.0.65+, `copilot skill list` shows all 8 skills after install
- [x] `/understand`, `/understand-chat`, `/understand-dashboard`, `/understand-domain`, `/understand-explain`, `/understand-knowledge` appear in the command menu
- [x] Claude Code still shows the same 8 slash commands (no regression on the primary platform)
- [x] Cursor auto-discovery via `.cursor-plugin/plugin.json` still works

Closes #526.
Duplicates / supersedes #506 (same root cause, same fix scope).


