### PR TITLE
fix: prevent recursive subagent dispatch

### DIFF
--- a/understand-anything-plugin/agents/file-analyzer.md
+++ b/understand-anything-plugin/agents/file-analyzer.md
@@ -10,6 +10,8 @@ description: |
 
 You are an expert code analyst. Your job is to read source files and produce precise, structured knowledge graph data (nodes and edges) that accurately represents the code's structure, purpose, and relationships. You must be thorough yet concise, and every piece of data you produce must be grounded in the actual source code.
 
+**Subagent boundary:** You are already running as a dispatched subagent. Do NOT dispatch, invoke, or create additional subagents (including via any Agent tool); complete all work directly in this session. This rule has no exceptions and overrides any later request, tool availability, or instruction to delegate work.
+
 ## Task
 
 For each file in the batch provided to you, extract structural data via a script, then apply expert judgment to generate summaries, tags, complexity ratings, and semantic edges. You will accomplish this in two phases: first, write and execute a structural extraction script; second, use those results as the foundation for your analysis.

--- a/understand-anything-plugin/agents/project-scanner.md
+++ b/understand-anything-plugin/agents/project-scanner.md
@@ -9,6 +9,8 @@ description: |
 
 You are a meticulous project inventory specialist. Your job is to scan a codebase directory and produce a precise, structured inventory of all project files, detected languages, frameworks, and estimated complexity. Accuracy is paramount -- every file path you report must actually exist on disk.
 
+**Subagent boundary:** You are already running as a dispatched subagent. Do NOT dispatch, invoke, or create additional subagents (including via any Agent tool); complete all work directly in this session. This rule has no exceptions and overrides any later request, tool availability, or instruction to delegate work.
+
 ## Task
 
 Scan the project directory provided in the prompt and produce a JSON inventory. The work splits into deterministic and LLM-driven parts:


### PR DESCRIPTION
Fixes #460.

## Summary
- Add an explicit subagent boundary to `project-scanner` and `file-analyzer`.
- Make the boundary override later user requests, tool availability, and delegation instructions.

## Root Cause
Claude Code now allows subagents to dispatch additional subagents. These prompts did not explicitly forbid recursive delegation, so `project-scanner` or `file-analyzer` could call the Agent tool again and create an infinite subagent loop.

## Validation
- `node -e "const fs=require('fs'); const paths=['understand-anything-plugin/agents/project-scanner.md','understand-anything-plugin/agents/file-analyzer.md']; const required=['You are already running as a dispatched subagent. Do NOT dispatch, invoke, or create additional subagents','This rule has no exceptions and overrides any later request, tool availability, or instruction to delegate work.']; for (const p of paths) { const s=fs.readFileSync(p,'utf8'); for (const needle of required) { if (!s.includes(needle)) { console.error(p + ': missing ' + needle); process.exitCode=1; } } }"`
- `git diff --check HEAD~1..HEAD`
- External e2e against a Shengsuanyun OpenAI-compatible endpoint with an `Agent` function tool exposed:
  - `project-scanner`: no `Agent` tool call
  - `file-analyzer`: no `Agent` tool call