### PR TITLE
fix(skills): limit changed-file batches to changed targets

### DIFF
--- a/tests/skill/understand/test_compute_batches.test.mjs
+++ b/tests/skill/understand/test_compute_batches.test.mjs
@@ -577,20 +577,22 @@ describe('compute-batches.mjs — --changed-files', () => {
     if (root) rmSync(root, { recursive: true, force: true });
   });
 
-  it('emits only batches containing changed files', () => {
+  it('emits only changed files from retained batches with Windows-style changed-file paths', () => {
     root = setupProject('scan-result-3-cliques.json');
     const changedPath = join(root, 'changed.txt');
-    // Only the auth clique is changed
-    writeFileSync(changedPath, ['src/auth/login.ts', 'src/auth/tokens.ts'].join('\n'));
+    // Only two files in the auth clique are changed. Use CRLF plus one
+    // backslash path to cover Windows git diff/path-list inputs.
+    writeFileSync(changedPath, ['src\\auth\\login.ts', 'src/auth/tokens.ts'].join('\r\n'));
 
     const result = runScript(root, [`--changed-files=${changedPath}`]);
     expect(result.status).toBe(0);
 
     const out = readBatches(root);
-    // Auth files are in batches; other cliques' batches must be omitted
+    // Auth files are retained, but the unchanged auth file from the original
+    // full-graph batch must not be analyzed in changed-files mode.
     const allPaths = out.batches.flatMap(b => b.files.map(f => f.path));
-    expect(allPaths).toContain('src/auth/login.ts');
-    expect(allPaths).toContain('src/auth/tokens.ts');
+    expect(allPaths.sort()).toEqual(['src/auth/login.ts', 'src/auth/tokens.ts']);
+    expect(allPaths).not.toContain('src/auth/session.ts');
     expect(allPaths).not.toContain('src/api/handlers.ts');
     expect(allPaths).not.toContain('src/db/users.ts');
 
@@ -598,5 +600,106 @@ describe('compute-batches.mjs — --changed-files', () => {
     const loginBatch = out.batches.find(b =>
       b.files.some(f => f.path === 'src/auth/login.ts'));
     expect(loginBatch).toBeDefined();
+  });
+
+  it('does not emit unchanged same-community files as analysis targets', () => {
+    root = setupProject('scan-result-3-cliques.json');
+    const changedPath = join(root, 'changed.txt');
+    writeFileSync(changedPath, 'src/auth/login.ts\n');
+
+    const result = runScript(root, [`--changed-files=${changedPath}`]);
+    expect(result.status).toBe(0);
+
+    const out = readBatches(root);
+    expect(out.totalBatches).toBe(1);
+    expect(out.batches).toHaveLength(1);
+
+    const [batch] = out.batches;
+    expect(batch.files.map(f => f.path)).toEqual(['src/auth/login.ts']);
+    expect(Object.keys(batch.batchImportData)).toEqual(['src/auth/login.ts']);
+    expect(batch.batchImportData['src/auth/login.ts'].sort()).toEqual([
+      'src/auth/session.ts',
+      'src/auth/tokens.ts',
+    ]);
+    expect((batch.neighborMap['src/auth/login.ts'] || []).map(n => n.path).sort()).toEqual([
+      'src/auth/session.ts',
+      'src/auth/tokens.ts',
+    ]);
+  });
+
+  it('emits only changed files inside retained batches while preserving unchanged neighbor context', () => {
+    root = mkdtempSync(join(tmpdir(), 'ua-cb-changed-nbr-'));
+    mkdirSync(join(root, '.understand-anything', 'intermediate'), { recursive: true });
+    mkdirSync(join(root, 'src', 'a'), { recursive: true });
+    mkdirSync(join(root, 'src', 'b'), { recursive: true });
+
+    writeFileSync(join(root, 'src', 'a', 'core.ts'),
+      'export function findUser(id: string) { return null; }\nexport class User {}\n');
+    writeFileSync(join(root, 'src', 'a', 'helper1.ts'),
+      'import { findUser } from "./core";\nexport const h1 = () => findUser("x");\n');
+    writeFileSync(join(root, 'src', 'a', 'helper2.ts'),
+      'import { User } from "./core";\nimport { h1 } from "./helper1";\nexport const h2 = () => h1();\n');
+
+    writeFileSync(join(root, 'src', 'b', 'entry.ts'),
+      'import { findUser } from "../a/core";\nexport const entry = () => findUser("y");\n');
+    writeFileSync(join(root, 'src', 'b', 'middle.ts'),
+      'import { entry } from "./entry";\nexport const middle = () => entry();\n');
+    writeFileSync(join(root, 'src', 'b', 'leaf.ts'),
+      'import { middle } from "./middle";\nexport const leaf = () => middle();\n');
+
+    const files = [
+      { path: 'src/a/core.ts',    language: 'typescript', sizeLines: 2, fileCategory: 'code' },
+      { path: 'src/a/helper1.ts', language: 'typescript', sizeLines: 2, fileCategory: 'code' },
+      { path: 'src/a/helper2.ts', language: 'typescript', sizeLines: 3, fileCategory: 'code' },
+      { path: 'src/b/entry.ts',   language: 'typescript', sizeLines: 2, fileCategory: 'code' },
+      { path: 'src/b/middle.ts',  language: 'typescript', sizeLines: 2, fileCategory: 'code' },
+      { path: 'src/b/leaf.ts',    language: 'typescript', sizeLines: 2, fileCategory: 'code' },
+    ];
+    const scan = {
+      name: 'changed-neighbor-test', description: '',
+      languages: ['typescript'], frameworks: [],
+      files,
+      totalFiles: 6, filteredByIgnore: 0, estimatedComplexity: 'small',
+      importMap: {
+        'src/a/core.ts': [],
+        'src/a/helper1.ts': ['src/a/core.ts'],
+        'src/a/helper2.ts': ['src/a/core.ts', 'src/a/helper1.ts'],
+        'src/b/entry.ts': ['src/a/core.ts'],
+        'src/b/middle.ts': ['src/b/entry.ts'],
+        'src/b/leaf.ts': ['src/b/middle.ts'],
+      },
+    };
+    writeFileSync(
+      join(root, '.understand-anything', 'intermediate', 'scan-result.json'),
+      JSON.stringify(scan));
+
+    const changedPath = join(root, 'changed.txt');
+    writeFileSync(changedPath, 'src/b/entry.ts\n');
+
+    const result = runScript(root, [`--changed-files=${changedPath}`]);
+    expect(result.status).toBe(0);
+
+    const out = readBatches(root);
+    expect(out.totalBatches).toBe(1);
+    expect(out.batches).toHaveLength(1);
+
+    const [batch] = out.batches;
+    expect(batch.files.map(f => f.path)).toEqual(['src/b/entry.ts']);
+    expect(Object.keys(batch.batchImportData)).toEqual(['src/b/entry.ts']);
+    expect(Object.keys(batch.neighborMap)).toEqual(['src/b/entry.ts']);
+
+    const neighbors = batch.neighborMap['src/b/entry.ts'];
+    expect(neighbors).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        path: 'src/a/core.ts',
+        symbols: expect.arrayContaining(['findUser', 'User']),
+      }),
+      expect.objectContaining({
+        path: 'src/b/middle.ts',
+        symbols: expect.arrayContaining(['middle']),
+      }),
+    ]));
+    expect(neighbors.find(n => n.path === 'src/a/core.ts').batchIndex).not.toBe(batch.batchIndex);
+    expect(neighbors.find(n => n.path === 'src/b/middle.ts').batchIndex).toBe(batch.batchIndex);
   });
 });

