### PR TITLE
feat(core): broaden .understandignore starter — Rust test/bench patterns

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
@@ -162,6 +162,12 @@ describe("generateStarterIgnoreFile", () => {
       const content = generateStarterIgnoreFile(testDir);
       expect(content).toContain("# bench/");
     });
+
+    it("suggests benches/ directories (Cargo convention)", () => {
+      mkdirSync(join(testDir, "benches"), { recursive: true });
+      const content = generateStarterIgnoreFile(testDir);
+      expect(content).toContain("# benches/");
+    });
   });
 
   describe("language-grouped test file patterns", () => {

--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
@@ -240,6 +240,15 @@ describe("generateStarterIgnoreFile", () => {
       expect(content).toContain("# **/tests.rs");
     });
 
+    it("includes Rust workspace-style *_test.rs and test_*.rs conventions", () => {
+      const content = generateStarterIgnoreFile(testDir);
+      // Dominant in large workspaces (polkadot-sdk, rust-lang/rust,
+      // solana-labs/solana) where tests colocate with source rather
+      // than living inside inline `#[cfg(test)] mod tests`.
+      expect(content).toContain("# **/test_*.rs");
+      expect(content).toContain("# **/*_test.rs");
+    });
+
     it("groups patterns under the JS / TS sub-header", () => {
       const content = generateStarterIgnoreFile(testDir);
       expect(content).toContain("# JS / TS");

--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
@@ -233,12 +233,19 @@ describe("generateStarterIgnoreFile", () => {
       expect(content).toContain("# **/conftest.py");
     });
 
+    it("includes Rust tests.rs per-module extraction convention", () => {
+      const content = generateStarterIgnoreFile(testDir);
+      expect(content).toContain("# Rust");
+      // Rust Book ch. 11.3 pattern — extracted sibling test module.
+      expect(content).toContain("# **/tests.rs");
+    });
+
     it("groups patterns under the JS / TS sub-header", () => {
       const content = generateStarterIgnoreFile(testDir);
       expect(content).toContain("# JS / TS");
     });
 
-    it("emits language groups in stable order: JS, C#, Java, Go, C++, Python", () => {
+    it("emits language groups in stable order: JS, C#, Java, Go, C++, Python, Rust", () => {
       const content = generateStarterIgnoreFile(testDir);
       const jsIdx = content.indexOf("# JS / TS");
       const csIdx = content.indexOf("# C# / .NET");
@@ -246,12 +253,14 @@ describe("generateStarterIgnoreFile", () => {
       const goIdx = content.indexOf("# Go");
       const cppIdx = content.indexOf("# C++");
       const pyIdx = content.indexOf("# Python");
+      const rustIdx = content.indexOf("# Rust");
       expect(jsIdx).toBeGreaterThan(-1);
       expect(csIdx).toBeGreaterThan(jsIdx);
       expect(javaIdx).toBeGreaterThan(csIdx);
       expect(goIdx).toBeGreaterThan(javaIdx);
       expect(cppIdx).toBeGreaterThan(goIdx);
       expect(pyIdx).toBeGreaterThan(cppIdx);
+      expect(rustIdx).toBeGreaterThan(pyIdx);
     });
 
     it("keeps all suggestions commented even with no detected dirs and no .gitignore", () => {

--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
@@ -249,6 +249,15 @@ describe("generateStarterIgnoreFile", () => {
       expect(content).toContain("# **/*_test.rs");
     });
 
+    it("includes Rust criterion / test::Bencher file patterns", () => {
+      const content = generateStarterIgnoreFile(testDir);
+      // Defensive: most Cargo benches live under `benches/` (covered by
+      // the dir rule) but a small fraction of workspaces name benchmark
+      // files with these prefixes/suffixes outside that directory.
+      expect(content).toContain("# **/bench_*.rs");
+      expect(content).toContain("# **/*_bench.rs");
+    });
+
     it("groups patterns under the JS / TS sub-header", () => {
       const content = generateStarterIgnoreFile(testDir);
       expect(content).toContain("# JS / TS");

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -34,6 +34,7 @@ const EXACT_DIR_NAMES = [
   "bench",
   "benchmark",
   "benchmarks",
+  "benches",
 ];
 
 // Directory-name suffixes matched case-insensitively via String.endsWith.

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -113,13 +113,17 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
     ],
   },
   {
-    // Rust's dominant unit-test convention is inline `#[cfg(test)] mod
-    // tests { ... }` blocks that cannot be excluded by filename. The
-    // Rust Book (chapter 11.3) also describes extracting those blocks
-    // into a sibling `tests.rs` file — that extracted form is what a
-    // file-pattern rule can catch. Integration tests already live under
-    // tests/ (covered by EXACT_DIR_NAMES); benches/ was added in the
-    // same PR as this group.
+    // Rust testing is bimodal, similar to Python. Library-scale crates
+    // (ripgrep, alacritty, helix, cargo) keep unit tests inline in
+    // `#[cfg(test)] mod tests { ... }` blocks that no file-pattern
+    // rule can catch, so the group barely moves the needle for them.
+    // Workspace monorepos (paritytech/polkadot-sdk, solana-labs/solana,
+    // rust-lang/rust) colocate a `foo_test.rs` beside `foo.rs` at
+    // scale — measurement showed *_test.rs alone accounts for the
+    // majority of hits (232 files / −15% on polkadot-sdk analysed
+    // budget). Integration tests already live under tests/ and Cargo
+    // benches under benches/ (both dir-covered), so the file globs
+    // here target the colocated shape specifically.
     label: "Rust",
     patterns: [
       "**/tests.rs",

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -112,6 +112,19 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
       "**/conftest.py",
     ],
   },
+  {
+    // Rust's dominant unit-test convention is inline `#[cfg(test)] mod
+    // tests { ... }` blocks that cannot be excluded by filename. The
+    // Rust Book (chapter 11.3) also describes extracting those blocks
+    // into a sibling `tests.rs` file — that extracted form is what a
+    // file-pattern rule can catch. Integration tests already live under
+    // tests/ (covered by EXACT_DIR_NAMES); benches/ was added in the
+    // same PR as this group.
+    label: "Rust",
+    patterns: [
+      "**/tests.rs",
+    ],
+  },
 ];
 
 /**

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -123,6 +123,8 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
     label: "Rust",
     patterns: [
       "**/tests.rs",
+      "**/test_*.rs",
+      "**/*_test.rs",
     ],
   },
 ];

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -125,6 +125,8 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
       "**/tests.rs",
       "**/test_*.rs",
       "**/*_test.rs",
+      "**/bench_*.rs",
+      "**/*_bench.rs",
     ],
   },
 ];


### PR DESCRIPTION
## Summary

- `EXACT_DIR_NAMES` += `benches` — Cargo's canonical plural benchmark directory (currently only the singular / C++-style `bench` / `benchmark` / `benchmarks` variants are recognised).
- New `TEST_PATTERN_GROUPS` entry `Rust` with 5 patterns (Rust Book `tests.rs`, colocated `*_test.rs` / `test_*.rs`, criterion `bench_*.rs` / `*_bench.rs`).
- +4 tests in `ignore-generator.test.ts`; ordering invariant extended to place Rust after Python.
- build + lint clean; ignore-generator suite 45/45 pass, core suite 866 pass (2 pre-existing wasm module resolution failures on `scala-extractor.test.ts` / `swift-extractor.test.ts` reproduce unmodified on `origin/main`).

`SKILL.md` unchanged — Phase 0.5 delegates to `generate-ignore.mjs` since a0155c5, so no inline duplicate to keep in sync.

## Why these patterns (and not others)

Rust testing is bimodal:
- **Library-scale crates** (ripgrep, alacritty, helix, cargo) keep unit tests inline in `#[cfg(test)] mod tests { … }` — no file-pattern rule can touch them, group is a near-noop.
- **Workspace monorepos** (polkadot-sdk, solana, rust-lang/rust) colocate `foo_test.rs` next to `foo.rs` at scale — dir rules miss them entirely; file patterns are load-bearing.

Rejected as too project-specific or ambiguous: `**/*Test.rs` (PascalCase Rust filenames are rare — snake_case dominates), `**/it_*.rs` / `**/*_it.rs` (no Rust ecosystem uses "IT" as an integration-test marker — integration tests live under `tests/`), `**/*Bench.rs` (PascalCase, effectively unused).

Kept `**/tests.rs` and `**/*_test.rs` as separate globs so users on Rust Book–style projects (single sibling `tests.rs` per module) aren't forced to also strip a colocated-file shape they never use.

## Token impact (measured across ~60 public Rust repos)

Methodology: `gh api .../git/trees?recursive=1`, Rust source = `.rs`, 1 MiB ≈ 262K tokens. Two hero projects reported below — the highest **percentage** win and the highest **absolute** win — because Rust's ecosystem produces genuinely bimodal savings.

| Project | Before (analyzed) | After (analyzed) | Reduction |
|---|---|---|---|
| `paritytech/parity-common` | 0.52 MB / ~0.13M tok | 0.37 MB / ~0.09M tok | **−0.04M (28%)** |
| `paritytech/polkadot-sdk` | 51.84 MB / ~12.95M tok | 44.14 MB / ~11.03M tok | **−1.92M (15%)** |

- **`parity-common`** — small utility-crate monorepo, best % result in the survey. Colocated `*_test.rs` files dominate the source tree.
- **`polkadot-sdk`** — largest absolute saving. 232 files match the new file globs; 28 more sit under `benches/` subdirs the current rule misses. All reside outside the current directory-ignore surface (`substrate/frame/**/*_test.rs` sits directly next to the pallet source).

Unlike C++ (PR #480, up to 62% on nlohmann/json) and Python (PR #579, 47% on tensorflow), Rust never approaches those percentages in the wild because the dominant unit-test convention is inline `#[cfg(test)] mod tests { … }` — invisible to any file-pattern rule. That's the ecosystem, not a gap in these patterns. The opt-in model means library-scale projects incur zero behaviour change unless they uncomment the group; monorepo workspaces see the parity-common / polkadot-sdk-scale savings the moment they do.

## Test plan
- [x] `pnpm --filter @understand-anything/core build` — clean
- [x] `pnpm --filter @understand-anything/core exec vitest run src/__tests__/ignore-generator.test.ts` — 45/45 pass (4 new Rust tests + the `benches/` dir test)
- [x] `pnpm --filter @understand-anything/core test` — 866 pass, 2 pre-existing wasm-module failures also present on `origin/main` (unrelated: scala-extractor, swift-extractor)
- [x] `pnpm lint` — clean
- [x] Manual preview of generated `.understandignore` on a fixture with `benches/`, `tests/`, plus a colocated `foo.rs` + `foo_test.rs` — Rust group emitted after Python, all five patterns present, `# benches/` in the detected-dirs section, all commented

Closes #581