### PR TITLE
fix(install): add missing vibe platform to install.ps1 + cross-script parity test

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -34,6 +34,7 @@ $Platforms = [ordered]@{
     pi          = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     openclaw    = @{ Target = (Join-Path $HOME '.openclaw\skills');           Style = 'folder' }
     antigravity = @{ Target = (Join-Path $HOME '.gemini\antigravity\skills'); Style = 'folder' }
+    vibe        = @{ Target = (Join-Path $HOME '.vibe\skills');               Style = 'per-skill' }
     vscode      = @{ Target = (Join-Path $HOME '.copilot\skills');            Style = 'per-skill' }
     hermes      = @{ Target = (Join-Path $HOME '.hermes\skills');             Style = 'folder' }
     cline       = @{ Target = (Join-Path $HOME '.cline\skills');              Style = 'folder' }

--- a/tests/install/platform-table-consistency.test.mjs
+++ b/tests/install/platform-table-consistency.test.mjs
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../..');
+
+const installSh = readFileSync(resolve(repoRoot, 'install.sh'), 'utf-8');
+const installPs1 = readFileSync(resolve(repoRoot, 'install.ps1'), 'utf-8');
+const readme = readFileSync(resolve(repoRoot, 'README.md'), 'utf-8');
+
+/**
+ * Parse the platforms_table() heredoc in install.sh:
+ *   id|$HOME/target/dir|style
+ */
+function parseShPlatforms(source) {
+  const heredoc = source.match(/platforms_table\(\)\s*\{\s*\n\s*cat <<EOF\n([\s\S]*?)\nEOF/);
+  if (!heredoc) return [];
+  const rows = [];
+  for (const line of heredoc[1].split('\n')) {
+    const m = line.match(/^([a-z0-9][a-z0-9-]*)\|([^|]+)\|(per-skill|folder)$/);
+    if (m) rows.push({ id: m[1], target: m[2], style: m[3] });
+  }
+  return rows;
+}
+
+/**
+ * Parse the $Platforms ordered hashtable in install.ps1:
+ *   id = @{ Target = (Join-Path $HOME 'target\dir'); Style = 'style' }
+ */
+function parsePs1Platforms(source) {
+  const block = source.match(/\$Platforms\s*=\s*\[ordered\]@\{\r?\n([\s\S]*?)\r?\n\}/);
+  if (!block) return [];
+  const rows = [];
+  for (const line of block[1].split('\n')) {
+    const m = line.match(
+      /^\s*([a-z0-9][a-z0-9-]*)\s*=\s*@\{\s*Target\s*=\s*\(Join-Path \$HOME '([^']+)'\);\s*Style\s*=\s*'(per-skill|folder)'\s*\}/,
+    );
+    if (m) rows.push({ id: m[1], target: m[2], style: m[3] });
+  }
+  return rows;
+}
+
+/**
+ * Normalize a skills target dir for cross-script comparison: drop the
+ * home-dir prefix (`$HOME/` in bash; PowerShell targets are already relative
+ * to $HOME via Join-Path) and unify path separators.
+ */
+function normalizeTarget(target) {
+  return target.replace(/^\$HOME\//, '').replace(/\\/g, '/');
+}
+
+/** Backtick-quoted ids on the "Supported `<platform>` values:" README line. */
+function parseReadmeSupportedValues(source) {
+  const line = source.match(/^- Supported `<platform>` values: (.+)$/m);
+  if (!line) return [];
+  return [...line[1].matchAll(/`([a-z0-9][a-z0-9-]*)`/g)].map((m) => m[1]);
+}
+
+/** Ids referenced as `install.sh <id>` in the Platform Compatibility table. */
+function parseReadmeCompatTableIds(source) {
+  const section = source.match(/### Platform Compatibility\n([\s\S]*?)\n#{2,3} /);
+  if (!section) return [];
+  return [...section[1].matchAll(/`install\.sh ([a-z0-9][a-z0-9-]*)`/g)].map((m) => m[1]);
+}
+
+const shRows = parseShPlatforms(installSh);
+const ps1Rows = parsePs1Platforms(installPs1);
+
+describe('installer platform table consistency', () => {
+  // Guard against the parsers silently matching nothing (e.g. after a
+  // formatting change in either script): a regex mismatch must fail loudly
+  // here, not let the comparison tests pass vacuously on two empty lists.
+  it('parses a plausible number of platforms from both scripts', () => {
+    expect(shRows.length).toBeGreaterThanOrEqual(10);
+    expect(ps1Rows.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('install.sh and install.ps1 define the same platform ids in the same order', () => {
+    // Same order matters, not just the same set: both scripts number their
+    // interactive platform menus from the table order, so "3) opencode" must
+    // mean the same thing on macOS/Linux and on Windows.
+    expect(ps1Rows.map((r) => r.id)).toEqual(shRows.map((r) => r.id));
+  });
+
+  it('each platform has the same link style in both scripts', () => {
+    const ps1ById = new Map(ps1Rows.map((r) => [r.id, r]));
+    for (const row of shRows) {
+      expect(ps1ById.get(row.id)?.style, `style for "${row.id}"`).toBe(row.style);
+    }
+  });
+
+  it('each platform has the same skills target dir in both scripts', () => {
+    const ps1ById = new Map(ps1Rows.map((r) => [r.id, r]));
+    for (const row of shRows) {
+      const ps1Row = ps1ById.get(row.id);
+      if (!ps1Row) continue; // id-set mismatch is reported by the test above
+      expect(normalizeTarget(ps1Row.target), `target for "${row.id}"`).toBe(
+        normalizeTarget(row.target),
+      );
+    }
+  });
+
+  it('README "Supported <platform> values" line matches the installer table', () => {
+    const readmeIds = parseReadmeSupportedValues(readme);
+    expect(readmeIds.length).toBeGreaterThanOrEqual(10);
+    expect([...readmeIds].sort()).toEqual(shRows.map((r) => r.id).sort());
+  });
+
+  it('README Platform Compatibility table only references real installer platforms', () => {
+    // The table may legitimately document a platform via another install
+    // method (e.g. vscode → auto-discovery), so this is a subset check; full
+    // coverage of the id list is enforced by the supported-values test above.
+    const tableIds = parseReadmeCompatTableIds(readme);
+    expect(tableIds.length).toBeGreaterThanOrEqual(10);
+    const shIds = new Set(shRows.map((r) => r.id));
+    for (const id of tableIds) {
+      expect(shIds.has(id), `"install.sh ${id}" in README compatibility table`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`install.sh` supports the `vibe` platform (`vibe|$HOME/.vibe/skills|per-skill`, line 37), README documents `vibe` as a supported `<platform>` value (line 218) and lists Vibe CLI as ✅ Supported in the Platform Compatibility table (line 266) — but `install.ps1`'s `$Platforms` table skips straight from `antigravity` to `vscode`. On Windows, `install.ps1 vibe` dies in `Resolve-Platform` with `Unknown platform: vibe` (`$ErrorActionPreference = 'Stop'`), and the interactive `Prompt-Platform` menu never offers it either — so the documented Vibe CLI support is 100% unavailable on Windows, including via the README's one-line `iwr -useb … | iex` install.

This PR (1) adds the missing `vibe` entry to `install.ps1`, inserted between `antigravity` and `vscode` to mirror `install.sh`'s row order so the interactive menu numbering stays identical across both installers, and (2) adds a regression test that keeps the two platform tables — and the README — from drifting apart again.

### Why the test is the interesting part

This repo adds new install platforms at a steady clip, and there are **several platform-addition PRs open right now** — #425 (oh-my-pi), #420 (codeflicker), #470 (Qoder), #478/#404/#386/#281 (CodeBuddy) — each of which has to remember to update `install.sh`, `install.ps1`, *and* two places in README.md by hand. The `vibe` gap this PR fixes is exactly what happens when one of the four spots gets missed.

`tests/install/platform-table-consistency.test.mjs` (picked up by the root `vitest.config.ts` `tests/**` include, so it runs in plain `pnpm test`/CI) parses the `platforms_table()` heredoc in `install.sh` and the `$Platforms` ordered hashtable in `install.ps1` and asserts:

- **Same platform ids in the same order** — order matters because both scripts number their interactive menus from table order; "3) opencode" must mean the same thing on macOS/Linux and Windows.
- **Same link style** (`per-skill` vs `folder`) per platform.
- **Same normalized skills-target dir** per platform (strips the `$HOME/` prefix, unifies `\` vs `/`).
- **README stays in sync**: the "Supported `<platform>` values" line matches the installer table exactly, and every `install.sh <id>` referenced in the Platform Compatibility table is a real platform id (subset check, since some table rows legitimately use other install methods, e.g. vscode → auto-discovery).
- **Loud parser failure**: both parsers must yield ≥ 10 entries, so a future formatting change in either script makes the test fail with an obvious signal instead of vacuously passing on two empty lists.

So if any of the queued platform PRs updates only one script (or forgets the README line), `pnpm test` fails with a diff naming the exact platform id — that's the intended behavior, and rebasing those PRs on this one gives them a free four-way consistency check.

## Linked issue(s)

None — found while auditing installer/README consistency. (Related context: #417 touches `install.ps1` error handling but not the platform table; no open PR addresses the missing `vibe` entry.)

## How I tested this

- [x] `pnpm lint` — clean
- [x] `pnpm --filter @understand-anything/core test` — 809 passed
- [x] `pnpm test` — 216 passed, 1 skipped (17 files, includes the new test)
- [x] **Red/green check**: on `main` (before the `install.ps1` fix), the new test fails on exactly the two assertions the bug violates:

  ```
  × install.sh and install.ps1 define the same platform ids in the same order
      - Expected  [ …, 'antigravity', 'vibe', 'vscode', … ]   (14 ids, from install.sh)
      + Received  [ …, 'antigravity', 'vscode', … ]           (13 ids, from install.ps1)
  × each platform has the same link style in both scripts
      → style for "vibe": expected undefined to be 'per-skill'
  ✓ parses a plausible number of platforms from both scripts
  ✓ each platform has the same skills target dir in both scripts
  ✓ README "Supported <platform> values" line matches the installer table
  ✓ README Platform Compatibility table only references real installer platforms
  ```

  After the one-line `install.ps1` fix, all 6 pass.

- Manual check: the inserted line mirrors `install.sh`'s `vibe|$HOME/.vibe/skills|per-skill` — `per-skill` style, `~\.vibe\skills` target — and preserves the table's column alignment. (No Windows/pwsh available in my environment for a live `install.ps1 vibe` run; the entry is structurally identical to the thirteen existing ones, and the parity test now pins it against install.sh.)

## Versioning

- [x] N/A — installer script + tests only; `install.sh`/`install.ps1` are fetched raw from `main` by the one-line installers and are not part of the versioned plugin payload shipped through the five manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