--- a/understand-anything-plugin/skills/understand/compute-batches.mjs
+++ b/understand-anything-plugin/skills/understand/compute-batches.mjs
@@ -226,6 +226,14 @@ function buildBatchOfMap(allBatches) {
   return m;
 }
 
+function normalizeRelativePathForMatch(pathText) {
+  return pathText
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\.\/+/, '')
+    .replace(/\/+/g, '/');
+}
+
 /**
  * Returns Map<path, communityId> via Louvain. May throw — caller must catch
  * and fall back if it does. Honors UA_COMPUTE_BATCHES_FORCE_LOUVAIN_THROW=1
@@ -355,7 +363,7 @@ async function main() {
       }
       const lines = content
         .split('\n')
-        .map(s => s.trim())
+        .map(normalizeRelativePathForMatch)
         .filter(Boolean);
       changedFiles = new Set(lines);
     }
@@ -480,15 +488,18 @@ async function main() {
 
   const MAX_NEIGHBORS = 50;
 
-  // Second-pass: enrich each batch with batchImportData + neighborMap
-  const batches = mergedBareBatches.map(b => {
-    const batchPaths = new Set(b.files.map(f => f.path));
+  // Second-pass: enrich each batch with batchImportData + neighborMap.
+  // `analysisFiles` is usually the full batch. In --changed-files mode, it is
+  // only the changed target set, while batchOf remains the full-graph lookup.
+  const buildBatchPayload = (b, analysisFiles = b.files) => {
+    const analysisPaths = new Set(analysisFiles.map(f => f.path));
     const batchImportData = {};
     const neighborMap = {};
-    for (const f of b.files) {
+    for (const f of analysisFiles) {
       batchImportData[f.path] = (importMap[f.path] || []).slice();
 
-      // 1-hop neighbors: imports out + imported-by in, excluding same batch.
+      // 1-hop neighbors: imports out + imported-by in, excluding files already
+      // emitted for analysis in this payload.
       // Note on truncation: we measure "popularity" by total raw 1-hop neighbor
       // count (rawCount), not kept.length. A widely-imported hub like a logger
       // module may have N>50 inbound imports but, after Louvain + size
@@ -500,7 +511,7 @@ async function main() {
       const inNeighbors = reverseImportMap.get(f.path) || [];
       const all = new Set([...outNeighbors, ...inNeighbors]);
       const rawCount = all.size;
-      const filtered = [...all].filter(p => batchOf.has(p) && !batchPaths.has(p));
+      const filtered = [...all].filter(p => batchOf.has(p) && !analysisPaths.has(p));
 
       let kept = filtered.map(p => ({
         path: p,
@@ -523,12 +534,21 @@ async function main() {
 
       if (kept.length) neighborMap[f.path] = kept;
     }
-    return { batchIndex: b.batchIndex, files: b.files, batchImportData, neighborMap };
-  });
+    return { batchIndex: b.batchIndex, files: analysisFiles, batchImportData, neighborMap };
+  };
+
+  const batches = mergedBareBatches.map(b => buildBatchPayload(b));
 
   let finalBatches = batches;
   if (changedFiles) {
-    finalBatches = batches.filter(b => b.files.some(f => changedFiles.has(f.path)));
+    finalBatches = mergedBareBatches
+      .map(b => {
+        const changedBatchFiles = b.files.filter(f =>
+          changedFiles.has(normalizeRelativePathForMatch(f.path)));
+        if (changedBatchFiles.length === 0) return null;
+        return buildBatchPayload(b, changedBatchFiles);
+      })
+      .filter(Boolean);
     // batchIndex on filtered batches retains the full-graph assignment
     // (the design says neighborMap should still reference unchanged files'
     // full-graph batchIndex). No renumbering.


### PR DESCRIPTION
## Summary
- Limit `--changed-files` batches to changed analysis targets instead of full Louvain communities.
- Rebuild `batchImportData` and `neighborMap` for changed targets while preserving full-graph `batchIndex` context.
- Normalize Windows-style changed-file paths (CRLF, backslashes, leading `./`).

## Related Issue
- Fixes #547

## Test Plan
- `pnpm vitest run tests/skill/understand/test_compute_batches.test.mjs`
- `pnpm test`
- `pnpm build`
- `pnpm lint`