### PR TITLE
feat(core): broaden .understandignore starter — Python test/fixture patterns

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
@@ -222,6 +222,11 @@ describe("generateStarterIgnoreFile", () => {
       expect(content).toContain("# **/tests.py");
     });
 
+    it("includes pytest conftest.py convention", () => {
+      const content = generateStarterIgnoreFile(testDir);
+      expect(content).toContain("# **/conftest.py");
+    });
+
     it("groups patterns under the JS / TS sub-header", () => {
       const content = generateStarterIgnoreFile(testDir);
       expect(content).toContain("# JS / TS");

--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
@@ -208,23 +208,34 @@ describe("generateStarterIgnoreFile", () => {
       expect(content).toContain("# **/*Benchmark.cpp");
     });
 
+    it("includes Python pytest / unittest file patterns", () => {
+      const content = generateStarterIgnoreFile(testDir);
+      expect(content).toContain("# Python");
+      // pytest / unittest default discovery — file must start with test_.
+      expect(content).toContain("# **/test_*.py");
+      // Alternate convention used by tensorflow, google-style, etc.
+      expect(content).toContain("# **/*_test.py");
+    });
+
     it("groups patterns under the JS / TS sub-header", () => {
       const content = generateStarterIgnoreFile(testDir);
       expect(content).toContain("# JS / TS");
     });
 
-    it("emits language groups in stable order: JS, C#, Java, Go, C++", () => {
+    it("emits language groups in stable order: JS, C#, Java, Go, C++, Python", () => {
       const content = generateStarterIgnoreFile(testDir);
       const jsIdx = content.indexOf("# JS / TS");
       const csIdx = content.indexOf("# C# / .NET");
       const javaIdx = content.indexOf("# Java / Kotlin");
       const goIdx = content.indexOf("# Go");
       const cppIdx = content.indexOf("# C++");
+      const pyIdx = content.indexOf("# Python");
       expect(jsIdx).toBeGreaterThan(-1);
       expect(csIdx).toBeGreaterThan(jsIdx);
       expect(javaIdx).toBeGreaterThan(csIdx);
       expect(goIdx).toBeGreaterThan(javaIdx);
       expect(cppIdx).toBeGreaterThan(goIdx);
+      expect(pyIdx).toBeGreaterThan(cppIdx);
     });
 
     it("keeps all suggestions commented even with no detected dirs and no .gitignore", () => {

--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
@@ -217,6 +217,11 @@ describe("generateStarterIgnoreFile", () => {
       expect(content).toContain("# **/*_test.py");
     });
 
+    it("includes Django's single-file tests.py convention", () => {
+      const content = generateStarterIgnoreFile(testDir);
+      expect(content).toContain("# **/tests.py");
+    });
+
     it("groups patterns under the JS / TS sub-header", () => {
       const content = generateStarterIgnoreFile(testDir);
       expect(content).toContain("# JS / TS");

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -104,6 +104,7 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
       "**/test_*.py",
       "**/*_test.py",
       "**/tests.py",
+      "**/conftest.py",
     ],
   },
 ];

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -94,6 +94,17 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
       "**/*Benchmark.cpp",
     ],
   },
+  {
+    // pytest / unittest discovery is filename-based, so large Python
+    // codebases (pandas, numpy, scikit-learn, tensorflow) commonly ship
+    // test_*.py or *_test.py files co-located with the module under test
+    // rather than clustered in a single tests/ tree.
+    label: "Python",
+    patterns: [
+      "**/test_*.py",
+      "**/*_test.py",
+    ],
+  },
 ];
 
 /**

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -95,10 +95,14 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
     ],
   },
   {
-    // pytest / unittest discovery is filename-based, so large Python
-    // codebases (pandas, numpy, scikit-learn, tensorflow) commonly ship
-    // test_*.py or *_test.py files co-located with the module under test
-    // rather than clustered in a single tests/ tree.
+    // Python testing conventions are bimodal. Most projects (django,
+    // flask, pandas, numpy) cluster tests inside a top-level tests/ dir,
+    // where the existing directory rules already catch them. But Google-
+    // style codebases (tensorflow, jax, some Meta libs) interleave
+    // *_test.py directly alongside the module under test — e.g. tensor-
+    // flow/python/ops/array_ops.py + array_ops_test.py — so file-pattern
+    // rules add the majority of the token savings for that half of the
+    // ecosystem.
     label: "Python",
     patterns: [
       "**/test_*.py",

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -103,6 +103,7 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
     patterns: [
       "**/test_*.py",
       "**/*_test.py",
+      "**/tests.py",
     ],
   },
 ];


