### PR TITLE
Fix stale container layout cache on cross-layer navigation

### DIFF
--- a/understand-anything-plugin/packages/dashboard/src/__tests__/store-navigation.test.ts
+++ b/understand-anything-plugin/packages/dashboard/src/__tests__/store-navigation.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { GraphNode, KnowledgeGraph } from "@understand-anything/core/types";
+import { useDashboardStore } from "../store";
+
+function node(id: string): GraphNode {
+  return {
+    id,
+    type: "file",
+    name: id,
+    summary: "",
+    tags: [],
+    complexity: "simple",
+  };
+}
+
+function graph(): KnowledgeGraph {
+  return {
+    version: "1.0.0",
+    project: {
+      name: "fixture",
+      languages: [],
+      frameworks: [],
+      description: "",
+      analyzedAt: "2026-07-03T00:00:00.000Z",
+      gitCommitHash: "test",
+    },
+    nodes: [node("a1"), node("a2"), node("b1"), node("b2")],
+    edges: [],
+    layers: [
+      { id: "layer:a", name: "A", description: "", nodeIds: ["a1", "a2"] },
+      { id: "layer:b", name: "B", description: "", nodeIds: ["b1", "b2"] },
+    ],
+    tour: [],
+  };
+}
+
+function seedContainerState(): void {
+  useDashboardStore.getState().expandContainer("container:cluster-0");
+  useDashboardStore.getState().setPendingFocusContainer("container:cluster-0");
+  useDashboardStore.getState().setContainerLayout(
+    "container:cluster-0",
+    new Map([["a1", { x: 10, y: 20 }]]),
+    { width: 200, height: 120 },
+  );
+}
+
+function expectContainerStateCleared(): void {
+  const state = useDashboardStore.getState();
+  expect(state.containerLayoutCache.size).toBe(0);
+  expect(state.containerSizeMemory.size).toBe(0);
+  expect(state.expandedContainers.size).toBe(0);
+  expect(state.pendingFocusContainer).toBeNull();
+}
+
+beforeEach(() => {
+  useDashboardStore.setState(useDashboardStore.getInitialState(), true);
+});
+
+describe("store layer navigation container cache resets", () => {
+  it("clears container state when navigateToNodeInLayer crosses layers", () => {
+    useDashboardStore.getState().setGraph(graph());
+    useDashboardStore.getState().navigateToNodeInLayer("a1");
+    seedContainerState();
+
+    useDashboardStore.getState().navigateToNodeInLayer("b1");
+
+    expect(useDashboardStore.getState().activeLayerId).toBe("layer:b");
+    expectContainerStateCleared();
+  });
+
+  it("preserves container state when navigateToNodeInLayer stays in the same layer", () => {
+    useDashboardStore.getState().setGraph(graph());
+    useDashboardStore.getState().navigateToNodeInLayer("a1");
+    seedContainerState();
+
+    useDashboardStore.getState().navigateToNodeInLayer("a2");
+
+    const state = useDashboardStore.getState();
+    expect(state.activeLayerId).toBe("layer:a");
+    expect(state.containerLayoutCache.size).toBe(1);
+    expect(state.containerSizeMemory.size).toBe(1);
+    expect(state.expandedContainers.has("container:cluster-0")).toBe(true);
+    expect(state.pendingFocusContainer).toBe("container:cluster-0");
+  });
+
+  it("clears container state when navigateToHistoryIndex crosses layers", () => {
+    useDashboardStore.getState().setGraph(graph());
+    useDashboardStore.getState().navigateToNodeInLayer("b1");
+    useDashboardStore.getState().navigateToNodeInLayer("a1");
+    seedContainerState();
+
+    useDashboardStore.getState().navigateToHistoryIndex(0);
+
+    expect(useDashboardStore.getState().activeLayerId).toBe("layer:b");
+    expectContainerStateCleared();
+  });
+
+  it("clears container state when goBackNode crosses layers", () => {
+    useDashboardStore.getState().setGraph(graph());
+    useDashboardStore.getState().navigateToNodeInLayer("b1");
+    useDashboardStore.getState().navigateToNodeInLayer("a1");
+    seedContainerState();
+
+    useDashboardStore.getState().goBackNode();
+
+    expect(useDashboardStore.getState().activeLayerId).toBe("layer:b");
+    expectContainerStateCleared();
+  });
+});

