### PR TITLE
fix(dashboard): guard res.ok on the knowledge-graph fetch (fixes misleading "Missing or invalid project metadata")

### DIFF
--- a/understand-anything-plugin/packages/dashboard/src/App.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/App.tsx
@@ -133,7 +133,26 @@ function Dashboard({ accessToken }: { accessToken: string }) {
 
   useEffect(() => {
     fetch(dataUrl("knowledge-graph.json", accessToken))
-      .then((res) => res.json())
+      .then(async (res) => {
+        // Guard res.ok before parsing (matching the meta.json/config.json/
+        // diff-overlay.json/domain-graph.json fetches in this file). Without
+        // this, a serving/config failure returns a 404 JSON error body that
+        // gets parsed and handed to validateGraph, which fails project-metadata
+        // validation and surfaces the misleading "Invalid knowledge graph:
+        // Missing or invalid project metadata" instead of the real cause
+        // (graph file not found / GRAPH_DIR unset). See issues #288, #406.
+        if (!res.ok) {
+          let detail = `HTTP ${res.status}`;
+          try {
+            const body = await res.json();
+            if (body?.error) detail = body.error;
+          } catch {
+            /* non-JSON error body; keep the status code */
+          }
+          throw new Error(detail);
+        }
+        return res.json();
+      })
       .then((data: unknown) => {
         const result = validateGraph(data);
         if (result.success && result.data) {


### PR DESCRIPTION
## Problem

Several users (#288, #406) hit a fatal dashboard error **"Invalid knowledge graph: Missing or invalid project metadata"** in situations where the graph file was never actually served (e.g. `GRAPH_DIR` unset - common on Windows PowerShell, where the documented `GRAPH_DIR=... npx vite` bash-prefix syntax does not set the env var).

The message is misleading: the graph wasn't malformed, it was never loaded.

## Root cause

In `packages/dashboard/src/App.tsx`, the `knowledge-graph.json` fetch is the **only** data fetch in the file that calls `res.json()` without first checking `res.ok`:

```ts
fetch(dataUrl("knowledge-graph.json", accessToken))
  .then((res) => res.json())            // <- no res.ok guard
  .then((data) => { validateGraph(data) ... })
```

The sibling fetches all guard correctly:
- `meta.json` / `config.json`: `.then((r) => (r.ok ? r.json() : null))`
- `diff-overlay.json` / `domain-graph.json`: `if (!res.ok) return null;`

When `vite.config.ts` returns its 404 JSON error body (`{ "error": "No knowledge graph found. Run /understand first." }`), that object is parsed and handed to `validateGraph()`. Since it has no `project` field, `ProjectMetaSchema.safeParse` fails and `validateGraph` returns the fatal `"Missing or invalid project metadata"`, which becomes the displayed error.

Causal chain: **404 JSON body -> unguarded `res.json()` -> `validateGraph(errorBody)` -> `ProjectMetaSchema` fails -> "Missing or invalid project metadata".**

## Fix

Guard `res.ok` on the knowledge-graph fetch (matching the four sibling fetches) and surface the server's actual error message via the existing `.catch`, so users see the real, actionable cause:

> Failed to load knowledge graph: No knowledge graph found. Run /understand first.

instead of a schema-validation red herring. One-file change, no behavior change on the success path.

This is exactly the frontend guard suggested by the reporter in #288.

## Verification

- `tsc -b` on the dashboard package: clean
- `eslint` on the changed file: clean
- `vitest run` (dashboard): 57/57 pass

## Note on a related, separate gap (not fixed here)

The genuinely-malformed case can also arise if a graph is written without a required `project` field (`ProjectMetaSchema` requires `name`, `languages`, `frameworks`, `description`, `analyzedAt`, `gitCommitHash`). The `/understand` skill's inline Phase-6 validator checks nodes/edges/layers/tour but does not validate `project` metadata, so a run can pass inline yet be rejected by the dashboard's `validateGraph`. That's a separate change and out of scope for this PR, but worth a follow-up so the two validators agree.

Fixes #288
Fixes #406