### PR TITLE
Fix dashboard skill placeholder paths

### DIFF
--- a/tests/skill/understand/test_skill_security_snippets.test.mjs
+++ b/tests/skill/understand/test_skill_security_snippets.test.mjs
@@ -51,9 +51,12 @@ describe('skill command hardening', () => {
     expect(content).toMatch(/DASHBOARD_DIR="\$PLUGIN_ROOT\/packages\/dashboard"/);
     expect(content).toMatch(/: "\$\{PLUGIN_ROOT:\?Run step 3 first so PLUGIN_ROOT is set\}"/);
     expect(content).toMatch(/: "\$\{PROJECT_DIR:\?Run step 1 first so PROJECT_DIR is set\}"/);
-    expect(content).toMatch(/: "\$\{DASHBOARD_DIR:\?Run step 4 first so DASHBOARD_DIR is set\}"/);
+    expect(content).toMatch(/: "\$\{DASHBOARD_DIR:\?Run step 5 first so DASHBOARD_DIR is set\}"/);
     expect(content).toMatch(/cd "\$PLUGIN_ROOT" && pnpm --filter @understand-anything\/core build/);
     expect(content).toMatch(/cd "\$DASHBOARD_DIR" && GRAPH_DIR="\$PROJECT_DIR" npx vite/);
+    // Fast path: the viewer URL is version-pinned and both npx arguments are quoted.
+    expect(content).toMatch(/VIEWER_URL="https:\/\/github\.com\/Egonex-AI\/Understand-Anything\/releases\/download\/v\$\{PLUGIN_VERSION\}\/understand-anything-viewer\.tgz"/);
+    expect(content).toMatch(/npx --yes "\$VIEWER_URL" "\$PROJECT_DIR"/);
   });
 
   it('marks project-controlled context as untrusted data', () => {

--- a/tests/skill/understand/test_skill_security_snippets.test.mjs
+++ b/tests/skill/understand/test_skill_security_snippets.test.mjs
@@ -42,8 +42,18 @@ describe('skill command hardening', () => {
   it('quotes dashboard cd targets and GRAPH_DIR assignment', () => {
     const content = readRepoFile('understand-anything-plugin/skills/understand-dashboard/SKILL.md');
 
+    expect(content).not.toMatch(/<(?:dashboard-dir|plugin-root|project-dir)>/);
     expect(content).not.toMatch(/\bcd <(?:dashboard-dir|plugin-root)>/);
     expect(content).not.toMatch(/GRAPH_DIR=<project-dir>/);
+    expect(content).toMatch(/PROJECT_DIR=\$\(pwd -P\)/);
+    expect(content).toMatch(/UA_DIR="\$PROJECT_DIR\/\.understand-anything"/);
+    expect(content).toMatch(/\[ ! -f "\$UA_DIR\/knowledge-graph\.json" \]/);
+    expect(content).toMatch(/DASHBOARD_DIR="\$PLUGIN_ROOT\/packages\/dashboard"/);
+    expect(content).toMatch(/: "\$\{PLUGIN_ROOT:\?Run step 3 first so PLUGIN_ROOT is set\}"/);
+    expect(content).toMatch(/: "\$\{PROJECT_DIR:\?Run step 1 first so PROJECT_DIR is set\}"/);
+    expect(content).toMatch(/: "\$\{DASHBOARD_DIR:\?Run step 4 first so DASHBOARD_DIR is set\}"/);
+    expect(content).toMatch(/cd "\$PLUGIN_ROOT" && pnpm --filter @understand-anything\/core build/);
+    expect(content).toMatch(/cd "\$DASHBOARD_DIR" && GRAPH_DIR="\$PROJECT_DIR" npx vite/);
   });
 
   it('marks project-controlled context as untrusted data', () => {

--- a/understand-anything-plugin/skills/understand-dashboard/SKILL.md
+++ b/understand-anything-plugin/skills/understand-dashboard/SKILL.md
@@ -10,13 +10,43 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
 
 ## Instructions
 
-1. Determine the project directory:
+1. Determine the project directory and data directory:
    - If `$ARGUMENTS` contains a path, use that as the project directory
    - Otherwise, use the current working directory
+   - Prefer the legacy `.understand-anything/` data directory when it exists, otherwise use `.ua/`
 
-2. **Resolve the data directory `$UA_DIR`.** Within the project directory, run `UA_DIR="<project-dir>/$([ -d "<project-dir>/.understand-anything" ] && echo .understand-anything || echo .ua)"` — this selects the legacy `.understand-anything/` when it already exists, otherwise the new `.ua/`. Check that `$UA_DIR/knowledge-graph.json` exists in the project directory. If not, tell the user:
+   Use the Bash tool to resolve:
+   ```bash
+   PROJECT_ARG="$ARGUMENTS"
+   if [ -n "$PROJECT_ARG" ]; then
+     PROJECT_DIR=$(cd "$PROJECT_ARG" 2>/dev/null && pwd -P)
+   else
+     PROJECT_DIR=$(pwd -P)
+   fi
+
+   if [ -z "$PROJECT_DIR" ] || [ ! -d "$PROJECT_DIR" ]; then
+     echo "Error: Project directory not found: ${PROJECT_ARG:-$PWD}"
+     exit 1
+   fi
+
+   if [ -d "$PROJECT_DIR/.understand-anything" ]; then
+     UA_DIR="$PROJECT_DIR/.understand-anything"
+   else
+     UA_DIR="$PROJECT_DIR/.ua"
+   fi
+   ```
+
+2. Check that `$UA_DIR/knowledge-graph.json` exists in the project directory. If not, tell the user:
    ```
    No knowledge graph found. Run /understand first to analyze this project.
+   ```
+
+   Use the Bash tool to check:
+   ```bash
+   if [ ! -f "$UA_DIR/knowledge-graph.json" ]; then
+     echo "No knowledge graph found. Run /understand first to analyze this project."
+     exit 1
+   fi
    ```
 
 3. Find the dashboard code. The dashboard is at `packages/dashboard/` relative to this plugin's root directory. Check these paths in order and use the first that exists:
@@ -66,20 +96,27 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
      echo "Make sure you followed the installation instructions for your platform."
      exit 1
    fi
+
+   DASHBOARD_DIR="$PLUGIN_ROOT/packages/dashboard"
    ```
 
 4. Install dependencies and build if needed:
    ```bash
-   cd "<dashboard-dir>" && (pnpm install --frozen-lockfile 2>/dev/null || pnpm install)
+   : "${PLUGIN_ROOT:?Run step 3 first so PLUGIN_ROOT is set}"
+   DASHBOARD_DIR="${DASHBOARD_DIR:-$PLUGIN_ROOT/packages/dashboard}"
+   cd "$DASHBOARD_DIR" && (pnpm install --frozen-lockfile 2>/dev/null || pnpm install)
    ```
    Then ensure the core package is built (the dashboard depends on it):
    ```bash
-   cd "<plugin-root>" && pnpm --filter @understand-anything/core build
+   : "${PLUGIN_ROOT:?Run step 3 first so PLUGIN_ROOT is set}"
+   cd "$PLUGIN_ROOT" && pnpm --filter @understand-anything/core build
    ```
 
 5. Start the Vite dev server pointing at the project's knowledge graph:
    ```bash
-   cd "<dashboard-dir>" && GRAPH_DIR="<project-dir>" npx vite --host 127.0.0.1
+   : "${PROJECT_DIR:?Run step 1 first so PROJECT_DIR is set}"
+   : "${DASHBOARD_DIR:?Run step 4 first so DASHBOARD_DIR is set}"
+   cd "$DASHBOARD_DIR" && GRAPH_DIR="$PROJECT_DIR" npx vite --host 127.0.0.1
    ```
    Run this in the background so the user can continue working.
 

--- a/understand-anything-plugin/skills/understand-dashboard/SKILL.md
+++ b/understand-anything-plugin/skills/understand-dashboard/SKILL.md
@@ -100,7 +100,19 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
    DASHBOARD_DIR="$PLUGIN_ROOT/packages/dashboard"
    ```
 
-4. Install dependencies and build if needed:
+4. **Fast path — try the prebuilt viewer first (no install, no build).** Each release ships a self-contained viewer tarball; run it pinned to the installed plugin version:
+   ```bash
+   : "${PLUGIN_ROOT:?Run step 3 first so PLUGIN_ROOT is set}"
+   : "${PROJECT_DIR:?Run step 1 first so PROJECT_DIR is set}"
+   PLUGIN_VERSION=$(node -p "require('$PLUGIN_ROOT/package.json').version")
+   VIEWER_URL="https://github.com/Egonex-AI/Understand-Anything/releases/download/v${PLUGIN_VERSION}/understand-anything-viewer.tgz"
+   npx --yes "$VIEWER_URL" "$PROJECT_DIR"
+   ```
+   Run this in the background. It prints the same `🔑  Dashboard URL` line as the dev server:
+   - If the line appears, **skip steps 5-6** and continue at step 7.
+   - If the process exits without printing it (no release asset for this version, or no network), fall back to steps 5-6.
+
+5. Fallback: install dependencies and build if needed:
    ```bash
    : "${PLUGIN_ROOT:?Run step 3 first so PLUGIN_ROOT is set}"
    DASHBOARD_DIR="${DASHBOARD_DIR:-$PLUGIN_ROOT/packages/dashboard}"
@@ -112,21 +124,21 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
    cd "$PLUGIN_ROOT" && pnpm --filter @understand-anything/core build
    ```
 
-5. Start the Vite dev server pointing at the project's knowledge graph:
+6. Fallback: start the Vite dev server pointing at the project's knowledge graph:
    ```bash
    : "${PROJECT_DIR:?Run step 1 first so PROJECT_DIR is set}"
-   : "${DASHBOARD_DIR:?Run step 4 first so DASHBOARD_DIR is set}"
+   : "${DASHBOARD_DIR:?Run step 5 first so DASHBOARD_DIR is set}"
    cd "$DASHBOARD_DIR" && GRAPH_DIR="$PROJECT_DIR" npx vite --host 127.0.0.1
    ```
    Run this in the background so the user can continue working.
 
-6. **Capture the access token URL from the server output.** The Vite server prints a line like:
+7. **Capture the access token URL from the server output.** The server (viewer or Vite) prints a line like:
    ```
    🔑  Dashboard URL: http://127.0.0.1:<PORT>?token=<TOKEN>
    ```
    Extract the full URL including the `?token=` parameter. The token is required to access the knowledge graph data — without it the dashboard will show an "Access Token Required" gate.
 
-7. Report to the user, including the full tokenized URL:
+8. Report to the user, including the full tokenized URL:
    ```
    Dashboard started at http://127.0.0.1:<PORT>?token=<TOKEN>
    Viewing: $UA_DIR/knowledge-graph.json
@@ -137,6 +149,7 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
 
 ## Notes
 
-- The dashboard auto-opens in the default browser via `--open`
-- If port 5173 is already in use, Vite will pick the next available port
-- The `GRAPH_DIR` environment variable tells the dashboard where to find the knowledge graph
+- The fast path (step 4) downloads a version-pinned, self-contained viewer from the GitHub release — nothing is installed into the plugin directory and no build runs
+- The dashboard auto-opens in the default browser (both the viewer and Vite's `--open`)
+- If port 5173 is already in use, the next available port is picked (both paths)
+- In the fallback, the `GRAPH_DIR` environment variable tells the dev server where to find the knowledge graph


### PR DESCRIPTION
Closes #497.

## Summary
- Resolve PROJECT_DIR and UA_DIR before checking the dashboard graph data.
- Derive DASHBOARD_DIR from PLUGIN_ROOT and use quoted shell variables for install, build, and Vite launch commands.
- Strengthen the skill hardening test so dashboard-dir, plugin-root, and project-dir placeholders cannot reappear in executable dashboard instructions.

## Validation
- pnpm exec vitest run tests/skill/understand/test_skill_security_snippets.test.mjs
- pnpm --filter @understand-anything/dashboard test -- src/utils/__tests__/smoke.test.ts
- pnpm --filter @understand-anything/dashboard build
- Fresh-cloned GoogleCloudPlatform/microservices-demo, generated a knowledge graph, launched the dashboard locally from this branch, and verified the served/rendered graph contained 339 nodes, 161 edges, 7 layers, and 4 tour steps.