### PR DESCRIPTION
## Summary

- New `TEST_PATTERN_GROUPS` entry `Python` with 4 patterns (pytest `test_*.py`, Google-style `*_test.py`, Django `tests.py`, pytest `conftest.py`)
- +3 tests in `ignore-generator.test.ts`; ordering invariant extended to place Python after C++
- build + lint clean; ignore-generator suite 41/41 pass, core suite 862 pass (2 pre-existing wasm module resolution failures on `scala-extractor.test.ts` / `swift-extractor.test.ts` reproduce unmodified on `origin/main`)

`SKILL.md` unchanged — Phase 0.5 delegates to `generate-ignore.mjs` since a0155c5, so no inline duplicate to keep in sync.

## Why these patterns (and not others)

Python testing is bimodal:
- **Cluster-in-`tests/`** projects (django, flask, pandas, numpy, scikit-learn) — existing directory rules already catch the tests; adding file patterns is essentially free.
- **Google-style interleaved** (tensorflow, jax, portions of cpython/pytorch) — dir rules miss the tests entirely; file patterns are the load-bearing exclusion.

Rejected as too project-specific or ambiguous: `**/*Test.py` (PascalCase Python filenames are rare — one-off matches per repo), `**/*_pytest.py` / `**/*_unittest.py` (not conventional), `**/testing/**` (name too generic — pytest's own repo uses it, but so do non-test dirs).

Kept `conftest.py` as a separate opt-in because it holds fixtures rather than tests-under-test — users who share fixtures with production imports can leave it commented and still take the other three globs.

## Token impact (measured on `tensorflow/tensorflow`)

Methodology: `gh api .../git/trees?recursive=1`, Python source = `.py .pyi .pyx`, 1 MiB ≈ 262K tokens.

| Project | Before (analyzed) | After (analyzed) | Reduction |
|---|---|---|---|
| `tensorflow/tensorflow` | 43.31 MB / ~10.82M tok | 22.92 MB / ~5.73M tok | **−5.09M (47%)** |

1205 of tensorflow's 3275 `.py` files match one of the four new globs; all reside outside the current directory-ignore surface (`tensorflow/python/**/*_test.py` sits directly next to `tensorflow/python/**/*.py`).

The uniform-savings story from #480 (median ~31% across 7 C++ repos) does not reproduce for Python — because most Python ecosystems already cluster tests into `tests/`. TensorFlow-scale wins are Google-style-specific but real, and the opt-in model means Django-style projects incur zero behaviour change unless they uncomment the group.

## Test plan
- [x] `pnpm --filter @understand-anything/core build` — clean
- [x] `pnpm --filter @understand-anything/core exec vitest run src/__tests__/ignore-generator.test.ts` — 41/41 pass (3 new Python-group tests)
- [x] `pnpm --filter @understand-anything/core test` — 862 pass, 2 pre-existing wasm-module failures also present on `origin/main` (unrelated: scala-extractor, swift-extractor)
- [x] `pnpm lint` — clean
- [x] Manual preview of generated `.understandignore` on a fixture with `tests/`, `bench/`, plus a co-located `foo.py` + `foo_test.py` — Python group emitted after C++, all four patterns present, all commented

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)