--- a/understand-anything-plugin/packages/dashboard/src/store.ts
+++ b/understand-anything-plugin/packages/dashboard/src/store.ts
@@ -411,7 +411,7 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   },
 
   navigateToNodeInLayer: (nodeId) => {
-    const { graph, selectedNodeId, nodeHistory, nodeIdToLayerId } = get();
+    const { graph, selectedNodeId, nodeHistory, nodeIdToLayerId, activeLayerId } = get();
     if (!graph) return;
     const layerId = nodeIdToLayerId.get(nodeId) ?? null;
     const newHistory =
@@ -419,15 +419,19 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
         ? [...nodeHistory, selectedNodeId].slice(-MAX_HISTORY)
         : nodeHistory;
     if (layerId) {
-      set({
-        navigationLevel: "layer-detail",
+      const layerNav = {
+        navigationLevel: "layer-detail" as const,
         activeLayerId: layerId,
+      };
+      set({
+        ...layerNav,
         selectedNodeId: nodeId,
         focusNodeId: null,
         codeViewerOpen: false,
         codeViewerNodeId: null,
         codeViewerExpanded: false,
         nodeHistory: newHistory,
+        ...layerResetIfChanged(layerNav, activeLayerId),
       });
     } else {
       set({
@@ -438,30 +442,38 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   },
 
   navigateToHistoryIndex: (index) => {
-    const { nodeHistory, graph, nodeIdToLayerId } = get();
+    const { nodeHistory, graph, nodeIdToLayerId, activeLayerId } = get();
     if (!graph || index < 0 || index >= nodeHistory.length) return;
     const targetId = nodeHistory[index];
     const newHistory = nodeHistory.slice(0, index);
     const layerId = nodeIdToLayerId.get(targetId) ?? null;
+    const layerNav = layerId
+      ? { navigationLevel: "layer-detail" as const, activeLayerId: layerId }
+      : {};
     set({
       selectedNodeId: targetId,
       nodeHistory: newHistory,
-      ...(layerId ? { navigationLevel: "layer-detail" as const, activeLayerId: layerId } : {}),
+      ...layerNav,
+      ...layerResetIfChanged(layerNav, activeLayerId),
     });
   },
 
   goBackNode: () => {
-    const { nodeHistory, graph, nodeIdToLayerId } = get();
+    const { nodeHistory, graph, nodeIdToLayerId, activeLayerId } = get();
     if (nodeHistory.length === 0 || !graph) return;
     const prevNodeId = nodeHistory[nodeHistory.length - 1];
     const newHistory = nodeHistory.slice(0, -1);
     const layerId = nodeIdToLayerId.get(prevNodeId) ?? null;
     if (layerId) {
-      set({
-        navigationLevel: "layer-detail",
+      const layerNav = {
+        navigationLevel: "layer-detail" as const,
         activeLayerId: layerId,
+      };
+      set({
+        ...layerNav,
         selectedNodeId: prevNodeId,
         nodeHistory: newHistory,
+        ...layerResetIfChanged(layerNav, activeLayerId),
       });
     } else {
       set({


### PR DESCRIPTION
## Summary
- clear stale container layout state when node, history, or back navigation crosses layers
- reuse the existing layer cache reset helper for these cross-layer navigation paths
- add store-level regression coverage for cross-layer node, history, and back navigation

Fixes #539.

## Validation
- `& .\node_modules\.bin\vitest.cmd run src\__tests__\store-navigation.test.ts --reporter=verbose`
- `& .\node_modules\.bin\vitest.cmd run --reporter=dot`
- `& .\node_modules\.bin\tsc.cmd -b`