### PR TITLE
perf(bench): add reproducible large-monorepo benchmark and scale report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 .env
 .env.*
 coverage/
+benchmark-results/
 *.log
 __pycache__/
 .claude/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,13 @@ Then open a Pull Request on GitHub with:
 
 ## 🧪 Testing Guidelines
 
+### Large Repository Benchmarks
+
+Use the [large monorepo benchmark](docs/benchmarks/large-monorepo.md) to collect
+reproducible scale, timing, and memory reports from projects that are too large
+for CI fixtures. The guide includes a pinned TensorFlow example and explains
+which deterministic stages are measured.
+
 ### Writing Tests
 
 - Use Vitest for testing

--- a/docs/benchmarks/large-monorepo.md
+++ b/docs/benchmarks/large-monorepo.md
@@ -1,0 +1,146 @@
+# Large Monorepo Benchmark
+
+Use this benchmark to collect reproducible scale and performance evidence from
+large repositories without running an LLM. It is intended for local and
+community runs on projects that are too large for normal CI fixtures.
+
+## Scope
+
+The runner executes the real deterministic helpers used by `/understand`:
+
+1. file scanning, classification, and line counting;
+2. static import-map extraction;
+3. semantic batch planning; and
+4. Tree-sitter structural extraction for every batch.
+
+It reports wall-clock time, CPU time where available, peak resident memory,
+output size, repository scale, batching statistics, structural coverage, and
+deterministic SHA-256 digests.
+
+For the regular scan, imports, and batching helpers, `peakRssBytes` is the peak
+RSS of that helper process. The concurrent structure stage instead reports
+`maxWorkerPeakRssBytes`, the maximum peak RSS of any individual worker, not a
+sum across workers. Its `userCpuTimeMicros` and `systemCpuTimeMicros` values are
+summed across all structure workers.
+
+It does **not** run an LLM, call an API, count tokens, estimate cost, generate a
+knowledge graph, or render the dashboard. Do not present these results as an
+end-to-end `/understand` benchmark. `estimatedAgentInputBytes` is the size of
+the deterministic batch payload, not a token estimate.
+
+## Run the benchmark
+
+From an Understand Anything checkout:
+
+```bash
+corepack pnpm install --frozen-lockfile
+corepack pnpm --filter @understand-anything/core build
+corepack pnpm benchmark:large-repo /absolute/path/to/repository --label public-repository-name --output /absolute/path/to/benchmark-results/public-repository-name.json
+```
+
+The command writes two files:
+
+- `public-repository-name.json`, which conforms to the versioned
+  [report schema](large-repo-report-1.0.0.schema.json); and
+- `public-repository-name.md`, a human-readable summary beside the JSON file.
+
+The benchmark tests compile that schema and validate normal, empty, degraded,
+and partial failed reports against it. The runner does not perform runtime
+schema validation.
+
+The default concurrency is 5. Override it with `--concurrency 1` through
+`--concurrency 32`. Use the same concurrency when comparing runs.
+
+All intermediate files are created under the operating system's temporary
+directory and deleted after the run. Existing `.ua/` and
+`.understand-anything/` analysis data is excluded from benchmark input. The
+only persistent writes are the requested JSON report and its adjacent Markdown
+summary. `--output` is mandatory and must resolve outside the subject
+repository; the CLI enforces this boundary, including through filesystem
+aliases.
+
+Published warning summaries are bounded. Each entry records the stage, the
+total warning `count`, up to five sanitized `messages`, and a `truncated` flag
+that reports omitted or shortened detail.
+
+`--keep-artifacts` preserves intermediate files and prints their location.
+Those private files contain absolute paths and detailed structural data; do not
+publish them without reviewing and sanitizing them.
+
+## Reproducibility protocol
+
+For results that another contributor can reproduce:
+
+1. Record an immutable commit for both Understand Anything and the subject
+   repository. The report captures both commits when the directories are Git
+   worktrees.
+2. Use clean worktrees where possible. The report records `dirty: true` when
+   tracked or untracked changes are present.
+3. Keep the operating system, Node.js version, machine, concurrency, and
+   `.understandignore` rules constant between compared runs.
+4. Run at least three times and retain every report. Treat the first run as a
+   possible cold-cache result instead of silently discarding it.
+5. Compare timing and memory only on the same machine. Cross-machine reports
+   are useful scale evidence, but they are not a fair performance regression
+   comparison.
+6. Confirm matching `inputDigest` and `outputDigest` values before comparing
+   performance for supposedly identical inputs.
+
+Share both the JSON and Markdown files. The report intentionally omits the Git
+remote URL, hostname, and absolute subject/tool/artifact paths. It does include
+the public label, commit hashes, OS release, CPU model, memory size, and project
+statistics, so review both files before publishing them.
+
+## TensorFlow reproduction recipe
+
+TensorFlow is a useful manual subject because it is a large, multilingual
+monorepo. The benchmark is not TensorFlow-specific, and TensorFlow is
+intentionally not cloned or benchmarked in CI. The commands below are a
+reproduction recipe, not a claim that a TensorFlow benchmark was run.
+
+This example pins TensorFlow v2.19.0 to commit
+`e36baa302922ea3c7131b302c2996bd2051ee5c4`:
+
+### Bash
+
+```bash
+git clone --depth 1 --branch v2.19.0 https://github.com/tensorflow/tensorflow.git ../tensorflow-v2.19.0
+if [ "$(git -C ../tensorflow-v2.19.0 rev-parse HEAD)" != "e36baa302922ea3c7131b302c2996bd2051ee5c4" ]; then echo "TensorFlow v2.19.0 did not resolve to the pinned commit" >&2; exit 1; fi
+corepack pnpm benchmark:large-repo ../tensorflow-v2.19.0 --label tensorflow-v2.19.0 --output ../benchmark-results/tensorflow-v2.19.0.json
+```
+
+### PowerShell
+
+```powershell
+git clone --depth 1 --branch v2.19.0 https://github.com/tensorflow/tensorflow.git ..\tensorflow-v2.19.0
+if ((git -C ..\tensorflow-v2.19.0 rev-parse HEAD).Trim() -ne 'e36baa302922ea3c7131b302c2996bd2051ee5c4') { throw 'TensorFlow v2.19.0 did not resolve to the pinned commit' }
+corepack pnpm benchmark:large-repo ..\tensorflow-v2.19.0 --label tensorflow-v2.19.0 --output ..\benchmark-results\tensorflow-v2.19.0.json
+```
+
+Both recipes assert the immutable commit before benchmarking and keep report
+outputs outside the TensorFlow checkout. Community testers can share the two
+report files; the environment block makes hardware and runtime differences
+explicit.
+
+## Community scale plan
+
+1. Land the reproducible deterministic harness and its validation-tested report
+   contract.
+2. Collect at least three reports with matching input and output digests for
+   TensorFlow and other community monorepos.
+3. Compare timing and memory only across same-machine runs.
+4. Use that evidence to choose the next bottleneck to optimize.
+5. Keep LLM, token, and cost benchmarking as a separate future layer rather
+   than inferring end-to-end performance from this deterministic harness.
+
+## Status and exit codes
+
+| Exit code | Meaning | Report behavior |
+| ---: | --- | --- |
+| `0` | Completed with status `ok` or `degraded` | JSON and Markdown are written |
+| `1` | A deterministic stage or integrity check failed | Partial reports are written when the output location is writable |
+| `2` | Invalid CLI usage | No report is written |
+
+`degraded` means the deterministic pipeline completed but reported warnings or
+skipped files. Inspect `warnings`, `integrity`, and the Markdown summary before
+using that run in a comparison.

--- a/docs/benchmarks/large-monorepo.md
+++ b/docs/benchmarks/large-monorepo.md
@@ -48,6 +48,15 @@ The benchmark tests compile that schema and validate normal, empty, degraded,
 and partial failed reports against it. The runner does not perform runtime
 schema validation.
 
+The JSON and Markdown files share a generated `pairId`. Writers for the same
+pair are serialized with an exclusive lock, and a caught synchronous delivery
+failure attempts to restore both previous files. This is not a crash-atomic
+filesystem transaction: process termination, power loss, or a machine crash
+between renames can still leave a missing or mismatched pair. Consumers should
+compare the `pairId` in both files and reject a mismatch. Recovery failures are
+reported only as bounded counters; report errors do not expose filesystem
+paths.
+
 The default concurrency is 5. Override it with `--concurrency 1` through
 `--concurrency 32`. Use the same concurrency when comparing runs.
 
@@ -63,6 +72,12 @@ Published warning summaries are bounded. Each entry records the stage, the
 total warning `count`, up to five sanitized `messages`, and a `truncated` flag
 that reports omitted or shortened detail.
 
+Structure diagnostics are bounded across the whole run, rather than once per
+batch. The report retains deterministic samples and aggregate success, failure,
+and skip counts, but discards raw per-worker stdout and stderr after those
+summaries are formed. Structural coverage counts successful structure analyses;
+failed analyses remain failures instead of being reported as skipped work.
+
 `--keep-artifacts` preserves intermediate files and prints their location.
 Those private files contain absolute paths and detailed structural data; do not
 publish them without reviewing and sanitizing them.
@@ -75,7 +90,8 @@ For results that another contributor can reproduce:
    repository. The report captures both commits when the directories are Git
    worktrees.
 2. Use clean worktrees where possible. The report records `dirty: true` when
-   tracked or untracked changes are present.
+   tracked or untracked changes are present, and the Markdown report displays a
+   visible warning when either the tool or subject worktree is dirty.
 3. Keep the operating system, Node.js version, machine, concurrency, and
    `.understandignore` rules constant between compared runs.
 4. Run at least three times and retain every report. Treat the first run as a
@@ -138,7 +154,7 @@ explicit.
 | Exit code | Meaning | Report behavior |
 | ---: | --- | --- |
 | `0` | Completed with status `ok` or `degraded` | JSON and Markdown are written |
-| `1` | A deterministic stage or integrity check failed | Partial reports are written when the output location is writable |
+| `1` | A deterministic stage, integrity check, or temporary-artifact cleanup failed | Partial reports are written when the output location is writable; cleanup failures appear in `secondaryErrors` without replacing the primary stage error |
 | `2` | Invalid CLI usage | No report is written |
 
 `degraded` means the deterministic pipeline completed but reported warnings or

--- a/docs/benchmarks/large-monorepo.md
+++ b/docs/benchmarks/large-monorepo.md
@@ -76,7 +76,10 @@ Structure diagnostics are bounded across the whole run, rather than once per
 batch. The report retains deterministic samples and aggregate success, failure,
 and skip counts, but discards raw per-worker stdout and stderr after those
 summaries are formed. Structural coverage counts successful structure analyses;
-failed analyses remain failures instead of being reported as skipped work.
+files without a registered structural parser are accounted in `filesSkipped`
+and produce a degraded report. Missing optional call-graph capability is also
+skipped. After a parser advertises a capability, an exception or invalid result
+remains an integrity failure instead of being reported as skipped work.
 
 `--keep-artifacts` preserves intermediate files and prints their location.
 Those private files contain absolute paths and detailed structural data; do not

--- a/docs/benchmarks/large-repo-report-1.0.0.schema.json
+++ b/docs/benchmarks/large-repo-report-1.0.0.schema.json
@@ -7,6 +7,7 @@
   "required": [
     "schemaUrl",
     "schemaVersion",
+    "pairId",
     "status",
     "mode",
     "run",
@@ -20,6 +21,7 @@
     "determinism",
     "llm",
     "warnings",
+    "secondaryErrors",
     "error"
   ],
   "properties": {
@@ -27,6 +29,10 @@
       "const": "https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/docs/benchmarks/large-repo-report-1.0.0.schema.json"
     },
     "schemaVersion": { "const": "1.0.0" },
+    "pairId": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
     "status": { "enum": ["ok", "degraded", "failed"] },
     "mode": { "const": "deterministic" },
     "run": { "$ref": "#/$defs/run" },
@@ -57,6 +63,11 @@
     "warnings": {
       "type": "array",
       "items": { "$ref": "#/$defs/warning" }
+    },
+    "secondaryErrors": {
+      "type": "array",
+      "maxItems": 5,
+      "items": { "$ref": "#/$defs/secondaryError" }
     },
     "error": { "type": ["string", "null"] }
   },
@@ -93,6 +104,7 @@
           },
           "integrity": { "$ref": "#/$defs/successIntegrity" },
           "determinism": { "$ref": "#/$defs/determinism" },
+          "secondaryErrors": { "type": "array", "maxItems": 0 },
           "error": { "type": "null" }
         }
       }
@@ -127,6 +139,34 @@
             }
           }
         }
+      }
+    },
+    {
+      "if": {
+        "properties": { "status": { "const": "degraded" } },
+        "required": ["status"]
+      },
+      "then": {
+        "anyOf": [
+          {
+            "properties": {
+              "warnings": { "type": "array", "minItems": 1 }
+            },
+            "required": ["warnings"]
+          },
+          {
+            "properties": {
+              "integrity": {
+                "type": "object",
+                "properties": {
+                  "filesSkipped": { "type": "integer", "minimum": 1 }
+                },
+                "required": ["filesSkipped"]
+              }
+            },
+            "required": ["integrity"]
+          }
+        ]
       }
     },
     {
@@ -438,7 +478,9 @@
         "warningCount",
         "warningMessages",
         "warningMessagesTruncated",
-        "outputBytes"
+        "outputBytes",
+        "failureSamples",
+        "failureSamplesTruncated"
       ],
       "properties": {
         "status": { "$ref": "#/$defs/status" },
@@ -449,11 +491,22 @@
         "warningCount": { "$ref": "#/$defs/count" },
         "warningMessages": { "$ref": "#/$defs/warningMessages" },
         "warningMessagesTruncated": { "type": "boolean" },
+        "failureSamples": {
+          "type": "array",
+          "maxItems": 5,
+          "items": { "$ref": "#/$defs/failureSample" }
+        },
+        "failureSamplesTruncated": { "type": "boolean" },
         "outputBytes": { "$ref": "#/$defs/count" },
         "batchesSucceeded": { "$ref": "#/$defs/count" },
         "batchesFailed": { "$ref": "#/$defs/count" },
         "filesAnalyzed": { "$ref": "#/$defs/count" },
         "filesSkipped": { "$ref": "#/$defs/count" },
+        "structureSucceeded": { "$ref": "#/$defs/count" },
+        "structureFailed": { "$ref": "#/$defs/count" },
+        "callGraphSucceeded": { "$ref": "#/$defs/count" },
+        "callGraphFailed": { "$ref": "#/$defs/count" },
+        "callGraphSkipped": { "$ref": "#/$defs/count" },
         "entities": { "$ref": "#/$defs/entities" },
         "batchDurationMs": { "$ref": "#/$defs/distribution" }
       },
@@ -469,6 +522,11 @@
               "batchesFailed",
               "filesAnalyzed",
               "filesSkipped",
+              "structureSucceeded",
+              "structureFailed",
+              "callGraphSucceeded",
+              "callGraphFailed",
+              "callGraphSkipped",
               "entities",
               "batchDurationMs"
             ]
@@ -496,6 +554,8 @@
         "unexpectedBatchFiles",
         "missingImportTargets",
         "structureCoverage",
+        "structureFailures",
+        "callGraphFailures",
         "filesSkipped",
         "failedBatches",
         "missingStructurePaths",
@@ -510,6 +570,8 @@
         "unexpectedBatchFiles": { "$ref": "#/$defs/count" },
         "missingImportTargets": { "$ref": "#/$defs/count" },
         "structureCoverage": { "type": "number", "minimum": 0, "maximum": 1 },
+        "structureFailures": { "$ref": "#/$defs/count" },
+        "callGraphFailures": { "$ref": "#/$defs/count" },
         "filesSkipped": { "$ref": "#/$defs/count" },
         "failedBatches": { "$ref": "#/$defs/count" },
         "missingStructurePaths": { "$ref": "#/$defs/count" },
@@ -527,6 +589,8 @@
         "unexpectedBatchFiles": { "const": 0 },
         "missingImportTargets": { "const": 0 },
         "structureCoverage": { "const": 1 },
+        "structureFailures": { "const": 0 },
+        "callGraphFailures": { "const": 0 },
         "failedBatches": { "const": 0 },
         "missingStructurePaths": { "const": 0 },
         "duplicateStructurePaths": { "const": 0 },
@@ -561,7 +625,7 @@
       "required": ["stage", "count", "messages", "truncated"],
       "properties": {
         "stage": { "enum": ["scan", "imports", "batching", "structure"] },
-        "count": { "$ref": "#/$defs/count" },
+        "count": { "type": "integer", "minimum": 1 },
         "messages": { "$ref": "#/$defs/warningMessages" },
         "truncated": { "type": "boolean" }
       }
@@ -570,6 +634,24 @@
       "type": "array",
       "maxItems": 5,
       "items": { "type": "string" }
+    },
+    "failureSample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["batchIndex", "message"],
+      "properties": {
+        "batchIndex": { "$ref": "#/$defs/count" },
+        "message": { "type": "string", "minLength": 1, "maxLength": 4096 }
+      }
+    },
+    "secondaryError": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stage", "message"],
+      "properties": {
+        "stage": { "const": "cleanup" },
+        "message": { "const": "Unable to remove temporary benchmark artifacts" }
+      }
     }
   }
 }

--- a/docs/benchmarks/large-repo-report-1.0.0.schema.json
+++ b/docs/benchmarks/large-repo-report-1.0.0.schema.json
@@ -1,0 +1,575 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/docs/benchmarks/large-repo-report-1.0.0.schema.json",
+  "title": "Understand Anything deterministic large-repository benchmark report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaUrl",
+    "schemaVersion",
+    "status",
+    "mode",
+    "run",
+    "tool",
+    "subject",
+    "environment",
+    "configuration",
+    "scale",
+    "stages",
+    "integrity",
+    "determinism",
+    "llm",
+    "warnings",
+    "error"
+  ],
+  "properties": {
+    "schemaUrl": {
+      "const": "https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/docs/benchmarks/large-repo-report-1.0.0.schema.json"
+    },
+    "schemaVersion": { "const": "1.0.0" },
+    "status": { "enum": ["ok", "degraded", "failed"] },
+    "mode": { "const": "deterministic" },
+    "run": { "$ref": "#/$defs/run" },
+    "tool": { "$ref": "#/$defs/tool" },
+    "subject": { "$ref": "#/$defs/subject" },
+    "environment": { "$ref": "#/$defs/environment" },
+    "configuration": { "$ref": "#/$defs/configuration" },
+    "scale": {
+      "oneOf": [
+        { "$ref": "#/$defs/scale" },
+        { "type": "null" }
+      ]
+    },
+    "stages": { "$ref": "#/$defs/stages" },
+    "integrity": {
+      "oneOf": [
+        { "$ref": "#/$defs/integrity" },
+        { "type": "null" }
+      ]
+    },
+    "determinism": {
+      "oneOf": [
+        { "$ref": "#/$defs/determinism" },
+        { "type": "null" }
+      ]
+    },
+    "llm": { "$ref": "#/$defs/llm" },
+    "warnings": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/warning" }
+    },
+    "error": { "type": ["string", "null"] }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "status": { "enum": ["ok", "degraded"] } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "scale": { "$ref": "#/$defs/scale" },
+          "stages": {
+            "type": "object",
+            "required": ["scan", "imports", "batching", "structure"],
+            "properties": {
+              "scan": {
+                "type": "object",
+                "properties": { "status": { "const": "ok" } }
+              },
+              "imports": {
+                "type": "object",
+                "properties": { "status": { "const": "ok" } }
+              },
+              "batching": {
+                "type": "object",
+                "properties": { "status": { "const": "ok" } }
+              },
+              "structure": {
+                "type": "object",
+                "properties": { "status": { "const": "ok" } }
+              }
+            }
+          },
+          "integrity": { "$ref": "#/$defs/successIntegrity" },
+          "determinism": { "$ref": "#/$defs/determinism" },
+          "error": { "type": "null" }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "status": { "const": "ok" } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "warnings": { "type": "array", "maxItems": 0 },
+          "integrity": {
+            "type": "object",
+            "properties": { "filesSkipped": { "const": 0 } }
+          },
+          "stages": {
+            "type": "object",
+            "properties": {
+              "scan": { "$ref": "#/$defs/noWarningsStage" },
+              "imports": { "$ref": "#/$defs/noWarningsStage" },
+              "batching": { "$ref": "#/$defs/noWarningsStage" },
+              "structure": {
+                "allOf": [
+                  { "$ref": "#/$defs/noWarningsStage" },
+                  {
+                    "type": "object",
+                    "properties": { "filesSkipped": { "const": 0 } }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "status": { "const": "failed" } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "error": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "nullableString": { "type": ["string", "null"] },
+    "nullableBoolean": { "type": ["boolean", "null"] },
+    "nullableNumber": { "type": ["number", "null"], "minimum": 0 },
+    "count": { "type": "integer", "minimum": 0 },
+    "status": { "enum": ["ok", "failed"] },
+    "noWarningsStage": {
+      "type": "object",
+      "properties": {
+        "warningCount": { "const": 0 },
+        "warningMessages": { "type": "array", "maxItems": 0 },
+        "warningMessagesTruncated": { "const": false }
+      }
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["startedAt", "finishedAt", "durationMs"],
+      "properties": {
+        "startedAt": { "type": "string", "format": "date-time" },
+        "finishedAt": { "type": ["string", "null"], "format": "date-time" },
+        "durationMs": { "$ref": "#/$defs/nullableNumber" }
+      }
+    },
+    "tool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["commit", "dirty", "packageVersion"],
+      "properties": {
+        "commit": { "$ref": "#/$defs/nullableString" },
+        "dirty": { "$ref": "#/$defs/nullableBoolean" },
+        "packageVersion": { "type": "string" }
+      }
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "commit", "dirty"],
+      "properties": {
+        "label": { "type": "string" },
+        "commit": { "$ref": "#/$defs/nullableString" },
+        "dirty": { "$ref": "#/$defs/nullableBoolean" }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "platform",
+        "release",
+        "arch",
+        "nodeVersion",
+        "cpuModel",
+        "logicalCores",
+        "totalMemoryBytes"
+      ],
+      "properties": {
+        "platform": { "type": "string" },
+        "release": { "type": "string" },
+        "arch": { "type": "string" },
+        "nodeVersion": { "type": "string" },
+        "cpuModel": { "type": "string" },
+        "logicalCores": { "type": "integer", "minimum": 1 },
+        "totalMemoryBytes": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "configuration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["concurrency", "stages"],
+      "properties": {
+        "concurrency": { "type": "integer", "minimum": 1, "maximum": 32 },
+        "stages": {
+          "const": ["scan", "imports", "batching", "structure"]
+        }
+      }
+    },
+    "stringCountMap": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/count" }
+    },
+    "scale": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "files",
+        "lines",
+        "bytes",
+        "missingFiles",
+        "filteredByUserIgnore",
+        "byCategory",
+        "byLanguage"
+      ],
+      "properties": {
+        "files": { "$ref": "#/$defs/count" },
+        "lines": { "$ref": "#/$defs/count" },
+        "bytes": { "$ref": "#/$defs/count" },
+        "missingFiles": { "$ref": "#/$defs/count" },
+        "filteredByUserIgnore": { "$ref": "#/$defs/count" },
+        "byCategory": { "$ref": "#/$defs/stringCountMap" },
+        "byLanguage": { "$ref": "#/$defs/stringCountMap" }
+      }
+    },
+    "scanStage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "durationMs",
+        "peakRssBytes",
+        "userCpuTimeMicros",
+        "systemCpuTimeMicros",
+        "warningCount",
+        "warningMessages",
+        "warningMessagesTruncated",
+        "stdoutTruncated",
+        "stderrTruncated",
+        "outputBytes"
+      ],
+      "properties": {
+        "status": { "$ref": "#/$defs/status" },
+        "durationMs": { "type": "number", "minimum": 0 },
+        "peakRssBytes": { "$ref": "#/$defs/nullableNumber" },
+        "userCpuTimeMicros": { "$ref": "#/$defs/nullableNumber" },
+        "systemCpuTimeMicros": { "$ref": "#/$defs/nullableNumber" },
+        "warningCount": { "$ref": "#/$defs/count" },
+        "warningMessages": { "$ref": "#/$defs/warningMessages" },
+        "warningMessagesTruncated": { "type": "boolean" },
+        "stdoutTruncated": { "type": "boolean" },
+        "stderrTruncated": { "type": "boolean" },
+        "outputBytes": { "$ref": "#/$defs/count" },
+        "files": { "$ref": "#/$defs/count" },
+        "lines": { "$ref": "#/$defs/count" },
+        "bytes": { "$ref": "#/$defs/count" },
+        "filteredByUserIgnore": { "$ref": "#/$defs/count" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "ok" } },
+            "required": ["status"]
+          },
+          "then": {
+            "required": [
+              "files",
+              "lines",
+              "bytes",
+              "filteredByUserIgnore"
+            ]
+          }
+        }
+      ]
+    },
+    "importsStage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "durationMs",
+        "peakRssBytes",
+        "userCpuTimeMicros",
+        "systemCpuTimeMicros",
+        "warningCount",
+        "warningMessages",
+        "warningMessagesTruncated",
+        "stdoutTruncated",
+        "stderrTruncated",
+        "outputBytes"
+      ],
+      "properties": {
+        "status": { "$ref": "#/$defs/status" },
+        "durationMs": { "type": "number", "minimum": 0 },
+        "peakRssBytes": { "$ref": "#/$defs/nullableNumber" },
+        "userCpuTimeMicros": { "$ref": "#/$defs/nullableNumber" },
+        "systemCpuTimeMicros": { "$ref": "#/$defs/nullableNumber" },
+        "warningCount": { "$ref": "#/$defs/count" },
+        "warningMessages": { "$ref": "#/$defs/warningMessages" },
+        "warningMessagesTruncated": { "type": "boolean" },
+        "stdoutTruncated": { "type": "boolean" },
+        "stderrTruncated": { "type": "boolean" },
+        "outputBytes": { "$ref": "#/$defs/count" },
+        "filesScanned": { "$ref": "#/$defs/count" },
+        "filesWithImports": { "$ref": "#/$defs/count" },
+        "edges": { "$ref": "#/$defs/count" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "ok" } },
+            "required": ["status"]
+          },
+          "then": {
+            "required": ["filesScanned", "filesWithImports", "edges"]
+          }
+        }
+      ]
+    },
+    "distribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["min", "p50", "p95", "max", "mean"],
+      "properties": {
+        "min": { "type": "number", "minimum": 0 },
+        "p50": { "type": "number", "minimum": 0 },
+        "p95": { "type": "number", "minimum": 0 },
+        "max": { "type": "number", "minimum": 0 },
+        "mean": { "type": "number", "minimum": 0 }
+      }
+    },
+    "batchingStage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "durationMs",
+        "peakRssBytes",
+        "userCpuTimeMicros",
+        "systemCpuTimeMicros",
+        "warningCount",
+        "warningMessages",
+        "warningMessagesTruncated",
+        "stdoutTruncated",
+        "stderrTruncated",
+        "outputBytes"
+      ],
+      "properties": {
+        "status": { "$ref": "#/$defs/status" },
+        "durationMs": { "type": "number", "minimum": 0 },
+        "peakRssBytes": { "$ref": "#/$defs/nullableNumber" },
+        "userCpuTimeMicros": { "$ref": "#/$defs/nullableNumber" },
+        "systemCpuTimeMicros": { "$ref": "#/$defs/nullableNumber" },
+        "warningCount": { "$ref": "#/$defs/count" },
+        "warningMessages": { "$ref": "#/$defs/warningMessages" },
+        "warningMessagesTruncated": { "type": "boolean" },
+        "stdoutTruncated": { "type": "boolean" },
+        "stderrTruncated": { "type": "boolean" },
+        "outputBytes": { "$ref": "#/$defs/count" },
+        "algorithm": { "type": "string" },
+        "totalBatches": { "$ref": "#/$defs/count" },
+        "batchSizes": { "$ref": "#/$defs/distribution" },
+        "estimatedAgentInputBytes": { "$ref": "#/$defs/count" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "ok" } },
+            "required": ["status"]
+          },
+          "then": {
+            "required": [
+              "algorithm",
+              "totalBatches",
+              "batchSizes",
+              "estimatedAgentInputBytes"
+            ]
+          }
+        }
+      ]
+    },
+    "entities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "functions",
+        "classes",
+        "exports",
+        "callGraph",
+        "definitions",
+        "services",
+        "endpoints",
+        "steps",
+        "resources"
+      ],
+      "properties": {
+        "functions": { "$ref": "#/$defs/count" },
+        "classes": { "$ref": "#/$defs/count" },
+        "exports": { "$ref": "#/$defs/count" },
+        "callGraph": { "$ref": "#/$defs/count" },
+        "definitions": { "$ref": "#/$defs/count" },
+        "services": { "$ref": "#/$defs/count" },
+        "endpoints": { "$ref": "#/$defs/count" },
+        "steps": { "$ref": "#/$defs/count" },
+        "resources": { "$ref": "#/$defs/count" }
+      }
+    },
+    "structureStage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "durationMs",
+        "maxWorkerPeakRssBytes",
+        "userCpuTimeMicros",
+        "systemCpuTimeMicros",
+        "warningCount",
+        "warningMessages",
+        "warningMessagesTruncated",
+        "outputBytes"
+      ],
+      "properties": {
+        "status": { "$ref": "#/$defs/status" },
+        "durationMs": { "type": "number", "minimum": 0 },
+        "maxWorkerPeakRssBytes": { "$ref": "#/$defs/nullableNumber" },
+        "userCpuTimeMicros": { "$ref": "#/$defs/nullableNumber" },
+        "systemCpuTimeMicros": { "$ref": "#/$defs/nullableNumber" },
+        "warningCount": { "$ref": "#/$defs/count" },
+        "warningMessages": { "$ref": "#/$defs/warningMessages" },
+        "warningMessagesTruncated": { "type": "boolean" },
+        "outputBytes": { "$ref": "#/$defs/count" },
+        "batchesSucceeded": { "$ref": "#/$defs/count" },
+        "batchesFailed": { "$ref": "#/$defs/count" },
+        "filesAnalyzed": { "$ref": "#/$defs/count" },
+        "filesSkipped": { "$ref": "#/$defs/count" },
+        "entities": { "$ref": "#/$defs/entities" },
+        "batchDurationMs": { "$ref": "#/$defs/distribution" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "ok" } },
+            "required": ["status"]
+          },
+          "then": {
+            "required": [
+              "batchesSucceeded",
+              "batchesFailed",
+              "filesAnalyzed",
+              "filesSkipped",
+              "entities",
+              "batchDurationMs"
+            ]
+          }
+        }
+      ]
+    },
+    "stages": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scan": { "$ref": "#/$defs/scanStage" },
+        "imports": { "$ref": "#/$defs/importsStage" },
+        "batching": { "$ref": "#/$defs/batchingStage" },
+        "structure": { "$ref": "#/$defs/structureStage" }
+      }
+    },
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "allScannedFilesBatched",
+        "missingBatchFiles",
+        "duplicateBatchFiles",
+        "unexpectedBatchFiles",
+        "missingImportTargets",
+        "structureCoverage",
+        "filesSkipped",
+        "failedBatches",
+        "missingStructurePaths",
+        "duplicateStructurePaths",
+        "unexpectedStructurePaths",
+        "malformedStructureBatches"
+      ],
+      "properties": {
+        "allScannedFilesBatched": { "type": "boolean" },
+        "missingBatchFiles": { "$ref": "#/$defs/count" },
+        "duplicateBatchFiles": { "$ref": "#/$defs/count" },
+        "unexpectedBatchFiles": { "$ref": "#/$defs/count" },
+        "missingImportTargets": { "$ref": "#/$defs/count" },
+        "structureCoverage": { "type": "number", "minimum": 0, "maximum": 1 },
+        "filesSkipped": { "$ref": "#/$defs/count" },
+        "failedBatches": { "$ref": "#/$defs/count" },
+        "missingStructurePaths": { "$ref": "#/$defs/count" },
+        "duplicateStructurePaths": { "$ref": "#/$defs/count" },
+        "unexpectedStructurePaths": { "$ref": "#/$defs/count" },
+        "malformedStructureBatches": { "$ref": "#/$defs/count" }
+      }
+    },
+    "successIntegrity": {
+      "type": "object",
+      "properties": {
+        "allScannedFilesBatched": { "const": true },
+        "missingBatchFiles": { "const": 0 },
+        "duplicateBatchFiles": { "const": 0 },
+        "unexpectedBatchFiles": { "const": 0 },
+        "missingImportTargets": { "const": 0 },
+        "structureCoverage": { "const": 1 },
+        "failedBatches": { "const": 0 },
+        "missingStructurePaths": { "const": 0 },
+        "duplicateStructurePaths": { "const": 0 },
+        "unexpectedStructurePaths": { "const": 0 },
+        "malformedStructureBatches": { "const": 0 }
+      }
+    },
+    "determinism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "inputDigest", "outputDigest"],
+      "properties": {
+        "algorithm": { "const": "sha256" },
+        "inputDigest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "outputDigest": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      }
+    },
+    "llm": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["invoked", "inputTokens", "outputTokens", "costUsd"],
+      "properties": {
+        "invoked": { "const": false },
+        "inputTokens": { "type": "null" },
+        "outputTokens": { "type": "null" },
+        "costUsd": { "type": "null" }
+      }
+    },
+    "warning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stage", "count", "messages", "truncated"],
+      "properties": {
+        "stage": { "enum": ["scan", "imports", "batching", "structure"] },
+        "count": { "$ref": "#/$defs/count" },
+        "messages": { "$ref": "#/$defs/warningMessages" },
+        "truncated": { "type": "boolean" }
+      }
+    },
+    "warningMessages": {
+      "type": "array",
+      "maxItems": 5,
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/docs/benchmarks/samples/understand-anything-pr587-full-sample.json
+++ b/docs/benchmarks/samples/understand-anything-pr587-full-sample.json
@@ -1,0 +1,218 @@
+{
+  "schemaUrl": "https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/docs/benchmarks/large-repo-report-1.0.0.schema.json",
+  "schemaVersion": "1.0.0",
+  "pairId": "d7a047c6-9c05-41b2-9923-43a1e71e9634",
+  "status": "degraded",
+  "mode": "deterministic",
+  "run": {
+    "startedAt": "2026-07-17T11:45:14.919Z",
+    "finishedAt": "2026-07-17T11:45:26.653Z",
+    "durationMs": 11734.69
+  },
+  "tool": {
+    "commit": "851ca14ebab22c81fde136986263d550daa38ee3",
+    "dirty": false,
+    "packageVersion": "2.9.3"
+  },
+  "subject": {
+    "label": "understand-anything-pr587-full-sample",
+    "commit": "851ca14ebab22c81fde136986263d550daa38ee3",
+    "dirty": false
+  },
+  "environment": {
+    "platform": "win32",
+    "release": "10.0.26200",
+    "arch": "x64",
+    "nodeVersion": "v22.18.0",
+    "cpuModel": "13th Gen Intel(R) Core(TM) i9-13900HX",
+    "logicalCores": 32,
+    "totalMemoryBytes": 16907100160
+  },
+  "configuration": {
+    "concurrency": 5,
+    "stages": [
+      "scan",
+      "imports",
+      "batching",
+      "structure"
+    ]
+  },
+  "scale": {
+    "files": 459,
+    "lines": 127155,
+    "bytes": 8918520,
+    "missingFiles": 0,
+    "filteredByUserIgnore": 0,
+    "byCategory": {
+      "config": 33,
+      "docs": 117,
+      "infra": 3,
+      "code": 301,
+      "markup": 3,
+      "script": 2
+    },
+    "byLanguage": {
+      "json": 27,
+      "yaml": 8,
+      "markdown": 117,
+      "unknown": 3,
+      "javascript": 31,
+      "astro": 10,
+      "css": 2,
+      "powershell": 1,
+      "shell": 1,
+      "python": 8,
+      "typescript": 247,
+      "html": 1,
+      "wasm": 2,
+      "swift": 1
+    }
+  },
+  "stages": {
+    "scan": {
+      "status": "ok",
+      "durationMs": 783.46,
+      "peakRssBytes": 80211968,
+      "userCpuTimeMicros": 281000,
+      "systemCpuTimeMicros": 407000,
+      "warningCount": 0,
+      "warningMessages": [],
+      "warningMessagesTruncated": false,
+      "stdoutTruncated": false,
+      "stderrTruncated": false,
+      "outputBytes": 82572,
+      "files": 459,
+      "lines": 127155,
+      "bytes": 8918520,
+      "filteredByUserIgnore": 0
+    },
+    "imports": {
+      "status": "ok",
+      "durationMs": 1172.55,
+      "peakRssBytes": 190054400,
+      "userCpuTimeMicros": 906000,
+      "systemCpuTimeMicros": 562000,
+      "warningCount": 0,
+      "warningMessages": [],
+      "warningMessagesTruncated": false,
+      "stdoutTruncated": false,
+      "stderrTruncated": false,
+      "outputBytes": 71809,
+      "filesScanned": 459,
+      "filesWithImports": 212,
+      "edges": 462
+    },
+    "batching": {
+      "status": "ok",
+      "durationMs": 1169.17,
+      "peakRssBytes": 191143936,
+      "userCpuTimeMicros": 875000,
+      "systemCpuTimeMicros": 578000,
+      "warningCount": 5,
+      "warningMessages": [
+        "Warning: compute-batches: community size 46 > max 35 — splitting via alphabetical chunking — modularity may decrease",
+        "Warning: compute-batches: community size 61 > max 35 — splitting via alphabetical chunking — modularity may decrease",
+        "Warning: compute-batches: community size 52 > max 35 — splitting via alphabetical chunking — modularity may decrease",
+        "Warning: compute-batches: neighborMap for understand-anything-plugin/packages/core/src/languages/types.ts has high 1-hop degree 59 — exceeds soft cap of 50 — keeping top 31 cross-batch entries (0 dropped by degree sort)",
+        "Warning: compute-batches: neighborMap for understand-anything-plugin/packages/core/src/types.ts has high 1-hop degree 58 — exceeds soft cap of 50 — keeping top 38 cross-batch entries (0 dropped by degree sort)"
+      ],
+      "warningMessagesTruncated": false,
+      "stdoutTruncated": false,
+      "stderrTruncated": false,
+      "outputBytes": 354328,
+      "algorithm": "louvain",
+      "totalBatches": 37,
+      "batchSizes": {
+        "min": 1,
+        "p50": 7,
+        "p95": 31,
+        "max": 31,
+        "mean": 12.41
+      },
+      "estimatedAgentInputBytes": 212711
+    },
+    "structure": {
+      "status": "ok",
+      "durationMs": 8070.21,
+      "maxWorkerPeakRssBytes": 193888256,
+      "userCpuTimeMicros": 18300000,
+      "systemCpuTimeMicros": 21344000,
+      "warningCount": 0,
+      "warningMessages": [],
+      "warningMessagesTruncated": false,
+      "failureSamples": [],
+      "failureSamplesTruncated": false,
+      "outputBytes": 1636826,
+      "batchesSucceeded": 37,
+      "batchesFailed": 0,
+      "filesAnalyzed": 439,
+      "filesSkipped": 20,
+      "structureSucceeded": 439,
+      "structureFailed": 0,
+      "callGraphSucceeded": 285,
+      "callGraphFailed": 0,
+      "callGraphSkipped": 154,
+      "entities": {
+        "functions": 654,
+        "classes": 55,
+        "exports": 628,
+        "callGraph": 8026,
+        "definitions": 0,
+        "services": 0,
+        "endpoints": 0,
+        "steps": 0,
+        "resources": 0
+      },
+      "batchDurationMs": {
+        "min": 800.05,
+        "p50": 991.31,
+        "p95": 1224.87,
+        "max": 1337.28,
+        "mean": 1027.58
+      }
+    }
+  },
+  "integrity": {
+    "allScannedFilesBatched": true,
+    "missingBatchFiles": 0,
+    "duplicateBatchFiles": 0,
+    "unexpectedBatchFiles": 0,
+    "missingImportTargets": 0,
+    "structureCoverage": 1,
+    "structureFailures": 0,
+    "callGraphFailures": 0,
+    "filesSkipped": 20,
+    "failedBatches": 0,
+    "missingStructurePaths": 0,
+    "duplicateStructurePaths": 0,
+    "unexpectedStructurePaths": 0,
+    "malformedStructureBatches": 0
+  },
+  "determinism": {
+    "algorithm": "sha256",
+    "inputDigest": "ff0ab0d785f92f6324bc36c389a50abdbfa86ddb6a892a0439be1162a4da6a6f",
+    "outputDigest": "69f6cee48ef7e3febf0c5bb7dd04528010fc5764386b9982a44865813d9ec24a"
+  },
+  "llm": {
+    "invoked": false,
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null
+  },
+  "warnings": [
+    {
+      "stage": "batching",
+      "count": 5,
+      "messages": [
+        "Warning: compute-batches: community size 46 > max 35 — splitting via alphabetical chunking — modularity may decrease",
+        "Warning: compute-batches: community size 61 > max 35 — splitting via alphabetical chunking — modularity may decrease",
+        "Warning: compute-batches: community size 52 > max 35 — splitting via alphabetical chunking — modularity may decrease",
+        "Warning: compute-batches: neighborMap for understand-anything-plugin/packages/core/src/languages/types.ts has high 1-hop degree 59 — exceeds soft cap of 50 — keeping top 31 cross-batch entries (0 dropped by degree sort)",
+        "Warning: compute-batches: neighborMap for understand-anything-plugin/packages/core/src/types.ts has high 1-hop degree 58 — exceeds soft cap of 50 — keeping top 38 cross-batch entries (0 dropped by degree sort)"
+      ],
+      "truncated": false
+    }
+  ],
+  "secondaryErrors": [],
+  "error": null
+}

--- a/docs/benchmarks/samples/understand-anything-pr587-full-sample.md
+++ b/docs/benchmarks/samples/understand-anything-pr587-full-sample.md
@@ -1,0 +1,71 @@
+# Large Repository Benchmark Report
+
+This report covers deterministic static-analysis stages only. It does not include LLM inference or dashboard generation.
+
+## Run
+
+| Metric | Value |
+| --- | --- |
+| Status | degraded |
+| Pair ID | d7a047c6-9c05-41b2-9923-43a1e71e9634 |
+| Subject | understand-anything-pr587-full-sample |
+| Subject commit | 851ca14ebab22c81fde136986263d550daa38ee3 |
+| Subject dirty | false |
+| Tool commit | 851ca14ebab22c81fde136986263d550daa38ee3 |
+| Tool dirty | false |
+| Tool version | 2.9.3 |
+| Started (UTC) | 2026-07-17T11:45:14.919Z |
+| Total duration | 11734.69 ms |
+| Concurrency | 5 |
+| LLM invoked | No |
+
+## Scale
+
+| Metric | Value |
+| --- | --- |
+| Files | 459 |
+| Lines | 127155 |
+| Source bytes | 8918520 |
+| Filtered by user ignore | 0 |
+| Missing during measurement | 0 |
+
+## Stages
+
+| Stage | Status | Duration | Peak / max worker RSS (bytes) | User CPU (micros) | System CPU (micros) | Output (bytes) |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| scan | ok | 783.46 ms | 80,211,968 | 281,000 | 407,000 | 82,572 |
+| imports | ok | 1172.55 ms | 190,054,400 | 906,000 | 562,000 | 71,809 |
+| batching | ok | 1169.17 ms | 191,143,936 | 875,000 | 578,000 | 354,328 |
+| structure | ok | 8070.21 ms | 193,888,256 | 18,300,000 | 21,344,000 | 1,636,826 |
+
+## Integrity and reproducibility
+
+| Metric | Value |
+| --- | --- |
+| All scanned files batched | true |
+| Structure coverage | 1 |
+| Files skipped | 20 |
+| Failed batches | 0 |
+| Missing structure paths | 0 |
+| Duplicate structure paths | 0 |
+| Unexpected structure paths | 0 |
+| Malformed structure batches | 0 |
+| Input digest (SHA-256) | ff0ab0d785f92f6324bc36c389a50abdbfa86ddb6a892a0439be1162a4da6a6f |
+| Output digest (SHA-256) | 69f6cee48ef7e3febf0c5bb7dd04528010fc5764386b9982a44865813d9ec24a |
+| Schema version | 1.0.0 |
+
+## Environment
+
+| Metric | Value |
+| --- | --- |
+| Platform | win32 |
+| OS release | 10.0.26200 |
+| Architecture | x64 |
+| Node.js | v22.18.0 |
+| CPU | 13th Gen Intel(R) Core(TM) i9-13900HX |
+| Logical cores | 32 |
+| Memory (bytes) | 16907100160 |
+
+## Warnings
+
+- batching: 5

--- a/docs/superpowers/plans/2026-07-17-benchmark-unsupported-outcomes.md
+++ b/docs/superpowers/plans/2026-07-17-benchmark-unsupported-outcomes.md
@@ -1,0 +1,78 @@
+# Benchmark Unsupported Outcomes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the large-repository benchmark distinguish unsupported or unavailable analysis capabilities from real execution failures.
+
+**Architecture:** Reuse the existing `filesSkipped` and call-graph `skipped` paths rather than changing report schema 1.0.0. Capability detection happens before interpreting parser results; only a selected, advertised capability that fails remains fatal.
+
+**Tech Stack:** Node.js ESM, `PluginRegistry`, Vitest, JSON Schema 2020-12, pnpm.
+
+## Global Constraints
+
+- Preserve `large-repo-report-1.0.0.schema.json` and paired Markdown/JSON compatibility.
+- Unsupported structure files must be accounted for, produce `degraded` rather than `failed`, and exit 0.
+- Missing optional call-graph capability must be skipped, not failed.
+- Exceptions or invalid values after a capability is selected must remain failed.
+- Do not weaken path, digest, privacy, cleanup, or malformed-output integrity checks.
+- Do not write benchmark output inside the subject repository.
+
+---
+
+### Task 1: Classify unsupported capabilities without false failures
+
+**Files:**
+- Modify: `tests/skill/understand/test_extract_structure_outcomes.test.mjs`
+- Modify: `understand-anything-plugin/skills/understand/extract-structure-result.mjs`
+- Modify: `understand-anything-plugin/skills/understand/extract-structure.mjs`
+- Modify: `docs/benchmarks/large-monorepo.md`
+
+**Interfaces:**
+- Consumes: `PluginRegistry.getPluginForFile()`, optional `AnalyzerPlugin.extractCallGraph`, existing `filesSkipped`, and existing analysis outcome counters.
+- Produces: capability-aware `analyzeFileWithOutcomes()` results and schema-compatible degraded reports for unsupported files.
+
+- [ ] **Step 1: Add failing outcome tests**
+
+  Add one test whose registry exposes `getPluginForFile()` returning `null` and expects both outcomes to be `skipped`. Add one test whose selected parser supports structure but has neither `analyzeFileFull` nor `extractCallGraph`; expect structure `succeeded` and call graph `skipped`.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+  Run:
+
+  ```powershell
+  & .\node_modules\.bin\vitest.CMD run tests\skill\understand\test_extract_structure_outcomes.test.mjs
+  ```
+
+  Expected: the new unsupported/capability tests fail because the current mapper returns `failed`.
+
+- [ ] **Step 3: Implement minimal capability-aware classification**
+
+  Update `analyzeFileWithOutcomes()` to distinguish a known missing plugin from a selected plugin that fails. Return skipped outcomes for a known unsupported file. For code/script files, attempt call-graph analysis only when the selected plugin advertises `analyzeFileFull` or `extractCallGraph`; otherwise return `skipped`.
+
+  In `extract-structure.mjs`, account a skipped structure path in `filesSkipped` and do not append a result or outcome count for it. Preserve existing counts for analyzed results so the benchmark's shape validation remains valid.
+
+- [ ] **Step 4: Run focused and benchmark tests and verify GREEN**
+
+  Run:
+
+  ```powershell
+  & .\node_modules\.bin\vitest.CMD run tests\skill\understand\test_extract_structure_outcomes.test.mjs tests\benchmark\test_large_repo_report_schema.test.mjs tests\benchmark\test_large_repo_benchmark.test.mjs
+  ```
+
+  Expected: all tests pass, with only existing documented skips.
+
+- [ ] **Step 5: Document the semantics**
+
+  Clarify in `docs/benchmarks/large-monorepo.md` that unsupported structural files are accounted as skipped and produce degraded reports, while a parser failure after capability selection remains fatal.
+
+- [ ] **Step 6: Run full verification**
+
+  Run the root test suite serially, build the core package, and run the benchmark against the clean repository with output outside the subject worktree. Validate the JSON against schema 1.0.0 and confirm the paired report IDs match.
+
+- [ ] **Step 7: Commit**
+
+  Commit as KumamuKuma with:
+
+  ```text
+  fix(bench): distinguish unsupported analysis from failures
+  ```

--- a/docs/superpowers/specs/2026-07-17-benchmark-unsupported-outcomes-design.md
+++ b/docs/superpowers/specs/2026-07-17-benchmark-unsupported-outcomes-design.md
@@ -1,0 +1,70 @@
+# Benchmark Unsupported-Outcome Semantics
+
+## Context
+
+The large-repository benchmark currently reports the Understand Anything
+repository as failed even though every reported analysis failure is an
+unsupported file or an unavailable optional call-graph capability. The
+current mapper collapses `PluginRegistry`'s contractual `null` return into a
+runtime failure, and the benchmark correctly treats that mislabeled outcome
+as an integrity failure.
+
+The reproduced full-repository run scanned 457 files and 126,169 lines. All
+20 structure failures had no registered analyzer. All 18 call-graph failures
+had no call-graph capability. No registered parser failed.
+
+## Approaches considered
+
+### 1. Capability-aware use of the existing skipped path (selected)
+
+Check registry support before analysis. Files with no registered analyzer are
+accounted for through the existing `filesSkipped` field, so the report is
+`degraded` with exit code 0. A code or script parser without an optional
+call-graph API records a skipped call graph. A selected parser that throws,
+returns an invalid final value, or produces damaged output remains failed.
+
+This preserves report schema 1.0.0, keeps repository scale totals intact, and
+uses an already tested degraded-report path.
+
+### 2. Add explicit unsupported counters to a new schema version
+
+Add `structureUnsupported` and capability-level counters. This is more
+expressive, but it expands the patch into schema versioning and migration when
+the existing skipped fields already model the required behavior.
+
+### 3. Exclude unsupported extensions during scanning
+
+Teach the scanner to ignore every unsupported extension. This hides useful
+repository scale information, requires a brittle duplicate allowlist, and
+does not solve optional capability detection for supported parsers.
+
+## Selected behavior
+
+- Scanner totals continue to include every discovered file.
+- If `PluginRegistry.getPluginForFile(path)` returns `null`, structural
+  extraction accounts for the path in `filesSkipped` and emits no structural
+  result for that path.
+- If a selected parser supports structure but not call-graph extraction, its
+  structure result succeeds and its call graph is skipped.
+- Once a parser advertises a capability, an exception, missing final value,
+  or malformed output is a real failure.
+- A run containing only unsupported structure skips is `degraded`, not
+  `failed`, and exits 0.
+- The Markdown and JSON reports retain the same schema version and pair
+  integrity rules.
+
+## Verification
+
+Tests must prove the red/green transition for an unsupported file and a
+structure-only parser. Existing exception tests must continue to prove that
+real parser errors are failures. The full benchmark must then run against the
+clean Understand Anything worktree and produce paired schema-valid reports
+with zero structure failures, zero call-graph failures, zero failed batches,
+and a non-failed status.
+
+## Publication
+
+After the fix is committed and pushed, share the generated Markdown and JSON
+reports on PR #587. The comment must state that TensorFlow was not run locally
+because its repository size and resource requirements exceed the practical
+scope of this local validation.

--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
     "prepare": "pnpm --filter @understand-anything/core build",
     "build": "pnpm -r build",
     "test": "vitest run",
+    "benchmark:large-repo": "node scripts/benchmark-large-repo.mjs",
     "dev:dashboard": "pnpm --filter @understand-anything/dashboard dev",
     "lint": "eslint ."
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
+    "ajv": "8.17.1",
     "eslint": "^9.0.0",
     "globals": "^17.6.0",
     "typescript": "^5.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@eslint/js':
         specifier: ^9.0.0
         version: 9.39.4
+      ajv:
+        specifier: 8.17.1
+        version: 8.17.1
       eslint:
         specifier: ^9.0.0
         version: 9.39.4(jiti@2.6.1)
@@ -1363,6 +1366,9 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1794,6 +1800,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2074,6 +2083,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2666,6 +2678,10 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -4405,6 +4421,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -4928,6 +4951,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.3: {}
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -5255,6 +5280,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -6046,6 +6073,8 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 

--- a/scripts/benchmark-large-repo.mjs
+++ b/scripts/benchmark-large-repo.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import {
+  BenchmarkArtifactCleanupError,
+  BenchmarkReportWriteError,
+  CliUsageError,
+  helpText,
+  parseArgs,
+  runBenchmark,
+} from './lib/large-repo-benchmark.mjs';
+
+async function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    if (error instanceof CliUsageError) {
+      process.stderr.write(`Error: ${error.message}\n\n${helpText()}`);
+      process.exitCode = 2;
+      return;
+    }
+    throw error;
+  }
+
+  if (options.help) {
+    process.stdout.write(helpText());
+    return;
+  }
+
+  let result;
+  try {
+    result = await runBenchmark(options, {
+      onProgress(stage) {
+        process.stderr.write(`[benchmark] ${stage}\n`);
+      },
+      onBatchProgress(completed, total) {
+        process.stderr.write(`[benchmark] structure ${completed}/${total}\n`);
+      },
+    });
+  } catch (error) {
+    if (error instanceof BenchmarkArtifactCleanupError) {
+      process.stderr.write(`Error: ${error.message}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    if (error instanceof BenchmarkReportWriteError) {
+      process.stderr.write(`Error: ${error.message}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    throw error;
+  }
+
+  process.stdout.write(
+    `Benchmark ${result.report.status}. JSON report: ${options.outputPath}\n` +
+      `Markdown report: ${options.markdownPath}\n`,
+  );
+  if (result.artifactRoot) {
+    process.stdout.write(`Artifacts preserved at: ${result.artifactRoot}\n`);
+  }
+  process.exitCode = result.exitCode;
+}
+
+await main();

--- a/scripts/lib/benchmark-stage-worker.mjs
+++ b/scripts/lib/benchmark-stage-worker.mjs
@@ -16,16 +16,30 @@ const resolvedScript = resolve(scriptPath);
 const startedAt = performance.now();
 const usageBefore = process.resourceUsage();
 let failure = null;
+const originalExit = process.exit;
+
+class ImportedHelperExitError extends Error {
+  constructor(code) {
+    super(`Imported benchmark helper requested process exit ${code}`);
+    this.name = 'ImportedHelperExitError';
+    this.code = code;
+  }
+}
 
 try {
   // The deterministic helpers use process.argv to identify their CLI entry
   // point. Recreate the argv shape they receive when launched directly, then
   // import them in this process so resourceUsage() measures the real stage.
   process.argv = [process.execPath, resolvedScript, ...scriptArgs];
+  process.exit = (code = 0) => {
+    throw new ImportedHelperExitError(code);
+  };
   await import(pathToFileURL(resolvedScript).href);
 } catch (error) {
   failure = error instanceof Error ? error : new Error(String(error));
   process.stderr.write(`${failure.stack ?? failure.message}\n`);
+} finally {
+  process.exit = originalExit;
 }
 
 const usageAfter = process.resourceUsage();
@@ -37,5 +51,6 @@ const metrics = {
   systemCpuTimeMicros: usageAfter.systemCPUTime - usageBefore.systemCPUTime,
 };
 
-process.stderr.write(`${STAGE_METRICS_PREFIX}${JSON.stringify(metrics)}\n`);
+// Start the marker on its own line even when a helper left stderr unterminated.
+process.stderr.write(`\n${STAGE_METRICS_PREFIX}${JSON.stringify(metrics)}\n`);
 if (failure) process.exitCode = 1;

--- a/scripts/lib/benchmark-stage-worker.mjs
+++ b/scripts/lib/benchmark-stage-worker.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import { performance } from 'node:perf_hooks';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const STAGE_METRICS_PREFIX = '__UA_BENCHMARK_METRICS__';
+
+const [scriptPath, ...scriptArgs] = process.argv.slice(2);
+if (!scriptPath) {
+  process.stderr.write('benchmark-stage-worker: missing script path\n');
+  process.exit(2);
+}
+
+const resolvedScript = resolve(scriptPath);
+const startedAt = performance.now();
+const usageBefore = process.resourceUsage();
+let failure = null;
+
+try {
+  // The deterministic helpers use process.argv to identify their CLI entry
+  // point. Recreate the argv shape they receive when launched directly, then
+  // import them in this process so resourceUsage() measures the real stage.
+  process.argv = [process.execPath, resolvedScript, ...scriptArgs];
+  await import(pathToFileURL(resolvedScript).href);
+} catch (error) {
+  failure = error instanceof Error ? error : new Error(String(error));
+  process.stderr.write(`${failure.stack ?? failure.message}\n`);
+}
+
+const usageAfter = process.resourceUsage();
+const metrics = {
+  durationMs: Math.round((performance.now() - startedAt) * 100) / 100,
+  // Node reports maxRSS in KiB on every supported platform.
+  peakRssBytes: usageAfter.maxRSS * 1024,
+  userCpuTimeMicros: usageAfter.userCPUTime - usageBefore.userCPUTime,
+  systemCpuTimeMicros: usageAfter.systemCPUTime - usageBefore.systemCPUTime,
+};
+
+process.stderr.write(`${STAGE_METRICS_PREFIX}${JSON.stringify(metrics)}\n`);
+if (failure) process.exitCode = 1;

--- a/scripts/lib/large-repo-benchmark.mjs
+++ b/scripts/lib/large-repo-benchmark.mjs
@@ -65,6 +65,7 @@ export const GIT_METADATA_MAX_BUFFER = 64 * 1024;
 // from each stream while continuing to drain and inspect all child output.
 export const STAGE_OUTPUT_MAX_BYTES = 128 * 1024;
 export const WARNING_SAMPLE_LIMIT = 5;
+export const STRUCTURE_DIAGNOSTIC_SAMPLE_MAX_BYTES = 4 * 1024;
 const ENTITY_FIELDS = [
   'functions',
   'classes',
@@ -93,10 +94,18 @@ export class BenchmarkStageError extends Error {
 }
 
 export class BenchmarkReportWriteError extends Error {
-  constructor(artifactRoot = null) {
+  constructor(artifactRoot = null, recovery = {}) {
     super('Unable to write benchmark report files');
     this.name = 'BenchmarkReportWriteError';
     this.artifactRoot = artifactRoot;
+    this.recovery = {
+      lockAcquisitionFailed: recovery.lockAcquisitionFailed ?? false,
+      rollbackRemoveFailures: recovery.rollbackRemoveFailures ?? 0,
+      restoreFailures: recovery.restoreFailures ?? 0,
+      tempCleanupFailures: recovery.tempCleanupFailures ?? 0,
+      backupCleanupFailures: recovery.backupCleanupFailures ?? 0,
+      lockReleaseFailures: recovery.lockReleaseFailures ?? 0,
+    };
   }
 }
 
@@ -236,6 +245,9 @@ export function parseArgs(argv, cwd = process.cwd()) {
 
   if (help) return { help: true };
   if (!repoValue) throw new CliUsageError('A repository path is required');
+  if (outputValue === null || outputValue.trim() === '') {
+    throw new CliUsageError('--output is required and must be non-empty');
+  }
   if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 32) {
     throw new CliUsageError('--concurrency must be an integer between 1 and 32');
   }
@@ -248,10 +260,7 @@ export function parseArgs(argv, cwd = process.cwd()) {
     throw new CliUsageError(`Repository path is not a directory: ${repoValue}`);
   }
 
-  const outputPath = resolve(
-    cwd,
-    outputValue ?? join('benchmark-results', 'large-repo-report.json'),
-  );
+  const outputPath = resolve(cwd, outputValue);
   const markdownPath = resolve(
     cwd,
     outputPath.toLowerCase().endsWith('.json')
@@ -278,11 +287,11 @@ export function parseArgs(argv, cwd = process.cwd()) {
 
 export function helpText() {
   return `Usage:
-  node scripts/benchmark-large-repo.mjs <repo-path> [options]
-  node scripts/benchmark-large-repo.mjs --repo <repo-path> [options]
+  node scripts/benchmark-large-repo.mjs <repo-path> --output <path> [options]
+  node scripts/benchmark-large-repo.mjs --repo <repo-path> --output <path> [options]
 
 Options:
-  -o, --output <path>       JSON report path
+  -o, --output <path>       JSON report path (required)
       --label <name>        Public label for the subject repository
       --concurrency <1-32>  Structural extraction workers (default: 5)
       --keep-artifacts      Preserve temporary deterministic outputs
@@ -397,7 +406,13 @@ function addRootAliases(aliases, root, replacement) {
 
 function hasPathBoundary(text, index) {
   if (index >= text.length) return true;
-  return text[index] === '/' || text[index] === '\\';
+  return (
+    text[index] === '/' ||
+    text[index] === '\\' ||
+    text[index] === '\n' ||
+    text[index] === '\r' ||
+    text[index] === '\t'
+  );
 }
 
 function replacePathAlias(text, alias, replacement, caseInsensitive) {
@@ -675,6 +690,99 @@ function readJson(path) {
   return JSON.parse(readFileSync(path, 'utf-8'));
 }
 
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isNonNegativeInteger(value) {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function isStringCountMap(value) {
+  return (
+    isRecord(value) && Object.values(value).every(isNonNegativeInteger)
+  );
+}
+
+function validateScanArtifact(scan) {
+  if (
+    !isRecord(scan) ||
+    scan.scriptCompleted !== true ||
+    !Array.isArray(scan.files) ||
+    !isNonNegativeInteger(scan.totalFiles) ||
+    scan.totalFiles !== scan.files.length ||
+    !isNonNegativeInteger(scan.filteredByIgnore) ||
+    !isRecord(scan.stats) ||
+    !isNonNegativeInteger(scan.stats.filesScanned) ||
+    scan.stats.filesScanned !== scan.totalFiles ||
+    !isStringCountMap(scan.stats.byCategory) ||
+    !isStringCountMap(scan.stats.byLanguage) ||
+    typeof scan.contentDigest !== 'string' ||
+    !/^[a-f0-9]{64}$/.test(scan.contentDigest) ||
+    scan.files.some(
+      (file) =>
+        !isRecord(file) ||
+        typeof file.path !== 'string' ||
+        file.path.length === 0 ||
+        !isNonNegativeInteger(file.sizeLines),
+    )
+  ) {
+    throw new Error('Scan artifact does not match the required shape');
+  }
+}
+
+function validateImportArtifact(imports) {
+  if (
+    !isRecord(imports) ||
+    imports.scriptCompleted !== true ||
+    !isRecord(imports.importMap) ||
+    !isRecord(imports.stats) ||
+    !isNonNegativeInteger(imports.stats.filesScanned) ||
+    !isNonNegativeInteger(imports.stats.filesWithImports) ||
+    !isNonNegativeInteger(imports.stats.totalEdges) ||
+    Object.values(imports.importMap).some(
+      (targets) =>
+        !Array.isArray(targets) ||
+        targets.some((target) => typeof target !== 'string'),
+    )
+  ) {
+    throw new Error('Import artifact does not match the required shape');
+  }
+}
+
+function validateBatchArtifact(batches) {
+  if (
+    !isRecord(batches) ||
+    batches.schemaVersion !== 1 ||
+    typeof batches.algorithm !== 'string' ||
+    batches.algorithm.length === 0 ||
+    !Array.isArray(batches.batches) ||
+    !isNonNegativeInteger(batches.totalBatches) ||
+    batches.totalBatches !== batches.batches.length ||
+    batches.batches.some(
+      (batch) =>
+        !isRecord(batch) ||
+        !isNonNegativeInteger(batch.batchIndex) ||
+        !Array.isArray(batch.files) ||
+        !isRecord(batch.batchImportData) ||
+        !isRecord(batch.neighborMap),
+    )
+  ) {
+    throw new Error('Batch artifact does not match the required shape');
+  }
+}
+
+function markArtifactFailure(stage, stageName, error, redactionRoots) {
+  const rawMessage = error instanceof Error ? error.message : String(error);
+  const safeMessage = sanitizeBounded(
+    `${stageName} stage produced an invalid artifact: ${rawMessage}`,
+    redactionRoots,
+  );
+  stage.status = 'failed';
+  stage.stderr = safeMessage.text;
+  stage.stderrTruncated ||= safeMessage.truncated;
+}
+
 function fileSizeOrZero(path) {
   try {
     return statSync(path).size;
@@ -696,25 +804,56 @@ function preflightReportTargets(paths, fileSystem) {
   }
 }
 
-function bestEffortRemove(path, fileSystem) {
+function tryRemove(path, fileSystem) {
   try {
     fileSystem.rmSync(path, { force: true });
+    return true;
   } catch {
-    // Transaction cleanup must never mask the primary delivery failure.
+    return false;
   }
 }
 
-function rollbackReportEntry(entry, fileSystem) {
+function rollbackReportEntry(entry, fileSystem, recovery) {
   if (entry.backupMoved) {
-    bestEffortRemove(entry.targetPath, fileSystem);
+    if (!tryRemove(entry.targetPath, fileSystem)) {
+      recovery.rollbackRemoveFailures += 1;
+    }
     try {
       fileSystem.renameSync(entry.backupPath, entry.targetPath);
     } catch {
-      // Leave an unrestored backup in place rather than delete original data.
+      recovery.restoreFailures += 1;
     }
   } else if (!entry.hadOriginal && entry.installAttempted) {
-    bestEffortRemove(entry.targetPath, fileSystem);
+    if (!tryRemove(entry.targetPath, fileSystem)) {
+      recovery.rollbackRemoveFailures += 1;
+    }
   }
+}
+
+export function reportPairLockPath(outputPath, markdownPath) {
+  const outputDirectory = canonicalizePhysicalPath(dirname(outputPath));
+  const markdownDirectory = canonicalizePhysicalPath(dirname(markdownPath));
+  const normalizePairPath = (pathValue) =>
+    process.platform === 'win32' ? pathValue.toLowerCase() : pathValue;
+  if (
+    normalizePairPath(outputDirectory) !==
+    normalizePairPath(markdownDirectory)
+  ) {
+    throw new Error('Benchmark report files must share a directory');
+  }
+  const normalizedOutputPath = normalizePairPath(
+    canonicalizePhysicalPath(outputPath),
+  );
+  const normalizedMarkdownPath = normalizePairPath(
+    canonicalizePhysicalPath(markdownPath),
+  );
+  const pairKey = createHash('sha256')
+    .update(normalizedOutputPath)
+    .update('\0')
+    .update(normalizedMarkdownPath)
+    .digest('hex')
+    .slice(0, 24);
+  return join(resolve(dirname(outputPath)), `.ua-report-pair-${pairKey}.lock`);
 }
 
 function stageReportEntry(entry, fileSystem) {
@@ -752,6 +891,17 @@ export function deliverBenchmarkReports(reportFiles, operations = {}) {
     writeFileSync: operations.writeFileSync ?? writeFileSync,
   };
   const transactionId = randomUUID();
+  const recovery = {
+    lockAcquisitionFailed: false,
+    rollbackRemoveFailures: 0,
+    restoreFailures: 0,
+    tempCleanupFailures: 0,
+    backupCleanupFailures: 0,
+    lockReleaseFailures: 0,
+  };
+  let deliveryFailed = false;
+  let lockOwned = false;
+  let lockPath = null;
   const entries = [
     [reportFiles.outputPath, reportFiles.jsonContents],
     [reportFiles.markdownPath, reportFiles.markdownContents],
@@ -775,6 +925,19 @@ export function deliverBenchmarkReports(reportFiles, operations = {}) {
   try {
     for (const entry of entries) {
       fileSystem.mkdirSync(dirname(entry.targetPath), { recursive: true });
+    }
+    lockPath = reportPairLockPath(
+      reportFiles.outputPath,
+      reportFiles.markdownPath,
+    );
+    let lockDescriptor;
+    try {
+      lockDescriptor = fileSystem.openSync(lockPath, 'wx');
+      lockOwned = true;
+      fileSystem.closeSync(lockDescriptor);
+    } catch (error) {
+      if (!lockOwned) recovery.lockAcquisitionFailed = true;
+      throw error;
     }
     preflightReportTargets(
       entries.map((entry) => entry.targetPath),
@@ -802,20 +965,36 @@ export function deliverBenchmarkReports(reportFiles, operations = {}) {
     }
     for (const entry of entries) {
       if (entry.backupMoved) {
-        bestEffortRemove(entry.backupPath, fileSystem);
+        if (!tryRemove(entry.backupPath, fileSystem)) {
+          recovery.backupCleanupFailures += 1;
+        }
       }
     }
   } catch {
+    deliveryFailed = true;
     for (const entry of [...entries].reverse()) {
-      rollbackReportEntry(entry, fileSystem);
+      rollbackReportEntry(entry, fileSystem, recovery);
     }
-    throw new BenchmarkReportWriteError();
   } finally {
     for (const entry of entries) {
       if (entry.tempCreated) {
-        bestEffortRemove(entry.tempPath, fileSystem);
+        if (!tryRemove(entry.tempPath, fileSystem)) {
+          recovery.tempCleanupFailures += 1;
+        }
       }
     }
+    if (lockOwned && !tryRemove(lockPath, fileSystem)) {
+      recovery.lockReleaseFailures += 1;
+    }
+  }
+
+  if (
+    deliveryFailed ||
+    recovery.tempCleanupFailures > 0 ||
+    recovery.backupCleanupFailures > 0 ||
+    recovery.lockReleaseFailures > 0
+  ) {
+    throw new BenchmarkReportWriteError(null, recovery);
   }
 }
 
@@ -863,9 +1042,12 @@ export function renderMarkdownReport(report) {
     '| Metric | Value |',
     '| --- | --- |',
     metricRow('Status', report.status),
+    metricRow('Pair ID', report.pairId),
     metricRow('Subject', report.subject.label),
     metricRow('Subject commit', report.subject.commit),
+    metricRow('Subject dirty', report.subject.dirty),
     metricRow('Tool commit', report.tool.commit),
+    metricRow('Tool dirty', report.tool.dirty),
     metricRow('Tool version', report.tool.packageVersion),
     metricRow('Started (UTC)', report.run.startedAt),
     metricRow('Total duration', duration(report.run.durationMs)),
@@ -917,10 +1099,27 @@ export function renderMarkdownReport(report) {
     metricRow('Memory (bytes)', report.environment.totalMemoryBytes),
   ];
 
+  if (report.subject.dirty === true || report.tool.dirty === true) {
+    lines.push(
+      '',
+      '> **Warning:** The subject or tool worktree was dirty; commit hashes alone do not reproduce this run.',
+    );
+  }
+
   if (report.warnings.length > 0) {
     lines.push('', '## Warnings', '');
     for (const warning of report.warnings) {
       lines.push(`- ${markdownValue(warning.stage)}: ${warning.count}`);
+    }
+  }
+  if ((report.secondaryErrors?.length ?? 0) > 0) {
+    lines.push('', '## Secondary errors', '');
+    for (const secondaryError of report.secondaryErrors) {
+      lines.push(
+        `- ${markdownValue(secondaryError.stage)}: ${markdownValue(
+          secondaryError.message,
+        )}`,
+      );
     }
   }
   if (report.error) {
@@ -1033,11 +1232,21 @@ export function aggregateStructureSummaries(structureSummaries) {
   const aggregate = {
     filesAnalyzed: 0,
     filesSkipped: 0,
+    structureSucceeded: 0,
+    structureFailed: 0,
+    callGraphSucceeded: 0,
+    callGraphFailed: 0,
+    callGraphSkipped: 0,
     entities: emptyEntityCounts(),
   };
   for (const summary of structureSummaries) {
     aggregate.filesAnalyzed += summary.filesAnalyzed;
     aggregate.filesSkipped += summary.filesSkipped;
+    aggregate.structureSucceeded += summary.structureSucceeded;
+    aggregate.structureFailed += summary.structureFailed;
+    aggregate.callGraphSucceeded += summary.callGraphSucceeded;
+    aggregate.callGraphFailed += summary.callGraphFailed;
+    aggregate.callGraphSkipped += summary.callGraphSkipped;
     for (const field of ENTITY_FIELDS) {
       aggregate.entities[field] += summary.entities[field];
     }
@@ -1051,6 +1260,24 @@ export function summarizeStructureOutput(batch, output) {
   const skippedPaths = Array.isArray(output?.filesSkipped)
     ? output.filesSkipped
     : [];
+  const outcomeCounts = output?.analysisOutcomes;
+  const hasOutcomeCounts = outcomeCounts !== undefined;
+  const isCount = (value) => Number.isInteger(value) && value >= 0;
+  const structureSucceeded = hasOutcomeCounts
+    ? outcomeCounts?.structure?.succeeded
+    : results.length;
+  const structureFailed = hasOutcomeCounts
+    ? outcomeCounts?.structure?.failed
+    : 0;
+  const callGraphSucceeded = hasOutcomeCounts
+    ? outcomeCounts?.callGraph?.succeeded
+    : 0;
+  const callGraphFailed = hasOutcomeCounts
+    ? outcomeCounts?.callGraph?.failed
+    : 0;
+  const callGraphSkipped = hasOutcomeCounts
+    ? outcomeCounts?.callGraph?.skipped
+    : results.length;
   let malformed =
     !output ||
     typeof output !== 'object' ||
@@ -1059,7 +1286,14 @@ export function summarizeStructureOutput(batch, output) {
     !Array.isArray(output.results) ||
     !Array.isArray(output.filesSkipped) ||
     !Number.isInteger(output.filesAnalyzed) ||
-    output.filesAnalyzed !== results.length;
+    output.filesAnalyzed !== results.length ||
+    !isCount(structureSucceeded) ||
+    !isCount(structureFailed) ||
+    !isCount(callGraphSucceeded) ||
+    !isCount(callGraphFailed) ||
+    !isCount(callGraphSkipped) ||
+    structureSucceeded + structureFailed !== results.length ||
+    callGraphSucceeded + callGraphFailed + callGraphSkipped !== results.length;
 
   const pathCounts = new Map();
   const entities = emptyEntityCounts();
@@ -1101,6 +1335,8 @@ export function summarizeStructureOutput(batch, output) {
     digest: canonicalSha256(output),
     complete:
       !malformed &&
+      structureFailed === 0 &&
+      callGraphFailed === 0 &&
       missingStructurePaths === 0 &&
       duplicateStructurePaths === 0 &&
       unexpectedStructurePaths === 0,
@@ -1109,6 +1345,11 @@ export function summarizeStructureOutput(batch, output) {
     accountedExpectedPaths,
     filesAnalyzed: results.length,
     filesSkipped: skippedPaths.length,
+    structureSucceeded: isCount(structureSucceeded) ? structureSucceeded : 0,
+    structureFailed: isCount(structureFailed) ? structureFailed : 0,
+    callGraphSucceeded: isCount(callGraphSucceeded) ? callGraphSucceeded : 0,
+    callGraphFailed: isCount(callGraphFailed) ? callGraphFailed : 0,
+    callGraphSkipped: isCount(callGraphSkipped) ? callGraphSkipped : 0,
     missingStructurePaths,
     duplicateStructurePaths,
     unexpectedStructurePaths,
@@ -1203,8 +1444,16 @@ export function buildBenchmarkIntegrity(
     }
   }
 
-  const accountedExpectedPaths = structureSummaries.reduce(
-    (sum, summary) => sum + summary.accountedExpectedPaths,
+  const structureSucceeded = structureSummaries.reduce(
+    (sum, summary) => sum + summary.structureSucceeded,
+    0,
+  );
+  const structureFailures = structureSummaries.reduce(
+    (sum, summary) => sum + summary.structureFailed,
+    0,
+  );
+  const callGraphFailures = structureSummaries.reduce(
+    (sum, summary) => sum + summary.callGraphFailed,
     0,
   );
   const filesSkipped = structureSummaries.reduce(
@@ -1236,9 +1485,14 @@ export function buildBenchmarkIntegrity(
     unexpectedBatchFiles: unexpectedBatchFiles.length,
     missingImportTargets,
     structureCoverage:
-      scan.totalFiles === 0
+      structureSucceeded + structureFailures === 0
         ? 1
-        : Math.round((accountedExpectedPaths / scan.totalFiles) * 10000) / 10000,
+        : Math.round(
+            (structureSucceeded / (structureSucceeded + structureFailures)) *
+              10000,
+          ) / 10000,
+    structureFailures,
+    callGraphFailures,
     filesSkipped,
     failedBatches,
     missingStructurePaths,
@@ -1253,6 +1507,8 @@ export function hasFailedIntegrity(integrity) {
     !integrity.allScannedFilesBatched ||
     integrity.missingImportTargets > 0 ||
     integrity.structureCoverage !== 1 ||
+    integrity.structureFailures > 0 ||
+    integrity.callGraphFailures > 0 ||
     integrity.failedBatches > 0 ||
     integrity.missingStructurePaths > 0 ||
     integrity.duplicateStructurePaths > 0 ||
@@ -1292,6 +1548,112 @@ export function aggregateStageWarnings(stages) {
   };
 }
 
+export function createStructureDiagnosticsAccumulator() {
+  const warningCandidates = [];
+  const failureCandidates = [];
+  let warningCount = 0;
+  let warningMessagesTruncated = false;
+  let failureSamplesTruncated = false;
+
+  function retainCandidate(candidates, candidate) {
+    candidates.push(candidate);
+    candidates.sort(
+      (left, right) =>
+        left.inputIndex - right.inputIndex ||
+        left.sampleIndex - right.sampleIndex,
+    );
+    if (candidates.length > WARNING_SAMPLE_LIMIT) {
+      candidates.pop();
+      return true;
+    }
+    return false;
+  }
+
+  function retainFailure(inputIndex, batchIndex, message, sampleIndex = 0) {
+    const safeMessage = boundUtf8(
+      `[batch ${batchIndex}] ${message}`,
+      STRUCTURE_DIAGNOSTIC_SAMPLE_MAX_BYTES,
+    );
+    const omitted = retainCandidate(failureCandidates, {
+      inputIndex,
+      sampleIndex,
+      batchIndex,
+      message: safeMessage.text,
+    });
+    failureSamplesTruncated ||=
+      safeMessage.truncated || omitted;
+  }
+
+  return {
+    record(inputIndex, batchIndex, stage) {
+      const stageMessages = stage.warningMessages ?? [];
+      const stageWarningCount = stage.warningCount ?? 0;
+      warningCount += stageWarningCount;
+      for (let sampleIndex = 0; sampleIndex < stageMessages.length; sampleIndex += 1) {
+        const safeMessage = boundUtf8(
+          `[batch ${batchIndex}] ${stageMessages[sampleIndex]}`,
+          STRUCTURE_DIAGNOSTIC_SAMPLE_MAX_BYTES,
+        );
+        const omitted = retainCandidate(warningCandidates, {
+          inputIndex,
+          sampleIndex,
+          message: safeMessage.text,
+        });
+        warningMessagesTruncated ||=
+          safeMessage.truncated || omitted;
+      }
+      warningMessagesTruncated ||=
+        stage.warningMessagesTruncated ||
+        stageWarningCount > stageMessages.length;
+
+      if (stage.status === 'failed') {
+        const message = stage.stderr?.trim()
+          ? stage.stderr.trim()
+          : `Structure worker failed with exit code ${stage.exitCode ?? 'unknown'}`;
+        retainFailure(inputIndex, batchIndex, message);
+      }
+
+      return {
+        name: stage.name,
+        status: stage.status,
+        exitCode: stage.exitCode,
+        durationMs: stage.durationMs,
+        peakRssBytes: stage.peakRssBytes,
+        userCpuTimeMicros: stage.userCpuTimeMicros,
+        systemCpuTimeMicros: stage.systemCpuTimeMicros,
+        warningCount: stageWarningCount,
+        warningMessagesTruncated:
+          stage.warningMessagesTruncated ||
+          stageWarningCount > stageMessages.length,
+        stdoutTruncated: stage.stdoutTruncated,
+        stderrTruncated: stage.stderrTruncated,
+      };
+    },
+    recordAnalysisOutcome(inputIndex, batchIndex, summary) {
+      if (summary.structureFailed > 0 || summary.callGraphFailed > 0) {
+        retainFailure(
+          inputIndex,
+          batchIndex,
+          `Analysis outcomes: ${summary.structureFailed} structure failure(s), ${summary.callGraphFailed} call-graph failure(s)`,
+          1,
+        );
+      }
+    },
+    summary() {
+      return {
+        warningCount,
+        warningMessages: warningCandidates.map((candidate) => candidate.message),
+        warningMessagesTruncated,
+        failureSamples: failureCandidates.map(({ batchIndex, message }) => ({
+          batchIndex,
+          message,
+        })),
+        failureSamplesTruncated,
+      };
+    },
+  };
+}
+
 export function warningSummary(stageResults) {
   return stageResults
     .filter((stage) => stage.warningCount > 0)
@@ -1316,6 +1678,7 @@ export async function runBenchmark(options, hooks = {}) {
     [artifactRoot, '<artifacts>'],
   ];
   const onProgress = hooks.onProgress ?? (() => {});
+  const runStage = hooks.runStage ?? runNodeStage;
   const toolGit = gitMetadata(REPO_ROOT);
   const subjectGit = gitMetadata(options.repoRoot);
   const stageResults = [];
@@ -1323,6 +1686,7 @@ export async function runBenchmark(options, hooks = {}) {
   const report = {
     schemaUrl: REPORT_SCHEMA_URL,
     schemaVersion: REPORT_SCHEMA_VERSION,
+    pairId: randomUUID(),
     status: 'failed',
     mode: 'deterministic',
     run: {
@@ -1356,6 +1720,7 @@ export async function runBenchmark(options, hooks = {}) {
       costUsd: null,
     },
     warnings: [],
+    secondaryErrors: [],
     error: null,
   };
 
@@ -1363,7 +1728,7 @@ export async function runBenchmark(options, hooks = {}) {
   try {
     const scanPath = join(artifactRoot, 'scan-result.json');
     onProgress('scan');
-    const scanStage = await runNodeStage(
+    const scanStage = await runStage(
       'scan',
       SCAN_SCRIPT,
       [options.repoRoot, scanPath, '--exclude-analysis-data'],
@@ -1374,8 +1739,20 @@ export async function runBenchmark(options, hooks = {}) {
       scanStage,
       fileSizeOrZero(scanPath),
     );
+    let scan = null;
+    if (scanStage.status === 'ok') {
+      try {
+        scan = readJson(scanPath);
+        validateScanArtifact(scan);
+      } catch (error) {
+        markArtifactFailure(scanStage, 'scan', error, redactionRoots);
+        report.stages.scan = summarizeStage(
+          scanStage,
+          fileSizeOrZero(scanPath),
+        );
+      }
+    }
     if (scanStage.status === 'failed') throw new BenchmarkStageError(scanStage);
-    const scan = readJson(scanPath);
     report.scale = subjectScale(options.repoRoot, scan);
     report.stages.scan = summarizeStage(scanStage, fileSizeOrZero(scanPath), {
       files: scan.totalFiles,
@@ -1391,7 +1768,7 @@ export async function runBenchmark(options, hooks = {}) {
       files: scan.files,
     });
     onProgress('imports');
-    const importStage = await runNodeStage(
+    const importStage = await runStage(
       'imports',
       IMPORT_SCRIPT,
       [importInputPath, importOutputPath],
@@ -1402,8 +1779,20 @@ export async function runBenchmark(options, hooks = {}) {
       importStage,
       fileSizeOrZero(importOutputPath),
     );
+    let imports = null;
+    if (importStage.status === 'ok') {
+      try {
+        imports = readJson(importOutputPath);
+        validateImportArtifact(imports);
+      } catch (error) {
+        markArtifactFailure(importStage, 'imports', error, redactionRoots);
+        report.stages.imports = summarizeStage(
+          importStage,
+          fileSizeOrZero(importOutputPath),
+        );
+      }
+    }
     if (importStage.status === 'failed') throw new BenchmarkStageError(importStage);
-    const imports = readJson(importOutputPath);
     report.stages.imports = summarizeStage(
       importStage,
       fileSizeOrZero(importOutputPath),
@@ -1419,7 +1808,7 @@ export async function runBenchmark(options, hooks = {}) {
     const enrichedScan = { ...scan, importMap: imports.importMap };
     writeJson(enrichedScanPath, enrichedScan);
     onProgress('batching');
-    const batchStage = await runNodeStage(
+    const batchStage = await runStage(
       'batching',
       BATCH_SCRIPT,
       [
@@ -1434,8 +1823,20 @@ export async function runBenchmark(options, hooks = {}) {
       batchStage,
       fileSizeOrZero(batchesPath),
     );
+    let batches = null;
+    if (batchStage.status === 'ok') {
+      try {
+        batches = readJson(batchesPath);
+        validateBatchArtifact(batches);
+      } catch (error) {
+        markArtifactFailure(batchStage, 'batching', error, redactionRoots);
+        report.stages.batching = summarizeStage(
+          batchStage,
+          fileSizeOrZero(batchesPath),
+        );
+      }
+    }
     if (batchStage.status === 'failed') throw new BenchmarkStageError(batchStage);
-    const batches = readJson(batchesPath);
     const batchSizes = batches.batches.map((batch) => batch.files.length);
     const estimatedAgentInputBytes = batches.batches.reduce(
       (sum, batch) =>
@@ -1463,10 +1864,11 @@ export async function runBenchmark(options, hooks = {}) {
     onProgress('structure');
     const structureStart = performance.now();
     let completedBatches = 0;
+    const structureDiagnostics = createStructureDiagnosticsAccumulator();
     const structureRuns = await mapWithConcurrency(
       batches.batches,
       options.concurrency,
-      async (batch) => {
+      async (batch, inputIndex) => {
         const inputPath = join(artifactRoot, `structure-input-${batch.batchIndex}.json`);
         const outputPath = join(artifactRoot, `structure-output-${batch.batchIndex}.json`);
         writeJson(inputPath, {
@@ -1474,7 +1876,7 @@ export async function runBenchmark(options, hooks = {}) {
           batchFiles: batch.files,
           batchImportData: batch.batchImportData,
         });
-        const stage = await runNodeStage(
+        const stage = await runStage(
           `structure:${batch.batchIndex}`,
           STRUCTURE_SCRIPT,
           [inputPath, outputPath],
@@ -1487,6 +1889,11 @@ export async function runBenchmark(options, hooks = {}) {
           try {
             const output = readJson(outputPath);
             summary = summarizeStructureOutput(batch, output);
+            structureDiagnostics.recordAnalysisOutcome(
+              inputIndex,
+              batch.batchIndex,
+              summary,
+            );
           } catch (error) {
             stage.status = 'failed';
             stage.stderr = redactPaths(
@@ -1495,8 +1902,13 @@ export async function runBenchmark(options, hooks = {}) {
             );
           }
         }
-        return {
+        const compactStage = structureDiagnostics.record(
+          inputIndex,
+          batch.batchIndex,
           stage,
+        );
+        return {
+          stage: compactStage,
           summary,
           outputBytes: fileSizeOrZero(outputPath),
         };
@@ -1508,13 +1920,17 @@ export async function runBenchmark(options, hooks = {}) {
       .map((run) => run.summary);
     const structureAggregate = aggregateStructureSummaries(structureSummaries);
     const failedBatches = structureRuns.filter(
-      (run) => run.stage.status === 'failed',
+      (run) => run.stage.status === 'failed' || run.summary?.complete === false,
     ).length;
     const structureDurationMs =
       Math.round((performance.now() - structureStart) * 100) / 100;
-    const structureWarnings = aggregateStageWarnings(
-      structureRuns.map((run) => run.stage),
-    );
+    const structureDiagnosticsSummary = structureDiagnostics.summary();
+    const structureWarnings = {
+      warningCount: structureDiagnosticsSummary.warningCount,
+      warningMessages: structureDiagnosticsSummary.warningMessages,
+      warningMessagesTruncated:
+        structureDiagnosticsSummary.warningMessagesTruncated,
+    };
     const structureResources = aggregateStructureResources(
       structureRuns.map((run) => run.stage),
     );
@@ -1535,11 +1951,19 @@ export async function runBenchmark(options, hooks = {}) {
       userCpuTimeMicros: structureResources.userCpuTimeMicros,
       systemCpuTimeMicros: structureResources.systemCpuTimeMicros,
       ...structureWarnings,
+      failureSamples: structureDiagnosticsSummary.failureSamples,
+      failureSamplesTruncated:
+        structureDiagnosticsSummary.failureSamplesTruncated,
       outputBytes: structureRuns.reduce((sum, run) => sum + run.outputBytes, 0),
       batchesSucceeded: structureRuns.length - failedBatches,
       batchesFailed: failedBatches,
       filesAnalyzed: structureAggregate.filesAnalyzed,
       filesSkipped: structureAggregate.filesSkipped,
+      structureSucceeded: structureAggregate.structureSucceeded,
+      structureFailed: structureAggregate.structureFailed,
+      callGraphSucceeded: structureAggregate.callGraphSucceeded,
+      callGraphFailed: structureAggregate.callGraphFailed,
+      callGraphSkipped: structureAggregate.callGraphSkipped,
       entities: structureAggregate.entities,
       batchDurationMs: distribution(
         structureRuns.map((run) => run.stage.durationMs),
@@ -1596,7 +2020,20 @@ export async function runBenchmark(options, hooks = {}) {
   }
 
   if (!options.keepArtifacts) {
-    cleanupBenchmarkArtifacts(artifactRoot);
+    try {
+      const cleanupArtifacts =
+        hooks.cleanupArtifacts ?? cleanupBenchmarkArtifacts;
+      cleanupArtifacts(artifactRoot);
+    } catch {
+      const cleanupMessage = 'Unable to remove temporary benchmark artifacts';
+      report.secondaryErrors.push({
+        stage: 'cleanup',
+        message: cleanupMessage,
+      });
+      report.error ??= cleanupMessage;
+      report.status = 'failed';
+      exitCode = 1;
+    }
   }
 
   try {
@@ -1606,9 +2043,10 @@ export async function runBenchmark(options, hooks = {}) {
       jsonContents: `${JSON.stringify(report, null, 2)}\n`,
       markdownContents: renderMarkdownReport(report),
     });
-  } catch {
+  } catch (error) {
     throw new BenchmarkReportWriteError(
       options.keepArtifacts ? artifactRoot : null,
+      error instanceof BenchmarkReportWriteError ? error.recovery : {},
     );
   }
 

--- a/scripts/lib/large-repo-benchmark.mjs
+++ b/scripts/lib/large-repo-benchmark.mjs
@@ -1,0 +1,1620 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import {
+  arch,
+  cpus,
+  platform,
+  release,
+  tmpdir,
+  totalmem,
+} from 'node:os';
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { StringDecoder } from 'node:string_decoder';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = resolve(__dirname, '../..');
+export const REPORT_SCHEMA_VERSION = '1.0.0';
+export const REPORT_SCHEMA_URL =
+  'https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/docs/benchmarks/large-repo-report-1.0.0.schema.json';
+
+const WORKER = resolve(__dirname, 'benchmark-stage-worker.mjs');
+const SCAN_SCRIPT = resolve(
+  REPO_ROOT,
+  'understand-anything-plugin/skills/understand/scan-project.mjs',
+);
+const IMPORT_SCRIPT = resolve(
+  REPO_ROOT,
+  'understand-anything-plugin/skills/understand/extract-import-map.mjs',
+);
+const BATCH_SCRIPT = resolve(
+  REPO_ROOT,
+  'understand-anything-plugin/skills/understand/compute-batches.mjs',
+);
+const STRUCTURE_SCRIPT = resolve(
+  REPO_ROOT,
+  'understand-anything-plugin/skills/understand/extract-structure.mjs',
+);
+
+export const STAGE_METRICS_PREFIX = '__UA_BENCHMARK_METRICS__';
+const DEFAULT_CONCURRENCY = 5;
+export const GIT_METADATA_MAX_BUFFER = 64 * 1024;
+// Child helpers can be noisy on large repositories. Retain at most 128 KiB
+// from each stream while continuing to drain and inspect all child output.
+export const STAGE_OUTPUT_MAX_BYTES = 128 * 1024;
+export const WARNING_SAMPLE_LIMIT = 5;
+const ENTITY_FIELDS = [
+  'functions',
+  'classes',
+  'exports',
+  'callGraph',
+  'definitions',
+  'services',
+  'endpoints',
+  'steps',
+  'resources',
+];
+
+export class CliUsageError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'CliUsageError';
+  }
+}
+
+export class BenchmarkStageError extends Error {
+  constructor(stage) {
+    super(`Benchmark stage failed: ${stage.name}`);
+    this.name = 'BenchmarkStageError';
+    this.stage = stage;
+  }
+}
+
+export class BenchmarkReportWriteError extends Error {
+  constructor(artifactRoot = null) {
+    super('Unable to write benchmark report files');
+    this.name = 'BenchmarkReportWriteError';
+    this.artifactRoot = artifactRoot;
+  }
+}
+
+export class BenchmarkArtifactCleanupError extends Error {
+  constructor() {
+    super('Unable to remove temporary benchmark artifacts');
+    this.name = 'BenchmarkArtifactCleanupError';
+  }
+}
+
+export function cleanupBenchmarkArtifacts(artifactRoot, operations = {}) {
+  const remove = operations.rmSync ?? rmSync;
+  try {
+    remove(artifactRoot, { recursive: true, force: true });
+  } catch {
+    throw new BenchmarkArtifactCleanupError();
+  }
+}
+
+function takeValue(argv, index, flag) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new CliUsageError(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function parseConcurrency(value) {
+  return /^[0-9]+$/.test(value) ? Number(value) : Number.NaN;
+}
+
+function canonicalizePhysicalPath(pathValue) {
+  const lexicalPath = resolve(withoutExtendedWindowsPrefix(pathValue));
+  const missingComponents = [];
+  let existingAncestor = lexicalPath;
+  let ancestorExists = existsSync(existingAncestor);
+
+  while (!ancestorExists) {
+    const parent = dirname(existingAncestor);
+    if (parent === existingAncestor) break;
+    missingComponents.unshift(basename(existingAncestor));
+    existingAncestor = parent;
+    ancestorExists = existsSync(existingAncestor);
+  }
+
+  let physicalAncestor = existingAncestor;
+  if (ancestorExists) {
+    try {
+      const nativeRealpath = realpathSync.native ?? realpathSync;
+      physicalAncestor = nativeRealpath(existingAncestor);
+    } catch {
+      // Fall back to the resolved lexical ancestor if metadata becomes unavailable.
+    }
+  }
+  return resolve(
+    withoutExtendedWindowsPrefix(physicalAncestor),
+    ...missingComponents,
+  );
+}
+
+export function isPathInsideOrEqual(rootPath, candidatePath) {
+  const relationship = relative(
+    canonicalizePhysicalPath(rootPath),
+    canonicalizePhysicalPath(candidatePath),
+  );
+  return (
+    relationship === '' ||
+    (relationship !== '..' &&
+      !relationship.startsWith(`..${sep}`) &&
+      !isAbsolute(relationship))
+  );
+}
+
+export function parseArgs(argv, cwd = process.cwd()) {
+  let repoValue = null;
+  let outputValue = null;
+  let label = null;
+  let concurrency = DEFAULT_CONCURRENCY;
+  let keepArtifacts = false;
+  let help = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+      continue;
+    }
+    if (arg === '--keep-artifacts') {
+      keepArtifacts = true;
+      continue;
+    }
+    if (arg === '--repo') {
+      repoValue = takeValue(argv, i, '--repo');
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--repo=')) {
+      repoValue = arg.slice('--repo='.length);
+      continue;
+    }
+    if (arg === '--output' || arg === '-o') {
+      outputValue = takeValue(argv, i, arg);
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--output=')) {
+      outputValue = arg.slice('--output='.length);
+      continue;
+    }
+    if (arg === '--label') {
+      label = takeValue(argv, i, '--label');
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--label=')) {
+      label = arg.slice('--label='.length);
+      continue;
+    }
+    if (arg === '--concurrency') {
+      const raw = takeValue(argv, i, '--concurrency');
+      concurrency = parseConcurrency(raw);
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--concurrency=')) {
+      concurrency = parseConcurrency(arg.slice('--concurrency='.length));
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw new CliUsageError(`Unknown option: ${arg}`);
+    }
+    if (repoValue) {
+      throw new CliUsageError(`Unexpected positional argument: ${arg}`);
+    }
+    repoValue = arg;
+  }
+
+  if (help) return { help: true };
+  if (!repoValue) throw new CliUsageError('A repository path is required');
+  if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 32) {
+    throw new CliUsageError('--concurrency must be an integer between 1 and 32');
+  }
+
+  const repoRoot = resolve(cwd, repoValue);
+  if (!existsSync(repoRoot)) {
+    throw new CliUsageError(`Repository path does not exist: ${repoValue}`);
+  }
+  if (!statSync(repoRoot).isDirectory()) {
+    throw new CliUsageError(`Repository path is not a directory: ${repoValue}`);
+  }
+
+  const outputPath = resolve(
+    cwd,
+    outputValue ?? join('benchmark-results', 'large-repo-report.json'),
+  );
+  const markdownPath = resolve(
+    cwd,
+    outputPath.toLowerCase().endsWith('.json')
+      ? `${outputPath.slice(0, -'.json'.length)}.md`
+      : `${outputPath}.md`,
+  );
+  if (isPathInsideOrEqual(repoRoot, outputPath)) {
+    throw new CliUsageError('--output must be outside the subject repository');
+  }
+  if (isPathInsideOrEqual(repoRoot, markdownPath)) {
+    throw new CliUsageError('Markdown report path must be outside the subject repository');
+  }
+
+  return {
+    help: false,
+    repoRoot,
+    outputPath,
+    markdownPath,
+    label: label || basename(repoRoot),
+    concurrency,
+    keepArtifacts,
+  };
+}
+
+export function helpText() {
+  return `Usage:
+  node scripts/benchmark-large-repo.mjs <repo-path> [options]
+  node scripts/benchmark-large-repo.mjs --repo <repo-path> [options]
+
+Options:
+  -o, --output <path>       JSON report path
+      --label <name>        Public label for the subject repository
+      --concurrency <1-32>  Structural extraction workers (default: 5)
+      --keep-artifacts      Preserve temporary deterministic outputs
+  -h, --help                Show this help
+
+This v1 runner measures deterministic helpers only. It does not invoke an LLM
+and keeps all intermediate artifacts outside the subject repository.
+`;
+}
+
+function gitProbe(directory, args) {
+  return spawnSync(
+    'git',
+    ['-c', 'core.optionalLocks=false', '-C', directory, ...args],
+    {
+      encoding: 'utf-8',
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
+      maxBuffer: GIT_METADATA_MAX_BUFFER,
+      windowsHide: true,
+    },
+  );
+}
+
+export function gitMetadata(directory) {
+  const commit = gitProbe(directory, ['rev-parse', 'HEAD']);
+  if (commit.status !== 0) return { commit: null, dirty: null };
+
+  const status = gitProbe(directory, ['status', '--porcelain']);
+  return {
+    commit: commit.stdout.trim() || null,
+    dirty:
+      status.error?.code === 'ENOBUFS'
+        ? true
+        : status.status === 0
+          ? status.stdout.trim().length > 0
+          : null,
+  };
+}
+
+function environmentMetadata() {
+  const processors = cpus();
+  return {
+    platform: platform(),
+    release: release(),
+    arch: arch(),
+    nodeVersion: process.version,
+    cpuModel: processors[0]?.model ?? 'unknown',
+    logicalCores: processors.length,
+    totalMemoryBytes: totalmem(),
+  };
+}
+
+function packageVersion() {
+  const packageJson = JSON.parse(
+    readFileSync(resolve(REPO_ROOT, 'understand-anything-plugin/package.json'), 'utf-8'),
+  );
+  return packageJson.version;
+}
+
+function withoutExtendedWindowsPrefix(pathValue) {
+  const extendedUncPrefix = pathValue.match(/^[\\/]{2}\?[\\/]unc[\\/]/i)?.[0];
+  if (extendedUncPrefix) {
+    return `\\\\${pathValue
+      .slice(extendedUncPrefix.length)
+      .replaceAll('/', '\\')}`;
+  }
+  const extendedPrefix = pathValue.match(/^[\\/]{2}\?[\\/]/)?.[0];
+  if (extendedPrefix) {
+    return pathValue.slice(extendedPrefix.length);
+  }
+  return pathValue;
+}
+
+function extendedWindowsPath(pathValue) {
+  const windowsPath = pathValue.replaceAll('/', '\\');
+  if (windowsPath.startsWith('\\\\?\\')) return windowsPath;
+  if (/^[A-Za-z]:\\/.test(windowsPath)) return `\\\\?\\${windowsPath}`;
+  if (windowsPath.startsWith('\\\\')) {
+    return `\\\\?\\UNC\\${windowsPath.slice(2)}`;
+  }
+  return null;
+}
+
+function addRootAliases(aliases, root, replacement) {
+  if (!root) return;
+  const resolvedRoot = resolve(root);
+  const resolvedAliases = new Set([resolvedRoot]);
+  try {
+    const nativeRealpath = realpathSync.native ?? realpathSync;
+    resolvedAliases.add(nativeRealpath(resolvedRoot));
+  } catch {
+    // Missing or inaccessible roots still retain their lexical aliases.
+  }
+
+  for (const resolvedAlias of resolvedAliases) {
+    const plainAlias = withoutExtendedWindowsPrefix(resolvedAlias);
+    const pathAliases = new Set([resolvedAlias, plainAlias]);
+    for (const pathAlias of pathAliases) {
+      aliases.push([pathAlias, replacement]);
+      aliases.push([pathAlias.replaceAll('\\', '/'), replacement]);
+      aliases.push([pathAlias.replaceAll('/', '\\'), replacement]);
+      const extendedAlias = extendedWindowsPath(pathAlias);
+      if (extendedAlias) aliases.push([extendedAlias, replacement]);
+      try {
+        aliases.push([pathToFileURL(pathAlias).href, replacement]);
+      } catch {
+        // Non-file path aliases are already represented in native forms.
+      }
+    }
+  }
+}
+
+function hasPathBoundary(text, index) {
+  if (index >= text.length) return true;
+  return text[index] === '/' || text[index] === '\\';
+}
+
+function replacePathAlias(text, alias, replacement, caseInsensitive) {
+  const haystack = caseInsensitive ? text.toLowerCase() : text;
+  const needle = caseInsensitive ? alias.toLowerCase() : alias;
+  let emittedUntil = 0;
+  let searchFrom = 0;
+  let result = '';
+
+  while (searchFrom < haystack.length) {
+    const index = haystack.indexOf(needle, searchFrom);
+    if (index === -1) break;
+    const end = index + needle.length;
+    if (hasPathBoundary(text, end)) {
+      result += text.slice(emittedUntil, index) + replacement;
+      emittedUntil = end;
+      searchFrom = end;
+    } else {
+      searchFrom = index + 1;
+    }
+  }
+  return result + text.slice(emittedUntil);
+}
+
+export function redactPaths(text, roots) {
+  const aliases = [];
+  for (const [root, replacement] of roots) {
+    addRootAliases(aliases, root, replacement);
+  }
+  const caseInsensitive = process.platform === 'win32';
+  const uniqueAliases = new Map();
+  for (const [alias, replacement] of aliases) {
+    const key = caseInsensitive ? alias.toLowerCase() : alias;
+    if (alias && !uniqueAliases.has(key)) {
+      uniqueAliases.set(key, [alias, replacement]);
+    }
+  }
+
+  let redacted = text;
+  for (const [alias, replacement] of [...uniqueAliases.values()].sort(
+    ([left], [right]) => right.length - left.length,
+  )) {
+    redacted = replacePathAlias(
+      redacted,
+      alias,
+      replacement,
+      caseInsensitive,
+    );
+  }
+  return redacted;
+}
+
+function createBoundedByteCollector(maxBytes = STAGE_OUTPUT_MAX_BYTES) {
+  const buffer = Buffer.allocUnsafe(maxBytes);
+  let length = 0;
+  let truncated = false;
+
+  return {
+    append(value) {
+      const source = Buffer.isBuffer(value) ? value : Buffer.from(value);
+      const copyLength = Math.min(source.length, maxBytes - length);
+      if (copyLength > 0) {
+        source.copy(buffer, length, 0, copyLength);
+        length += copyLength;
+      }
+      if (copyLength < source.length) truncated = true;
+    },
+    text() {
+      return buffer.subarray(0, length).toString('utf-8');
+    },
+    get truncated() {
+      return truncated;
+    },
+  };
+}
+
+function boundUtf8(text, maxBytes = STAGE_OUTPUT_MAX_BYTES) {
+  const bytes = Buffer.from(text);
+  if (bytes.length <= maxBytes) return { text, truncated: false };
+  const decoder = new StringDecoder('utf8');
+  return {
+    text: decoder.write(bytes.subarray(0, maxBytes)),
+    truncated: true,
+  };
+}
+
+function sanitizeBounded(text, redactionRoots) {
+  return boundUtf8(redactPaths(text, redactionRoots));
+}
+
+function createStderrInspector() {
+  const decoder = new StringDecoder('utf8');
+  const retained = createBoundedByteCollector();
+  const rawWarningMessages = [];
+  let warningCount = 0;
+  let warningMessageTruncated = false;
+  let metrics = null;
+  let lineKind = 'probing';
+  let lineProbe = '';
+  let lineCollector = null;
+
+  function classifyProbe() {
+    if (lineProbe === STAGE_METRICS_PREFIX) {
+      lineKind = 'metrics';
+      lineCollector = createBoundedByteCollector();
+      return;
+    }
+    if (lineProbe === 'Warning:') {
+      lineKind = 'warning';
+      retained.append(lineProbe);
+      if (rawWarningMessages.length < WARNING_SAMPLE_LIMIT) {
+        lineCollector = createBoundedByteCollector();
+        lineCollector.append(lineProbe);
+      }
+      return;
+    }
+    if (
+      STAGE_METRICS_PREFIX.startsWith(lineProbe) ||
+      'Warning:'.startsWith(lineProbe)
+    ) {
+      return;
+    }
+    lineKind = 'ordinary';
+    retained.append(lineProbe);
+  }
+
+  function processFragment(fragment) {
+    let offset = 0;
+    while (lineKind === 'probing' && offset < fragment.length) {
+      lineProbe += fragment[offset];
+      offset += 1;
+      classifyProbe();
+    }
+    if (offset >= fragment.length) return;
+    const remainder = fragment.slice(offset);
+    if (lineKind === 'metrics') {
+      lineCollector.append(remainder);
+    } else {
+      retained.append(remainder);
+      if (lineKind === 'warning' && lineCollector) {
+        lineCollector.append(remainder);
+      }
+    }
+  }
+
+  function finishLine(retainNewline) {
+    if (lineKind === 'probing') retained.append(lineProbe);
+    if (lineKind === 'metrics') {
+      try {
+        metrics = JSON.parse(lineCollector.text().replace(/\r$/, ''));
+      } catch {
+        // A malformed or oversized marker means telemetry is unavailable;
+        // child exit status and parent wall clock remain authoritative.
+      }
+    } else {
+      if (lineKind === 'warning') {
+        warningCount += 1;
+        if (lineCollector) {
+          rawWarningMessages.push(lineCollector.text().replace(/\r$/, ''));
+          warningMessageTruncated ||= lineCollector.truncated;
+        }
+      }
+      if (retainNewline) retained.append('\n');
+    }
+    lineKind = 'probing';
+    lineProbe = '';
+    lineCollector = null;
+  }
+
+  function processText(text) {
+    let offset = 0;
+    while (offset < text.length) {
+      const newline = text.indexOf('\n', offset);
+      if (newline === -1) {
+        processFragment(text.slice(offset));
+        return;
+      }
+      processFragment(text.slice(offset, newline));
+      finishLine(true);
+      offset = newline + 1;
+    }
+  }
+
+  return {
+    write(chunk) {
+      processText(decoder.write(chunk));
+    },
+    finish(redactionRoots) {
+      processText(decoder.end());
+      if (lineKind !== 'probing' || lineProbe.length > 0) finishLine(false);
+      const retainedStderr = retained.text().replace(/[\r\n]+$/, '');
+      const safeStderr = sanitizeBounded(retainedStderr, redactionRoots);
+      const warningMessages = rawWarningMessages.map((message) =>
+        sanitizeBounded(message, redactionRoots),
+      );
+      return {
+        metrics,
+        stderr: safeStderr.text,
+        stderrTruncated: retained.truncated || safeStderr.truncated,
+        warningCount,
+        warningMessages: warningMessages.map((message) => message.text),
+        warningMessagesTruncated:
+          warningCount > warningMessages.length ||
+          warningMessageTruncated ||
+          warningMessages.some((message) => message.truncated),
+      };
+    },
+  };
+}
+
+export function runNodeStage(name, scriptPath, args, redactionRoots = []) {
+  const startedAt = performance.now();
+  return new Promise((resolveStage) => {
+    const child = spawn(
+      process.execPath,
+      [WORKER, scriptPath, ...args],
+      { cwd: REPO_ROOT, windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    const stdoutCollector = createBoundedByteCollector();
+    const stderrInspector = createStderrInspector();
+    let settled = false;
+
+    child.stdout.on('data', (chunk) => stdoutCollector.append(chunk));
+    child.stderr.on('data', (chunk) => stderrInspector.write(chunk));
+    child.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      const durationMs = Math.round((performance.now() - startedAt) * 100) / 100;
+      const safeError = sanitizeBounded(error.message, redactionRoots);
+      resolveStage({
+        name,
+        status: 'failed',
+        exitCode: null,
+        durationMs,
+        peakRssBytes: null,
+        userCpuTimeMicros: null,
+        systemCpuTimeMicros: null,
+        warningCount: 0,
+        warningMessages: [],
+        warningMessagesTruncated: false,
+        stdout: '',
+        stderr: safeError.text,
+        stdoutTruncated: false,
+        stderrTruncated: safeError.truncated,
+      });
+    });
+    child.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      const durationMs = Math.round((performance.now() - startedAt) * 100) / 100;
+      const safeStdout = sanitizeBounded(stdoutCollector.text(), redactionRoots);
+      const inspectedStderr = stderrInspector.finish(redactionRoots);
+      const { metrics } = inspectedStderr;
+      resolveStage({
+        name,
+        status: code === 0 ? 'ok' : 'failed',
+        exitCode: code,
+        durationMs,
+        peakRssBytes: metrics?.peakRssBytes ?? null,
+        userCpuTimeMicros: metrics?.userCpuTimeMicros ?? null,
+        systemCpuTimeMicros: metrics?.systemCpuTimeMicros ?? null,
+        warningCount: inspectedStderr.warningCount,
+        warningMessages: inspectedStderr.warningMessages,
+        warningMessagesTruncated: inspectedStderr.warningMessagesTruncated,
+        stdout: safeStdout.text,
+        stderr: inspectedStderr.stderr,
+        stdoutTruncated: stdoutCollector.truncated || safeStdout.truncated,
+        stderrTruncated: inspectedStderr.stderrTruncated,
+      });
+    });
+  });
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+function fileSizeOrZero(path) {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+function writeJson(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+function preflightReportTargets(paths, fileSystem) {
+  for (const path of paths) {
+    if (fileSystem.existsSync(path) && fileSystem.statSync(path).isDirectory()) {
+      throw new Error('A benchmark report target is a directory');
+    }
+  }
+}
+
+function bestEffortRemove(path, fileSystem) {
+  try {
+    fileSystem.rmSync(path, { force: true });
+  } catch {
+    // Transaction cleanup must never mask the primary delivery failure.
+  }
+}
+
+function rollbackReportEntry(entry, fileSystem) {
+  if (entry.backupMoved) {
+    bestEffortRemove(entry.targetPath, fileSystem);
+    try {
+      fileSystem.renameSync(entry.backupPath, entry.targetPath);
+    } catch {
+      // Leave an unrestored backup in place rather than delete original data.
+    }
+  } else if (!entry.hadOriginal && entry.installAttempted) {
+    bestEffortRemove(entry.targetPath, fileSystem);
+  }
+}
+
+function stageReportEntry(entry, fileSystem) {
+  let descriptor;
+  let stageError = null;
+  try {
+    descriptor = fileSystem.openSync(entry.tempPath, 'wx');
+    entry.tempCreated = true;
+    fileSystem.writeFileSync(descriptor, entry.contents, {
+      encoding: 'utf-8',
+    });
+  } catch (error) {
+    stageError = error;
+  } finally {
+    if (descriptor !== undefined) {
+      try {
+        fileSystem.closeSync(descriptor);
+      } catch (error) {
+        stageError ??= error;
+      }
+    }
+  }
+  if (stageError) throw stageError;
+}
+
+export function deliverBenchmarkReports(reportFiles, operations = {}) {
+  const fileSystem = {
+    closeSync: operations.closeSync ?? closeSync,
+    existsSync: operations.existsSync ?? existsSync,
+    mkdirSync: operations.mkdirSync ?? mkdirSync,
+    openSync: operations.openSync ?? openSync,
+    renameSync: operations.renameSync ?? renameSync,
+    rmSync: operations.rmSync ?? rmSync,
+    statSync: operations.statSync ?? statSync,
+    writeFileSync: operations.writeFileSync ?? writeFileSync,
+  };
+  const transactionId = randomUUID();
+  const entries = [
+    [reportFiles.outputPath, reportFiles.jsonContents],
+    [reportFiles.markdownPath, reportFiles.markdownContents],
+  ].map(([targetPath, contents]) => ({
+    targetPath,
+    contents,
+    tempPath: join(
+      dirname(targetPath),
+      `.${basename(targetPath)}.ua-report-${transactionId}.tmp`,
+    ),
+    backupPath: join(
+      dirname(targetPath),
+      `.${basename(targetPath)}.ua-report-${transactionId}.backup`,
+    ),
+    hadOriginal: false,
+    tempCreated: false,
+    backupMoved: false,
+    installAttempted: false,
+  }));
+
+  try {
+    for (const entry of entries) {
+      fileSystem.mkdirSync(dirname(entry.targetPath), { recursive: true });
+    }
+    preflightReportTargets(
+      entries.map((entry) => entry.targetPath),
+      fileSystem,
+    );
+    for (const entry of entries) {
+      if (
+        fileSystem.existsSync(entry.tempPath) ||
+        fileSystem.existsSync(entry.backupPath)
+      ) {
+        throw new Error('A report transaction path already exists');
+      }
+      entry.hadOriginal = fileSystem.existsSync(entry.targetPath);
+      stageReportEntry(entry, fileSystem);
+    }
+    for (const entry of entries) {
+      if (entry.hadOriginal) {
+        fileSystem.renameSync(entry.targetPath, entry.backupPath);
+        entry.backupMoved = true;
+      }
+    }
+    for (const entry of entries) {
+      entry.installAttempted = true;
+      fileSystem.renameSync(entry.tempPath, entry.targetPath);
+    }
+    for (const entry of entries) {
+      if (entry.backupMoved) {
+        bestEffortRemove(entry.backupPath, fileSystem);
+      }
+    }
+  } catch {
+    for (const entry of [...entries].reverse()) {
+      rollbackReportEntry(entry, fileSystem);
+    }
+    throw new BenchmarkReportWriteError();
+  } finally {
+    for (const entry of entries) {
+      if (entry.tempCreated) {
+        bestEffortRemove(entry.tempPath, fileSystem);
+      }
+    }
+  }
+}
+
+function markdownValue(value) {
+  if (value === null || value === undefined) return 'n/a';
+  return String(value).replaceAll('|', '\\|').replaceAll(/\r?\n/g, ' ');
+}
+
+function metricRow(label, value) {
+  return `| ${label} | ${markdownValue(value)} |`;
+}
+
+function duration(value) {
+  return value === null || value === undefined ? 'n/a' : `${value} ms`;
+}
+
+function bytes(value) {
+  return value === null || value === undefined
+    ? 'n/a'
+    : new Intl.NumberFormat('en-US').format(value);
+}
+
+export function renderMarkdownReport(report) {
+  const scale = report.scale ?? {};
+  const integrity = report.integrity ?? {};
+  const stageRows = Object.entries(report.stages)
+    .map(([name, stage]) =>
+      `| ${markdownValue(name)} | ${markdownValue(stage.status)} | ${duration(
+        stage.durationMs,
+      )} | ${bytes(
+        stage.maxWorkerPeakRssBytes ?? stage.peakRssBytes,
+      )} | ${bytes(stage.userCpuTimeMicros)} | ${bytes(
+        stage.systemCpuTimeMicros,
+      )} | ${bytes(stage.outputBytes)} |`,
+    )
+    .join('\n');
+
+  const lines = [
+    '# Large Repository Benchmark Report',
+    '',
+    'This report covers deterministic static-analysis stages only. It does not include LLM inference or dashboard generation.',
+    '',
+    '## Run',
+    '',
+    '| Metric | Value |',
+    '| --- | --- |',
+    metricRow('Status', report.status),
+    metricRow('Subject', report.subject.label),
+    metricRow('Subject commit', report.subject.commit),
+    metricRow('Tool commit', report.tool.commit),
+    metricRow('Tool version', report.tool.packageVersion),
+    metricRow('Started (UTC)', report.run.startedAt),
+    metricRow('Total duration', duration(report.run.durationMs)),
+    metricRow('Concurrency', report.configuration.concurrency),
+    metricRow('LLM invoked', report.llm.invoked ? 'Yes' : 'No'),
+    '',
+    '## Scale',
+    '',
+    '| Metric | Value |',
+    '| --- | --- |',
+    metricRow('Files', scale.files),
+    metricRow('Lines', scale.lines),
+    metricRow('Source bytes', scale.bytes),
+    metricRow('Filtered by user ignore', scale.filteredByUserIgnore),
+    metricRow('Missing during measurement', scale.missingFiles),
+    '',
+    '## Stages',
+    '',
+    '| Stage | Status | Duration | Peak / max worker RSS (bytes) | User CPU (micros) | System CPU (micros) | Output (bytes) |',
+    '| --- | --- | ---: | ---: | ---: | ---: | ---: |',
+    stageRows || '| n/a | n/a | n/a | n/a | n/a | n/a | n/a |',
+    '',
+    '## Integrity and reproducibility',
+    '',
+    '| Metric | Value |',
+    '| --- | --- |',
+    metricRow('All scanned files batched', integrity.allScannedFilesBatched),
+    metricRow('Structure coverage', integrity.structureCoverage),
+    metricRow('Files skipped', integrity.filesSkipped),
+    metricRow('Failed batches', integrity.failedBatches),
+    metricRow('Missing structure paths', integrity.missingStructurePaths),
+    metricRow('Duplicate structure paths', integrity.duplicateStructurePaths),
+    metricRow('Unexpected structure paths', integrity.unexpectedStructurePaths),
+    metricRow('Malformed structure batches', integrity.malformedStructureBatches),
+    metricRow('Input digest (SHA-256)', report.determinism?.inputDigest),
+    metricRow('Output digest (SHA-256)', report.determinism?.outputDigest),
+    metricRow('Schema version', report.schemaVersion),
+    '',
+    '## Environment',
+    '',
+    '| Metric | Value |',
+    '| --- | --- |',
+    metricRow('Platform', report.environment.platform),
+    metricRow('OS release', report.environment.release),
+    metricRow('Architecture', report.environment.arch),
+    metricRow('Node.js', report.environment.nodeVersion),
+    metricRow('CPU', report.environment.cpuModel),
+    metricRow('Logical cores', report.environment.logicalCores),
+    metricRow('Memory (bytes)', report.environment.totalMemoryBytes),
+  ];
+
+  if (report.warnings.length > 0) {
+    lines.push('', '## Warnings', '');
+    for (const warning of report.warnings) {
+      lines.push(`- ${markdownValue(warning.stage)}: ${warning.count}`);
+    }
+  }
+  if (report.error) {
+    lines.push('', '## Error', '', markdownValue(report.error));
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function updateCanonicalHash(hash, value) {
+  if (Array.isArray(value)) {
+    hash.update('[');
+    for (let index = 0; index < value.length; index += 1) {
+      if (index > 0) hash.update(',');
+      updateCanonicalHash(hash, value[index]);
+    }
+    hash.update(']');
+    return;
+  }
+  if (value && typeof value === 'object') {
+    hash.update('{');
+    const keys = Object.keys(value).sort();
+    for (let index = 0; index < keys.length; index += 1) {
+      if (index > 0) hash.update(',');
+      const key = keys[index];
+      hash.update(JSON.stringify(key));
+      hash.update(':');
+      updateCanonicalHash(hash, value[key]);
+    }
+    hash.update('}');
+    return;
+  }
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) {
+    throw new TypeError(`Unsupported canonical JSON value: ${typeof value}`);
+  }
+  hash.update(encoded);
+}
+
+export function canonicalSha256(value) {
+  const hash = createHash('sha256');
+  updateCanonicalHash(hash, value);
+  return hash.digest('hex');
+}
+
+export function buildOutputDigest(importMap, batches, structureSummaries) {
+  const digestByBatchIndex = new Map(
+    structureSummaries.map((summary) => [summary.batchIndex, summary.digest]),
+  );
+  const structureBatchDigests = batches.batches.map((batch) => ({
+    batchIndex: batch.batchIndex,
+    digest: digestByBatchIndex.get(batch.batchIndex) ?? null,
+  }));
+  return canonicalSha256({
+    importMapDigest: canonicalSha256(importMap),
+    batchesDigest: canonicalSha256(batches),
+    structureBatchDigests,
+  });
+}
+
+function percentile(values, percentileValue) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.max(
+    0,
+    Math.min(sorted.length - 1, Math.ceil((percentileValue / 100) * sorted.length) - 1),
+  );
+  return sorted[index];
+}
+
+function distribution(values) {
+  if (values.length === 0) {
+    return { min: 0, p50: 0, p95: 0, max: 0, mean: 0 };
+  }
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return {
+    min: Math.min(...values),
+    p50: percentile(values, 50),
+    p95: percentile(values, 95),
+    max: Math.max(...values),
+    mean: Math.round((total / values.length) * 100) / 100,
+  };
+}
+
+async function mapWithConcurrency(items, concurrency, worker) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+
+  async function consume() {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await worker(items[index], index);
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, Math.max(1, items.length)) },
+    () => consume(),
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+function emptyEntityCounts() {
+  return Object.fromEntries(ENTITY_FIELDS.map((field) => [field, 0]));
+}
+
+export function aggregateStructureSummaries(structureSummaries) {
+  const aggregate = {
+    filesAnalyzed: 0,
+    filesSkipped: 0,
+    entities: emptyEntityCounts(),
+  };
+  for (const summary of structureSummaries) {
+    aggregate.filesAnalyzed += summary.filesAnalyzed;
+    aggregate.filesSkipped += summary.filesSkipped;
+    for (const field of ENTITY_FIELDS) {
+      aggregate.entities[field] += summary.entities[field];
+    }
+  }
+  return aggregate;
+}
+
+export function summarizeStructureOutput(batch, output) {
+  const expectedPaths = new Set(batch.files.map((file) => file.path));
+  const results = Array.isArray(output?.results) ? output.results : [];
+  const skippedPaths = Array.isArray(output?.filesSkipped)
+    ? output.filesSkipped
+    : [];
+  let malformed =
+    !output ||
+    typeof output !== 'object' ||
+    Array.isArray(output) ||
+    output.scriptCompleted !== true ||
+    !Array.isArray(output.results) ||
+    !Array.isArray(output.filesSkipped) ||
+    !Number.isInteger(output.filesAnalyzed) ||
+    output.filesAnalyzed !== results.length;
+
+  const pathCounts = new Map();
+  const entities = emptyEntityCounts();
+  for (const result of results) {
+    if (!result || typeof result !== 'object' || Array.isArray(result)) {
+      malformed = true;
+      continue;
+    }
+    if (typeof result.path !== 'string' || result.path.length === 0) {
+      malformed = true;
+    } else {
+      pathCounts.set(result.path, (pathCounts.get(result.path) ?? 0) + 1);
+    }
+    for (const field of ENTITY_FIELDS) {
+      entities[field] += Array.isArray(result[field]) ? result[field].length : 0;
+    }
+  }
+  for (const path of skippedPaths) {
+    if (typeof path !== 'string' || path.length === 0) {
+      malformed = true;
+      continue;
+    }
+    pathCounts.set(path, (pathCounts.get(path) ?? 0) + 1);
+  }
+
+  const accountedExpectedPaths = [...expectedPaths].filter((path) =>
+    pathCounts.has(path),
+  ).length;
+  const missingStructurePaths = expectedPaths.size - accountedExpectedPaths;
+  const duplicateStructurePaths = [...pathCounts.values()].filter(
+    (count) => count > 1,
+  ).length;
+  const unexpectedStructurePaths = [...pathCounts.keys()].filter(
+    (path) => !expectedPaths.has(path),
+  ).length;
+
+  return {
+    batchIndex: batch.batchIndex,
+    digest: canonicalSha256(output),
+    complete:
+      !malformed &&
+      missingStructurePaths === 0 &&
+      duplicateStructurePaths === 0 &&
+      unexpectedStructurePaths === 0,
+    malformed,
+    expectedFiles: expectedPaths.size,
+    accountedExpectedPaths,
+    filesAnalyzed: results.length,
+    filesSkipped: skippedPaths.length,
+    missingStructurePaths,
+    duplicateStructurePaths,
+    unexpectedStructurePaths,
+    entities,
+  };
+}
+
+export function aggregateStructureResources(stages) {
+  if (stages.length === 0) {
+    return {
+      maxWorkerPeakRssBytes: null,
+      userCpuTimeMicros: null,
+      systemCpuTimeMicros: null,
+    };
+  }
+  const values = (field) => stages.map((stage) => stage[field]);
+  const peakRssValues = values('peakRssBytes');
+  const userCpuValues = values('userCpuTimeMicros');
+  const systemCpuValues = values('systemCpuTimeMicros');
+  const allNumbers = (items) => items.every((value) => Number.isFinite(value));
+  const sum = (items) => items.reduce((total, value) => total + value, 0);
+  return {
+    maxWorkerPeakRssBytes: allNumbers(peakRssValues)
+      ? Math.max(...peakRssValues)
+      : null,
+    userCpuTimeMicros: allNumbers(userCpuValues) ? sum(userCpuValues) : null,
+    systemCpuTimeMicros: allNumbers(systemCpuValues)
+      ? sum(systemCpuValues)
+      : null,
+  };
+}
+
+function summarizeStage(stage, outputBytes, extra = {}) {
+  return {
+    status: stage.status,
+    durationMs: stage.durationMs,
+    peakRssBytes: stage.peakRssBytes,
+    userCpuTimeMicros: stage.userCpuTimeMicros,
+    systemCpuTimeMicros: stage.systemCpuTimeMicros,
+    warningCount: stage.warningCount,
+    warningMessages: stage.warningMessages,
+    warningMessagesTruncated: stage.warningMessagesTruncated,
+    stdoutTruncated: stage.stdoutTruncated,
+    stderrTruncated: stage.stderrTruncated,
+    outputBytes,
+    ...extra,
+  };
+}
+
+function subjectScale(repoRoot, scan) {
+  let bytes = 0;
+  let missingFiles = 0;
+  for (const file of scan.files) {
+    try {
+      bytes += statSync(resolve(repoRoot, file.path)).size;
+    } catch {
+      missingFiles += 1;
+    }
+  }
+  return {
+    files: scan.totalFiles,
+    lines: scan.files.reduce((sum, file) => sum + (file.sizeLines ?? 0), 0),
+    bytes,
+    missingFiles,
+    filteredByUserIgnore: scan.filteredByIgnore ?? 0,
+    byCategory: scan.stats?.byCategory ?? {},
+    byLanguage: scan.stats?.byLanguage ?? {},
+  };
+}
+
+export function buildBenchmarkIntegrity(
+  scan,
+  importMap,
+  batches,
+  structureSummaries,
+  failedBatches,
+) {
+  const scannedPaths = new Set(scan.files.map((file) => file.path));
+  const counts = new Map();
+  for (const batch of batches.batches) {
+    for (const file of batch.files) {
+      counts.set(file.path, (counts.get(file.path) ?? 0) + 1);
+    }
+  }
+  const missingBatchFiles = [...scannedPaths].filter((path) => !counts.has(path));
+  const duplicateBatchFiles = [...counts.values()].filter((count) => count > 1).length;
+  const unexpectedBatchFiles = [...counts.keys()].filter((path) => !scannedPaths.has(path));
+  let missingImportTargets = 0;
+  for (const targets of Object.values(importMap)) {
+    for (const target of targets) {
+      if (!scannedPaths.has(target)) missingImportTargets += 1;
+    }
+  }
+
+  const accountedExpectedPaths = structureSummaries.reduce(
+    (sum, summary) => sum + summary.accountedExpectedPaths,
+    0,
+  );
+  const filesSkipped = structureSummaries.reduce(
+    (sum, summary) => sum + summary.filesSkipped,
+    0,
+  );
+  const missingStructurePaths = structureSummaries.reduce(
+    (sum, summary) => sum + summary.missingStructurePaths,
+    0,
+  );
+  const duplicateStructurePaths = structureSummaries.reduce(
+    (sum, summary) => sum + summary.duplicateStructurePaths,
+    0,
+  );
+  const unexpectedStructurePaths = structureSummaries.reduce(
+    (sum, summary) => sum + summary.unexpectedStructurePaths,
+    0,
+  );
+  const malformedStructureBatches = structureSummaries.filter(
+    (summary) => summary.malformed,
+  ).length;
+  return {
+    allScannedFilesBatched:
+      missingBatchFiles.length === 0 &&
+      duplicateBatchFiles === 0 &&
+      unexpectedBatchFiles.length === 0,
+    missingBatchFiles: missingBatchFiles.length,
+    duplicateBatchFiles,
+    unexpectedBatchFiles: unexpectedBatchFiles.length,
+    missingImportTargets,
+    structureCoverage:
+      scan.totalFiles === 0
+        ? 1
+        : Math.round((accountedExpectedPaths / scan.totalFiles) * 10000) / 10000,
+    filesSkipped,
+    failedBatches,
+    missingStructurePaths,
+    duplicateStructurePaths,
+    unexpectedStructurePaths,
+    malformedStructureBatches,
+  };
+}
+
+export function hasFailedIntegrity(integrity) {
+  return (
+    !integrity.allScannedFilesBatched ||
+    integrity.missingImportTargets > 0 ||
+    integrity.structureCoverage !== 1 ||
+    integrity.failedBatches > 0 ||
+    integrity.missingStructurePaths > 0 ||
+    integrity.duplicateStructurePaths > 0 ||
+    integrity.unexpectedStructurePaths > 0 ||
+    integrity.malformedStructureBatches > 0
+  );
+}
+
+export function aggregateStageWarnings(stages) {
+  let warningCount = 0;
+  const warningMessages = [];
+  let warningMessagesTruncated = false;
+
+  for (const stage of stages) {
+    const stageCount = stage.warningCount ?? 0;
+    const stageMessages = stage.warningMessages ?? [];
+    warningCount += stageCount;
+    for (const message of stageMessages) {
+      if (warningMessages.length < WARNING_SAMPLE_LIMIT) {
+        warningMessages.push(message);
+      } else {
+        warningMessagesTruncated = true;
+      }
+    }
+    if (
+      stage.warningMessagesTruncated ||
+      stageCount > stageMessages.length
+    ) {
+      warningMessagesTruncated = true;
+    }
+  }
+
+  return {
+    warningCount,
+    warningMessages,
+    warningMessagesTruncated,
+  };
+}
+
+export function warningSummary(stageResults) {
+  return stageResults
+    .filter((stage) => stage.warningCount > 0)
+    .map((stage) => {
+      const warnings = aggregateStageWarnings([stage]);
+      return {
+        stage: stage.name,
+        count: warnings.warningCount,
+        messages: warnings.warningMessages,
+        truncated: warnings.warningMessagesTruncated,
+      };
+    });
+}
+
+export async function runBenchmark(options, hooks = {}) {
+  const startedAt = new Date();
+  const overallStart = performance.now();
+  const artifactRoot = mkdtempSync(join(tmpdir(), 'ua-large-bench-'));
+  const redactionRoots = [
+    [options.repoRoot, '<subject>'],
+    [REPO_ROOT, '<tool>'],
+    [artifactRoot, '<artifacts>'],
+  ];
+  const onProgress = hooks.onProgress ?? (() => {});
+  const toolGit = gitMetadata(REPO_ROOT);
+  const subjectGit = gitMetadata(options.repoRoot);
+  const stageResults = [];
+
+  const report = {
+    schemaUrl: REPORT_SCHEMA_URL,
+    schemaVersion: REPORT_SCHEMA_VERSION,
+    status: 'failed',
+    mode: 'deterministic',
+    run: {
+      startedAt: startedAt.toISOString(),
+      finishedAt: null,
+      durationMs: null,
+    },
+    tool: {
+      commit: toolGit.commit,
+      dirty: toolGit.dirty,
+      packageVersion: packageVersion(),
+    },
+    subject: {
+      label: options.label,
+      commit: subjectGit.commit,
+      dirty: subjectGit.dirty,
+    },
+    environment: environmentMetadata(),
+    configuration: {
+      concurrency: options.concurrency,
+      stages: ['scan', 'imports', 'batching', 'structure'],
+    },
+    scale: null,
+    stages: {},
+    integrity: null,
+    determinism: null,
+    llm: {
+      invoked: false,
+      inputTokens: null,
+      outputTokens: null,
+      costUsd: null,
+    },
+    warnings: [],
+    error: null,
+  };
+
+  let exitCode = 1;
+  try {
+    const scanPath = join(artifactRoot, 'scan-result.json');
+    onProgress('scan');
+    const scanStage = await runNodeStage(
+      'scan',
+      SCAN_SCRIPT,
+      [options.repoRoot, scanPath, '--exclude-analysis-data'],
+      redactionRoots,
+    );
+    stageResults.push(scanStage);
+    report.stages.scan = summarizeStage(
+      scanStage,
+      fileSizeOrZero(scanPath),
+    );
+    if (scanStage.status === 'failed') throw new BenchmarkStageError(scanStage);
+    const scan = readJson(scanPath);
+    report.scale = subjectScale(options.repoRoot, scan);
+    report.stages.scan = summarizeStage(scanStage, fileSizeOrZero(scanPath), {
+      files: scan.totalFiles,
+      lines: report.scale.lines,
+      bytes: report.scale.bytes,
+      filteredByUserIgnore: scan.filteredByIgnore ?? 0,
+    });
+
+    const importInputPath = join(artifactRoot, 'import-input.json');
+    const importOutputPath = join(artifactRoot, 'import-map.json');
+    writeJson(importInputPath, {
+      projectRoot: options.repoRoot,
+      files: scan.files,
+    });
+    onProgress('imports');
+    const importStage = await runNodeStage(
+      'imports',
+      IMPORT_SCRIPT,
+      [importInputPath, importOutputPath],
+      redactionRoots,
+    );
+    stageResults.push(importStage);
+    report.stages.imports = summarizeStage(
+      importStage,
+      fileSizeOrZero(importOutputPath),
+    );
+    if (importStage.status === 'failed') throw new BenchmarkStageError(importStage);
+    const imports = readJson(importOutputPath);
+    report.stages.imports = summarizeStage(
+      importStage,
+      fileSizeOrZero(importOutputPath),
+      {
+        filesScanned: imports.stats?.filesScanned ?? 0,
+        filesWithImports: imports.stats?.filesWithImports ?? 0,
+        edges: imports.stats?.totalEdges ?? 0,
+      },
+    );
+
+    const enrichedScanPath = join(artifactRoot, 'scan-result-with-imports.json');
+    const batchesPath = join(artifactRoot, 'batches.json');
+    const enrichedScan = { ...scan, importMap: imports.importMap };
+    writeJson(enrichedScanPath, enrichedScan);
+    onProgress('batching');
+    const batchStage = await runNodeStage(
+      'batching',
+      BATCH_SCRIPT,
+      [
+        options.repoRoot,
+        `--scan-result=${enrichedScanPath}`,
+        `--output=${batchesPath}`,
+      ],
+      redactionRoots,
+    );
+    stageResults.push(batchStage);
+    report.stages.batching = summarizeStage(
+      batchStage,
+      fileSizeOrZero(batchesPath),
+    );
+    if (batchStage.status === 'failed') throw new BenchmarkStageError(batchStage);
+    const batches = readJson(batchesPath);
+    const batchSizes = batches.batches.map((batch) => batch.files.length);
+    const estimatedAgentInputBytes = batches.batches.reduce(
+      (sum, batch) =>
+        sum +
+        Buffer.byteLength(
+          JSON.stringify({
+            files: batch.files,
+            batchImportData: batch.batchImportData,
+            neighborMap: batch.neighborMap,
+          }),
+        ),
+      0,
+    );
+    report.stages.batching = summarizeStage(
+      batchStage,
+      fileSizeOrZero(batchesPath),
+      {
+        algorithm: batches.algorithm,
+        totalBatches: batches.totalBatches,
+        batchSizes: distribution(batchSizes),
+        estimatedAgentInputBytes,
+      },
+    );
+
+    onProgress('structure');
+    const structureStart = performance.now();
+    let completedBatches = 0;
+    const structureRuns = await mapWithConcurrency(
+      batches.batches,
+      options.concurrency,
+      async (batch) => {
+        const inputPath = join(artifactRoot, `structure-input-${batch.batchIndex}.json`);
+        const outputPath = join(artifactRoot, `structure-output-${batch.batchIndex}.json`);
+        writeJson(inputPath, {
+          projectRoot: options.repoRoot,
+          batchFiles: batch.files,
+          batchImportData: batch.batchImportData,
+        });
+        const stage = await runNodeStage(
+          `structure:${batch.batchIndex}`,
+          STRUCTURE_SCRIPT,
+          [inputPath, outputPath],
+          redactionRoots,
+        );
+        completedBatches += 1;
+        hooks.onBatchProgress?.(completedBatches, batches.totalBatches);
+        let summary = null;
+        if (stage.status === 'ok') {
+          try {
+            const output = readJson(outputPath);
+            summary = summarizeStructureOutput(batch, output);
+          } catch (error) {
+            stage.status = 'failed';
+            stage.stderr = redactPaths(
+              error instanceof Error ? error.message : String(error),
+              redactionRoots,
+            );
+          }
+        }
+        return {
+          stage,
+          summary,
+          outputBytes: fileSizeOrZero(outputPath),
+        };
+      },
+    );
+
+    const structureSummaries = structureRuns
+      .filter((run) => run.summary)
+      .map((run) => run.summary);
+    const structureAggregate = aggregateStructureSummaries(structureSummaries);
+    const failedBatches = structureRuns.filter(
+      (run) => run.stage.status === 'failed',
+    ).length;
+    const structureDurationMs =
+      Math.round((performance.now() - structureStart) * 100) / 100;
+    const structureWarnings = aggregateStageWarnings(
+      structureRuns.map((run) => run.stage),
+    );
+    const structureResources = aggregateStructureResources(
+      structureRuns.map((run) => run.stage),
+    );
+    const structureSummaryStage = {
+      name: 'structure',
+      status: failedBatches === 0 ? 'ok' : 'failed',
+      durationMs: structureDurationMs,
+      peakRssBytes: structureResources.maxWorkerPeakRssBytes,
+      userCpuTimeMicros: structureResources.userCpuTimeMicros,
+      systemCpuTimeMicros: structureResources.systemCpuTimeMicros,
+      ...structureWarnings,
+    };
+    stageResults.push(structureSummaryStage);
+    report.stages.structure = {
+      status: structureSummaryStage.status,
+      durationMs: structureDurationMs,
+      maxWorkerPeakRssBytes: structureResources.maxWorkerPeakRssBytes,
+      userCpuTimeMicros: structureResources.userCpuTimeMicros,
+      systemCpuTimeMicros: structureResources.systemCpuTimeMicros,
+      ...structureWarnings,
+      outputBytes: structureRuns.reduce((sum, run) => sum + run.outputBytes, 0),
+      batchesSucceeded: structureRuns.length - failedBatches,
+      batchesFailed: failedBatches,
+      filesAnalyzed: structureAggregate.filesAnalyzed,
+      filesSkipped: structureAggregate.filesSkipped,
+      entities: structureAggregate.entities,
+      batchDurationMs: distribution(
+        structureRuns.map((run) => run.stage.durationMs),
+      ),
+    };
+
+    report.integrity = buildBenchmarkIntegrity(
+      scan,
+      imports.importMap,
+      batches,
+      structureSummaries,
+      failedBatches,
+    );
+    report.determinism = {
+      algorithm: 'sha256',
+      inputDigest: scan.contentDigest,
+      outputDigest: buildOutputDigest(
+        imports.importMap,
+        batches,
+        structureSummaries,
+      ),
+    };
+    report.warnings = warningSummary(stageResults);
+
+    if (hasFailedIntegrity(report.integrity)) {
+      report.status = 'failed';
+      report.error = 'One or more deterministic integrity checks failed';
+      exitCode = 1;
+    } else if (
+      report.warnings.length > 0 ||
+      report.integrity.filesSkipped > 0
+    ) {
+      report.status = 'degraded';
+      exitCode = 0;
+    } else {
+      report.status = 'ok';
+      exitCode = 0;
+    }
+  } catch (error) {
+    report.status = 'failed';
+    report.warnings = warningSummary(stageResults);
+    const rawMessage =
+      error instanceof BenchmarkStageError
+        ? error.stage.stderr || error.message
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    report.error = redactPaths(rawMessage, redactionRoots);
+    exitCode = 1;
+  } finally {
+    report.run.finishedAt = new Date().toISOString();
+    report.run.durationMs =
+      Math.round((performance.now() - overallStart) * 100) / 100;
+  }
+
+  if (!options.keepArtifacts) {
+    cleanupBenchmarkArtifacts(artifactRoot);
+  }
+
+  try {
+    deliverBenchmarkReports({
+      outputPath: options.outputPath,
+      markdownPath: options.markdownPath,
+      jsonContents: `${JSON.stringify(report, null, 2)}\n`,
+      markdownContents: renderMarkdownReport(report),
+    });
+  } catch {
+    throw new BenchmarkReportWriteError(
+      options.keepArtifacts ? artifactRoot : null,
+    );
+  }
+
+  return {
+    report,
+    exitCode,
+    artifactRoot: options.keepArtifacts ? artifactRoot : null,
+  };
+}

--- a/tests/benchmark/test_large_repo_benchmark.test.mjs
+++ b/tests/benchmark/test_large_repo_benchmark.test.mjs
@@ -13,7 +13,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import Ajv2020 from 'ajv/dist/2020.js';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -254,33 +254,25 @@ throw new Error(\`helper failed below \${subject}/failed.txt\`);
     expect(retained).not.toContain(artifacts);
   });
 
-  it('parses a final metrics marker without a newline', async () => {
+  it('keeps unterminated helper stderr separate from worker metrics', async () => {
     const root = mkdtempSync(join(tmpdir(), 'ua benchmark eof-metrics-'));
     cleanup.push(root);
     const helperPath = join(root, 'eof-metrics-helper.mjs');
-    const metrics = {
-      peakRssBytes: 123456,
-      userCpuTimeMicros: 234,
-      systemCpuTimeMicros: 345,
-    };
     writeFileSync(
       helperPath,
       `
 import { writeSync } from 'node:fs';
-writeSync(2, ${JSON.stringify(
-        `${benchmark.STAGE_METRICS_PREFIX}${JSON.stringify(metrics)}`,
-      )});
-process.exit(0);
+writeSync(2, 'ordinary final stderr');
 `,
     );
 
     const stage = await benchmark.runNodeStage('eof-metrics', helperPath, []);
 
     expect(stage.status).toBe('ok');
-    expect(stage.peakRssBytes).toBe(metrics.peakRssBytes);
-    expect(stage.userCpuTimeMicros).toBe(metrics.userCpuTimeMicros);
-    expect(stage.systemCpuTimeMicros).toBe(metrics.systemCpuTimeMicros);
-    expect(stage.stderr).toBe('');
+    expect(stage.peakRssBytes).toBeGreaterThan(0);
+    expect(stage.userCpuTimeMicros).toBeGreaterThanOrEqual(0);
+    expect(stage.systemCpuTimeMicros).toBeGreaterThanOrEqual(0);
+    expect(stage.stderr).toBe('ordinary final stderr');
     expect(stage.warningCount).toBe(0);
   });
 
@@ -295,7 +287,6 @@ process.exit(0);
       `
 import { writeSync } from 'node:fs';
 writeSync(2, \`Warning: final \${process.argv[2]}/file.ts\`);
-process.exit(0);
 `,
     );
 
@@ -314,7 +305,25 @@ process.exit(0);
     expect(stage.warningMessagesTruncated).toBe(false);
     expect(stage.stderr).toBe('Warning: final <subject>/file.ts');
     expect(stage.stderr.endsWith('\n')).toBe(false);
-    expect(stage.peakRssBytes).toBeNull();
+    expect(stage.peakRssBytes).toBeGreaterThan(0);
+  });
+
+  it('captures resource metrics before failing an imported helper process.exit', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua benchmark helper-exit-'));
+    cleanup.push(root);
+    const helperPath = join(root, 'exit-helper.mjs');
+    writeFileSync(
+      helperPath,
+      `process.stderr.write('helper requested exit\\n');\nprocess.exit(7);\n`,
+    );
+
+    const stage = await benchmark.runNodeStage('helper-exit', helperPath, []);
+
+    expect(stage.status).toBe('failed');
+    expect(stage.exitCode).not.toBe(0);
+    expect(stage.peakRssBytes).toBeGreaterThan(0);
+    expect(stage.userCpuTimeMicros).toBeGreaterThanOrEqual(0);
+    expect(stage.systemCpuTimeMicros).toBeGreaterThanOrEqual(0);
   });
 });
 
@@ -363,6 +372,59 @@ describe('benchmark warning aggregation', () => {
         truncated: true,
       },
     ]);
+  });
+
+  it('compacts completed structure workers into a globally bounded deterministic sample', () => {
+    expect(benchmark.createStructureDiagnosticsAccumulator).toBeTypeOf(
+      'function',
+    );
+    const diagnostics = benchmark.createStructureDiagnosticsAccumulator();
+    const compactStages = [];
+    for (let inputIndex = 999; inputIndex >= 0; inputIndex -= 1) {
+      compactStages.push(
+        diagnostics.record(inputIndex, inputIndex + 10, {
+          name: `structure:${inputIndex + 10}`,
+          status: inputIndex % 2 === 0 ? 'failed' : 'ok',
+          exitCode: inputIndex % 2 === 0 ? 1 : 0,
+          durationMs: 1,
+          peakRssBytes: 1024,
+          userCpuTimeMicros: 1,
+          systemCpuTimeMicros: 1,
+          warningCount: 1,
+          warningMessages: [`Warning: batch ${inputIndex} ${'w'.repeat(200_000)}`],
+          warningMessagesTruncated: false,
+          stdout: 'o'.repeat(200_000),
+          stderr: `failure ${inputIndex} ${'e'.repeat(200_000)}`,
+          stdoutTruncated: true,
+          stderrTruncated: true,
+        }),
+      );
+    }
+
+    expect(
+      compactStages.every(
+        (stage) =>
+          !Object.hasOwn(stage, 'stdout') &&
+          !Object.hasOwn(stage, 'stderr') &&
+          !Object.hasOwn(stage, 'warningMessages'),
+      ),
+    ).toBe(true);
+    const summary = diagnostics.summary();
+    expect(summary.warningMessages).toHaveLength(benchmark.WARNING_SAMPLE_LIMIT);
+    expect(summary.warningMessages[0]).toContain('batch 0');
+    expect(summary.failureSamples).toHaveLength(benchmark.WARNING_SAMPLE_LIMIT);
+    expect(summary.failureSamples.map((sample) => sample.batchIndex)).toEqual([
+      10,
+      12,
+      14,
+      16,
+      18,
+    ]);
+    expect(summary.warningMessagesTruncated).toBe(true);
+    expect(summary.failureSamplesTruncated).toBe(true);
+    expect(Buffer.byteLength(JSON.stringify(summary))).toBeLessThanOrEqual(
+      64 * 1024,
+    );
   });
 });
 
@@ -434,6 +496,11 @@ describe('structure output summaries', () => {
       accountedExpectedPaths: 3,
       filesAnalyzed: 2,
       filesSkipped: 1,
+      structureSucceeded: 2,
+      structureFailed: 0,
+      callGraphSucceeded: 0,
+      callGraphFailed: 0,
+      callGraphSkipped: 2,
       missingStructurePaths: 0,
       duplicateStructurePaths: 0,
       unexpectedStructurePaths: 0,
@@ -484,6 +551,33 @@ describe('structure output summaries', () => {
     });
   });
 
+  it('retains explicit parser outcomes instead of treating every returned path as success', () => {
+    const output = {
+      scriptCompleted: true,
+      filesAnalyzed: 3,
+      filesSkipped: [],
+      analysisOutcomes: {
+        structure: { succeeded: 2, failed: 1 },
+        callGraph: { succeeded: 1, failed: 1, skipped: 1 },
+      },
+      results: [
+        { path: 'src/a.ts' },
+        { path: 'src/b.ts' },
+        { path: 'src/c.ts' },
+      ],
+    };
+
+    expect(benchmark.summarizeStructureOutput(batch, output)).toMatchObject({
+      complete: false,
+      malformed: false,
+      structureSucceeded: 2,
+      structureFailed: 1,
+      callGraphSucceeded: 1,
+      callGraphFailed: 1,
+      callGraphSkipped: 1,
+    });
+  });
+
   it('aggregates file and entity counts from compact summaries', () => {
     expect(benchmark.aggregateStructureSummaries).toBeTypeOf('function');
     const first = benchmark.summarizeStructureOutput(batch, {
@@ -509,6 +603,11 @@ describe('structure output summaries', () => {
     expect(benchmark.aggregateStructureSummaries([first, second])).toEqual({
       filesAnalyzed: 3,
       filesSkipped: 1,
+      structureSucceeded: 3,
+      structureFailed: 0,
+      callGraphSucceeded: 0,
+      callGraphFailed: 0,
+      callGraphSkipped: 3,
       entities: {
         functions: 3,
         classes: 1,
@@ -558,9 +657,10 @@ describe('structure resource aggregation', () => {
     expect(benchmark.renderMarkdownReport).toBeTypeOf('function');
     const markdown = benchmark.renderMarkdownReport({
       schemaVersion: '1.0.0',
+      pairId: '11111111-1111-4111-8111-111111111111',
       status: 'ok',
-      subject: { label: 'fixture', commit: null },
-      tool: { commit: null, packageVersion: '0.0.0' },
+      subject: { label: 'fixture', commit: null, dirty: true },
+      tool: { commit: null, dirty: true, packageVersion: '0.0.0' },
       run: { startedAt: '2026-01-01T00:00:00.000Z', durationMs: 12 },
       configuration: { concurrency: 2 },
       llm: { invoked: false },
@@ -594,6 +694,12 @@ describe('structure resource aggregation', () => {
       '| Stage | Status | Duration | Peak / max worker RSS (bytes) | User CPU (micros) | System CPU (micros) | Output (bytes) |',
     );
     expect(markdown).toContain('| structure | ok | 12 ms | 250 | 50 | 10 | 99 |');
+    expect(markdown).toContain(
+      '| Pair ID | 11111111-1111-4111-8111-111111111111 |',
+    );
+    expect(markdown).toContain('| Tool dirty | true |');
+    expect(markdown).toContain('| Subject dirty | true |');
+    expect(markdown).toMatch(/warning.*dirty/i);
   });
 });
 
@@ -662,11 +768,42 @@ describe('benchmark integrity aggregation', () => {
     );
 
     expect(integrity).toMatchObject({
-      structureCoverage: 0.6667,
+      structureCoverage: 1,
       missingStructurePaths: 1,
       duplicateStructurePaths: 1,
       unexpectedStructurePaths: 1,
       failedBatches: 1,
+    });
+    expect(benchmark.hasFailedIntegrity(integrity)).toBe(true);
+  });
+
+  it('fails integrity when explicit structure or call-graph outcomes fail', () => {
+    const summary = benchmark.summarizeStructureOutput(batch, {
+      scriptCompleted: true,
+      filesAnalyzed: 3,
+      filesSkipped: [],
+      analysisOutcomes: {
+        structure: { succeeded: 2, failed: 1 },
+        callGraph: { succeeded: 1, failed: 1, skipped: 1 },
+      },
+      results: [
+        { path: 'src/a.ts' },
+        { path: 'src/b.ts' },
+        { path: 'src/c.ts' },
+      ],
+    });
+    const integrity = benchmark.buildBenchmarkIntegrity(
+      scan,
+      {},
+      batches,
+      [summary],
+      0,
+    );
+
+    expect(integrity).toMatchObject({
+      structureCoverage: 0.6667,
+      structureFailures: 1,
+      callGraphFailures: 1,
     });
     expect(benchmark.hasFailedIntegrity(integrity)).toBe(true);
   });
@@ -950,18 +1087,37 @@ describe('large repository benchmark CLI', () => {
     cleanup.push(root);
 
     const options = parseArgs(
-      [subject, '--concurrency', '3', '--label', 'polyglot-mini'],
+      [
+        subject,
+        '--output',
+        join(root, 'report.json'),
+        '--concurrency',
+        '3',
+        '--label',
+        'polyglot-mini',
+      ],
       root,
     );
     expect(options.repoRoot).toBe(subject);
     expect(options.concurrency).toBe(3);
     expect(options.label).toBe('polyglot-mini');
-    expect(options.markdownPath).toBe(
-      join(root, 'benchmark-results', 'large-repo-report.md'),
-    );
+    expect(options.markdownPath).toBe(join(root, 'report.md'));
     expect(() => parseArgs([subject, '--concurrency', '0'], root)).toThrow(
       CliUsageError,
     );
+  });
+
+  it('requires a non-empty explicit output path and reports usage exit 2', () => {
+    const { root, subject } = makeSubject();
+    cleanup.push(root);
+
+    expect(() => parseArgs([subject], root)).toThrow(/--output/);
+    expect(() => parseArgs([subject, '--output='], root)).toThrow(/--output/);
+    const result = runCli([subject]);
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('--output <path>');
+    expect(result.stderr).toMatch(/required/i);
   });
 
   it.each(['2.5', '3junk', '1e1', ''])(
@@ -1089,9 +1245,9 @@ describe('large repository benchmark CLI', () => {
       warningMessagesTruncated: false,
     });
     expect(result.report.stages.scan.durationMs).toBeGreaterThanOrEqual(0);
-    expect(result.report.stages.scan).toHaveProperty('peakRssBytes');
-    expect(result.report.stages.scan).toHaveProperty('userCpuTimeMicros');
-    expect(result.report.stages.scan).toHaveProperty('systemCpuTimeMicros');
+    expect(result.report.stages.scan.peakRssBytes).toBeGreaterThan(0);
+    expect(result.report.stages.scan.userCpuTimeMicros).toBeGreaterThanOrEqual(0);
+    expect(result.report.stages.scan.systemCpuTimeMicros).toBeGreaterThanOrEqual(0);
     expect(existsSync(outputPath)).toBe(true);
     expect(existsSync(markdownPath)).toBe(true);
     const serialized = readFileSync(outputPath, 'utf-8');
@@ -1101,6 +1257,183 @@ describe('large repository benchmark CLI', () => {
     expect(persisted.error).not.toContain(benchmark.REPO_ROOT);
     expect(readFileSync(markdownPath, 'utf-8')).not.toContain(subject);
   });
+
+  it.each([
+    ['scan', 'missing'],
+    ['imports', 'malformed'],
+    ['batching', 'wrong-shape'],
+  ])(
+    'marks an exit-zero %s stage failed for a %s artifact and emits schema-valid partial telemetry',
+    async (targetStage, corruption) => {
+      const { root, subject } = makeSubject();
+      cleanup.push(root);
+      const outputPath = join(root, 'reports', `${targetStage}.json`);
+      const markdownPath = join(root, 'reports', `${targetStage}.md`);
+
+      const result = await benchmark.runBenchmark(
+        {
+          repoRoot: subject,
+          outputPath,
+          markdownPath,
+          label: `corrupt-${targetStage}`,
+          concurrency: 1,
+          keepArtifacts: false,
+        },
+        {
+          async runStage(name, scriptPath, args, redactionRoots) {
+            const stage = await benchmark.runNodeStage(
+              name,
+              scriptPath,
+              args,
+              redactionRoots,
+            );
+            if (name === targetStage && stage.status === 'ok') {
+              const artifactPath =
+                name === 'batching'
+                  ? args.find((arg) => arg.startsWith('--output=')).slice(
+                      '--output='.length,
+                    )
+                  : args[1];
+              if (corruption === 'missing') {
+                rmSync(artifactPath, { force: true });
+              } else if (corruption === 'malformed') {
+                writeFileSync(artifactPath, '{ definitely not JSON', 'utf-8');
+              } else {
+                writeFileSync(artifactPath, '{}\n', 'utf-8');
+              }
+            }
+            return stage;
+          },
+        },
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.report.status).toBe('failed');
+      expect(result.report.stages[targetStage].status).toBe('failed');
+      expect(result.report.error).toBeTruthy();
+      expectValidReport(result.report);
+      expectValidReport(JSON.parse(readFileSync(outputPath, 'utf-8')));
+      expect(existsSync(markdownPath)).toBe(true);
+    },
+    70_000,
+  );
+
+  it.each([
+    [
+      'string file.sizeLines',
+      (scan, subject) => {
+        scan.files[0].sizeLines = subject;
+      },
+    ],
+    [
+      'negative file.sizeLines',
+      (scan) => {
+        scan.files[0].sizeLines = -1;
+      },
+    ],
+    [
+      'string filteredByIgnore',
+      (scan, subject) => {
+        scan.filteredByIgnore = subject;
+      },
+    ],
+    [
+      'negative filteredByIgnore',
+      (scan) => {
+        scan.filteredByIgnore = -1;
+      },
+    ],
+    [
+      'non-record stats',
+      (scan) => {
+        scan.stats = null;
+      },
+    ],
+    [
+      'non-record stats.byCategory',
+      (scan) => {
+        scan.stats.byCategory = [];
+      },
+    ],
+    [
+      'non-count stats.byCategory value',
+      (scan, subject) => {
+        scan.stats.byCategory = { code: subject };
+      },
+    ],
+    [
+      'non-record stats.byLanguage',
+      (scan) => {
+        scan.stats.byLanguage = [];
+      },
+    ],
+    [
+      'negative stats.byLanguage value',
+      (scan) => {
+        scan.stats.byLanguage = { TypeScript: -1 };
+      },
+    ],
+    [
+      'stats.filesScanned inconsistent with totalFiles',
+      (scan) => {
+        scan.stats.filesScanned = scan.totalFiles + 1;
+      },
+    ],
+  ])(
+    'rejects an exit-zero scan artifact with %s before copying nested values into the report',
+    async (_description, corruptScan) => {
+      const { root, subject } = makeSubject();
+      cleanup.push(root);
+      const outputPath = join(root, 'reports', 'nested-scan.json');
+      const markdownPath = join(root, 'reports', 'nested-scan.md');
+      const stagesStarted = [];
+
+      const result = await benchmark.runBenchmark(
+        {
+          repoRoot: subject,
+          outputPath,
+          markdownPath,
+          label: 'nested-corrupt-scan',
+          concurrency: 1,
+          keepArtifacts: false,
+        },
+        {
+          async runStage(name, scriptPath, args, redactionRoots) {
+            stagesStarted.push(name);
+            if (name !== 'scan') {
+              throw new Error('nested scan corruption reached a later stage');
+            }
+            const stage = await benchmark.runNodeStage(
+              name,
+              scriptPath,
+              args,
+              redactionRoots,
+            );
+            expect(stage.status).toBe('ok');
+            const artifactPath = args[1];
+            const scan = JSON.parse(readFileSync(artifactPath, 'utf-8'));
+            corruptScan(scan, subject);
+            writeFileSync(artifactPath, `${JSON.stringify(scan, null, 2)}\n`, 'utf-8');
+            return stage;
+          },
+        },
+      );
+
+      expect(stagesStarted).toEqual(['scan']);
+      expect(result.exitCode).toBe(1);
+      expect(result.report.status).toBe('failed');
+      expect(result.report.scale).toBeNull();
+      expect(result.report.stages.scan.status).toBe('failed');
+      expect(result.report.stages.scan).not.toHaveProperty('files');
+      expectValidReport(result.report);
+      const serialized = readFileSync(outputPath, 'utf-8');
+      const persisted = JSON.parse(serialized);
+      expectValidReport(persisted);
+      expect(serialized).not.toContain(subject);
+      expect(readFileSync(markdownPath, 'utf-8')).not.toContain(subject);
+    },
+    70_000,
+  );
 
   it('wraps cleanup operation failures without exposing artifact paths', () => {
     const artifactRoot = join(tmpdir(), 'ua-large-bench-private-cleanup');
@@ -1126,6 +1459,91 @@ describe('large repository benchmark CLI', () => {
     expect(cleanupError.message).not.toContain(artifactRoot);
     expect(cleanupError.message).not.toContain('EPERM');
   });
+
+  it('preserves a primary stage failure, records cleanup as secondary, and still delivers both reports', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua stage cleanup failure-'));
+    cleanup.push(root);
+    const subject = join(root, 'not-a-directory.txt');
+    const outputPath = join(root, 'reports', 'failed.json');
+    const markdownPath = join(root, 'reports', 'failed.md');
+    writeFileSync(subject, 'not a directory\n');
+    let artifactRoot;
+
+    const result = await benchmark.runBenchmark(
+      {
+        repoRoot: subject,
+        outputPath,
+        markdownPath,
+        label: 'stage-and-cleanup-failure',
+        concurrency: 1,
+        keepArtifacts: false,
+      },
+      {
+        cleanupArtifacts(path) {
+          artifactRoot = path;
+          throw new benchmark.BenchmarkArtifactCleanupError();
+        },
+      },
+    );
+    if (artifactRoot) cleanup.push(artifactRoot);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.report.status).toBe('failed');
+    expect(result.report.error).not.toBe(
+      'Unable to remove temporary benchmark artifacts',
+    );
+    expect(result.report.secondaryErrors).toEqual([
+      {
+        stage: 'cleanup',
+        message: 'Unable to remove temporary benchmark artifacts',
+      },
+    ]);
+    expect(result.artifactRoot).toBeNull();
+    expectValidReport(result.report);
+    expect(JSON.parse(readFileSync(outputPath, 'utf-8')).error).toBe(
+      result.report.error,
+    );
+    const markdown = readFileSync(markdownPath, 'utf-8');
+    expect(markdown).toContain(result.report.error.split(/\r?\n/, 1)[0]);
+    expect(markdown).toContain('Unable to remove temporary benchmark artifacts');
+    expect(JSON.stringify(result.report)).not.toContain(artifactRoot);
+  });
+
+  it('turns an otherwise successful run into exit 1 when artifact cleanup fails', async () => {
+    const { root, subject } = makeSubject();
+    cleanup.push(root);
+    const outputPath = join(root, 'reports', 'cleanup-failed.json');
+    const markdownPath = join(root, 'reports', 'cleanup-failed.md');
+    let artifactRoot;
+
+    const result = await benchmark.runBenchmark(
+      {
+        repoRoot: subject,
+        outputPath,
+        markdownPath,
+        label: 'cleanup-failure',
+        concurrency: 1,
+        keepArtifacts: false,
+      },
+      {
+        cleanupArtifacts(path) {
+          artifactRoot = path;
+          throw new benchmark.BenchmarkArtifactCleanupError();
+        },
+      },
+    );
+    if (artifactRoot) cleanup.push(artifactRoot);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.report.status).toBe('failed');
+    expect(result.report.error).toBe(
+      'Unable to remove temporary benchmark artifacts',
+    );
+    expect(result.report.secondaryErrors).toHaveLength(1);
+    expectValidReport(result.report);
+    expect(existsSync(outputPath)).toBe(true);
+    expect(existsSync(markdownPath)).toBe(true);
+  }, 70_000);
 
   it('rolls back both reports when the second report commit fails', () => {
     const root = mkdtempSync(join(tmpdir(), 'ua report transaction-'));
@@ -1177,6 +1595,146 @@ describe('large repository benchmark CLI', () => {
     expect(readFileSync(markdownPath, 'utf-8')).toBe('old markdown\n');
     expect(readFileSync(sentinelPath, 'utf-8')).toBe('unrelated\n');
     expect(readdirSync(reportsDirectory).sort()).toEqual(entriesBefore);
+  });
+
+  it('excludes a concurrent writer while the shared pair lock is held', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua report pair lock-'));
+    cleanup.push(root);
+    const outputPath = join(root, 'result.json');
+    const markdownPath = join(root, 'result.md');
+    expect(benchmark.reportPairLockPath).toBeTypeOf('function');
+    const lockPath = benchmark.reportPairLockPath(outputPath, markdownPath);
+    writeFileSync(lockPath, 'held by another writer\n', { flag: 'wx' });
+    let deliveryError;
+
+    try {
+      benchmark.deliverBenchmarkReports({
+        outputPath,
+        markdownPath,
+        jsonContents: 'new json\n',
+        markdownContents: 'new markdown\n',
+      });
+    } catch (error) {
+      deliveryError = error;
+    }
+
+    expect(deliveryError).toBeInstanceOf(benchmark.BenchmarkReportWriteError);
+    expect(deliveryError.recovery).toMatchObject({
+      lockAcquisitionFailed: true,
+    });
+    expect(existsSync(outputPath)).toBe(false);
+    expect(existsSync(markdownPath)).toBe(false);
+    expect(JSON.stringify(deliveryError.recovery)).not.toContain(root);
+  });
+
+  it.runIf(process.platform === 'win32')(
+    'uses one pair lock for Windows path-case aliases',
+    () => {
+      const root = mkdtempSync(join(tmpdir(), 'ua report case lock-'));
+      cleanup.push(root);
+      const outputPath = join(root, 'result.json');
+      const markdownPath = join(root, 'result.md');
+      const caseAliasRoot = root.toUpperCase();
+
+      expect(
+        basename(
+          benchmark.reportPairLockPath(
+            join(caseAliasRoot, 'RESULT.JSON'),
+            join(caseAliasRoot, 'RESULT.MD'),
+          ),
+        ),
+      ).toBe(
+        basename(benchmark.reportPairLockPath(outputPath, markdownPath)),
+      );
+    },
+  );
+
+  it('surfaces a rollback restore failure as bounded path-free recovery metadata', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua report rollback recovery-'));
+    cleanup.push(root);
+    const outputPath = join(root, 'result.json');
+    const markdownPath = join(root, 'result.md');
+    writeFileSync(outputPath, 'old json\n');
+    writeFileSync(markdownPath, 'old markdown\n');
+    let deliveryError;
+
+    try {
+      benchmark.deliverBenchmarkReports(
+        {
+          outputPath,
+          markdownPath,
+          jsonContents: 'new json\n',
+          markdownContents: 'new markdown\n',
+        },
+        {
+          renameSync(source, destination) {
+            if (destination === markdownPath && source.endsWith('.tmp')) {
+              throw new Error('injected second install failure');
+            }
+            if (destination === markdownPath && source.endsWith('.backup')) {
+              throw new Error('injected restore failure');
+            }
+            renameSync(source, destination);
+          },
+        },
+      );
+    } catch (error) {
+      deliveryError = error;
+    }
+
+    expect(deliveryError).toBeInstanceOf(benchmark.BenchmarkReportWriteError);
+    expect(deliveryError.recovery).toMatchObject({
+      restoreFailures: 1,
+    });
+    expect(JSON.stringify(deliveryError.recovery)).not.toContain(root);
+    expect(JSON.stringify(deliveryError.recovery)).not.toContain('injected');
+  });
+
+  it('surfaces a rollback target-removal failure as path-free recovery metadata', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua report rollback removal-'));
+    cleanup.push(root);
+    const outputPath = join(root, 'result.json');
+    const markdownPath = join(root, 'result.md');
+    writeFileSync(outputPath, 'old json\n');
+    writeFileSync(markdownPath, 'old markdown\n');
+    let removalFailed = false;
+    let deliveryError;
+
+    try {
+      benchmark.deliverBenchmarkReports(
+        {
+          outputPath,
+          markdownPath,
+          jsonContents: 'new json\n',
+          markdownContents: 'new markdown\n',
+        },
+        {
+          renameSync(source, destination) {
+            if (destination === markdownPath && source.endsWith('.tmp')) {
+              throw new Error('injected second install failure');
+            }
+            renameSync(source, destination);
+          },
+          rmSync(path, options) {
+            if (path === markdownPath && !removalFailed) {
+              removalFailed = true;
+              throw new Error('injected rollback removal failure');
+            }
+            rmSync(path, options);
+          },
+        },
+      );
+    } catch (error) {
+      deliveryError = error;
+    }
+
+    expect(removalFailed).toBe(true);
+    expect(deliveryError).toBeInstanceOf(benchmark.BenchmarkReportWriteError);
+    expect(deliveryError.recovery).toMatchObject({
+      rollbackRemoveFailures: 1,
+    });
+    expect(JSON.stringify(deliveryError.recovery)).not.toContain(root);
+    expect(JSON.stringify(deliveryError.recovery)).not.toContain('injected');
   });
 
   it('removes an owned partial temp when a staging write fails', () => {
@@ -1365,6 +1923,9 @@ describe('large repository benchmark CLI', () => {
     expectValidReport(report);
     expect(report.schemaUrl).toBe(schema.$id);
     expect(report.schemaVersion).toBe('1.0.0');
+    expect(report.pairId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
     expect(report.status).toBe('ok');
     expect(report.mode).toBe('deterministic');
     expect(report.subject).toEqual({
@@ -1389,6 +1950,7 @@ describe('large repository benchmark CLI', () => {
     expect(report.determinism.outputDigest).toMatch(/^[a-f0-9]{64}$/);
     expect(JSON.stringify(report)).not.toContain(subject);
     expect(markdown).toContain('# Large Repository Benchmark Report');
+    expect(markdown).toContain(`| Pair ID | ${report.pairId} |`);
     expect(markdown).toContain('| Files | 3 |');
     expect(markdown).toContain('| LLM invoked | No |');
     expect(markdown).toContain('Peak / max worker RSS (bytes)');
@@ -1414,6 +1976,44 @@ describe('large repository benchmark CLI', () => {
     expect(secondReport.stages.batching.batchSizes).toEqual(
       report.stages.batching.batchSizes,
     );
+  }, 70_000);
+
+  it('keeps full Unicode benchmark digests stable across locale environments', () => {
+    const { root, subject } = makeSubject();
+    cleanup.push(root);
+    const firstReportPath = join(root, 'locale-c.json');
+    const secondReportPath = join(root, 'locale-sv.json');
+    for (const name of ['Z', 'a', 'ä']) {
+      writeFileSync(join(subject, 'src', `${name}.ts`), `export const ${
+        name === 'ä' ? 'accented' : name
+      } = 1;\n`);
+    }
+    writeFileSync(
+      join(subject, 'src', 'index.ts'),
+      [
+        'import "./ä";',
+        'import "./Z";',
+        'import "./a";',
+        'export const answer = 42;',
+        '',
+      ].join('\n'),
+    );
+
+    const runWithLocale = (locale, reportPath) =>
+      runCli([subject, '--output', reportPath, '--concurrency', '2'], {
+        env: { ...process.env, LANG: locale, LC_ALL: locale },
+      });
+    const firstResult = runWithLocale('C', firstReportPath);
+    const secondResult = runWithLocale('sv_SE.UTF-8', secondReportPath);
+
+    expect(firstResult.status, firstResult.stderr).toBe(0);
+    expect(secondResult.status, secondResult.stderr).toBe(0);
+    const firstReport = JSON.parse(readFileSync(firstReportPath, 'utf-8'));
+    const secondReport = JSON.parse(readFileSync(secondReportPath, 'utf-8'));
+    expectValidReport(firstReport);
+    expectValidReport(secondReport);
+    expect(secondReport.determinism).toEqual(firstReport.determinism);
+    expect(secondReport.stages.imports.edges).toBe(3);
   }, 70_000);
 
   it('handles an empty repository as a valid deterministic run', () => {

--- a/tests/benchmark/test_large_repo_benchmark.test.mjs
+++ b/tests/benchmark/test_large_repo_benchmark.test.mjs
@@ -1,0 +1,1522 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as benchmark from '../../scripts/lib/large-repo-benchmark.mjs';
+
+const { CliUsageError, parseArgs } = benchmark;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(__dirname, '../../scripts/benchmark-large-repo.mjs');
+const REPORT_SCHEMA = resolve(
+  __dirname,
+  '../../docs/benchmarks/large-repo-report-1.0.0.schema.json',
+);
+const reportSchema = JSON.parse(readFileSync(REPORT_SCHEMA, 'utf-8'));
+const validateReport = new Ajv2020({
+  allErrors: true,
+  formats: { 'date-time': true },
+}).compile(reportSchema);
+
+function expectValidReport(report) {
+  expect(
+    validateReport(report),
+    JSON.stringify(validateReport.errors, null, 2),
+  ).toBe(true);
+}
+
+function makeSubject() {
+  const root = mkdtempSync(join(tmpdir(), 'ua benchmark subject-'));
+  const subject = join(root, '项目 with spaces');
+  mkdirSync(join(subject, 'src'), { recursive: true });
+  writeFileSync(
+    join(subject, 'src', 'math.ts'),
+    'export function add(a: number, b: number) { return a + b; }\n',
+  );
+  writeFileSync(
+    join(subject, 'src', 'index.ts'),
+    'import { add } from "./math";\nexport const answer = add(20, 22);\n',
+  );
+  writeFileSync(
+    join(subject, 'README.md'),
+    '# Mini repository\n\nA deterministic benchmark fixture.\n',
+  );
+  return { root, subject };
+}
+
+function snapshotTree(root) {
+  const entries = [];
+
+  function visit(directory, relativeDirectory = '') {
+    for (const entry of readdirSync(directory, { withFileTypes: true }).sort(
+      (left, right) => left.name.localeCompare(right.name),
+    )) {
+      const relativePath = join(relativeDirectory, entry.name).replaceAll('\\', '/');
+      const absolutePath = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        entries.push([relativePath, 'directory']);
+        visit(absolutePath, relativePath);
+      } else {
+        entries.push([
+          relativePath,
+          'file',
+          readFileSync(absolutePath).toString('base64'),
+        ]);
+      }
+    }
+  }
+
+  visit(root);
+  return entries;
+}
+
+function runCli(args, options = {}) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    encoding: 'utf-8',
+    timeout: 60_000,
+    ...options,
+  });
+}
+
+function benchmarkArtifactEntries() {
+  return readdirSync(tmpdir(), { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isDirectory() && entry.name.startsWith('ua-large-bench-'),
+    )
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function expectSafeReportWriteFailure(result, sensitivePaths) {
+  expect(result.status).toBe(1);
+  expect(result.stdout).toBe('');
+  expect(result.stderr).toMatch(
+    /^(?:\[benchmark\] [^\r\n]+\r?\n)*Error: Unable to write benchmark report files\r?\n$/,
+  );
+  expect(result.stderr).not.toMatch(
+    /UnhandledPromiseRejection|node:fs:|(?:^|\r?\n)\s*at\s|\bError: EISDIR\b/,
+  );
+  for (const sensitivePath of sensitivePaths) {
+    for (const alias of new Set([
+      sensitivePath,
+      sensitivePath.replaceAll('\\', '/'),
+      sensitivePath.replaceAll('/', '\\'),
+    ])) {
+      expect(result.stderr).not.toContain(alias);
+    }
+  }
+  expect(result.stderr).not.toContain('ua-large-bench-');
+}
+
+function runGit(directory, args) {
+  const result = spawnSync('git', ['-C', directory, ...args], {
+    encoding: 'utf-8',
+    windowsHide: true,
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `git ${args.join(' ')} failed`);
+  }
+  return result.stdout.trim();
+}
+
+function makeGitSubject() {
+  const root = mkdtempSync(join(tmpdir(), 'ua benchmark git-'));
+  const subject = join(root, 'subject repo');
+  mkdirSync(subject);
+  runGit(subject, ['init', '--quiet']);
+  writeFileSync(join(subject, 'tracked.txt'), 'clean\n');
+  runGit(subject, ['add', 'tracked.txt']);
+  runGit(subject, [
+    '-c',
+    'user.name=Benchmark Test',
+    '-c',
+    'user.email=benchmark@example.invalid',
+    'commit',
+    '--quiet',
+    '-m',
+    'initial',
+  ]);
+  return { root, subject };
+}
+
+describe('bounded benchmark stage output', () => {
+  const cleanup = [];
+
+  afterEach(() => {
+    for (const path of cleanup.splice(0)) {
+      rmSync(path, { recursive: true, force: true });
+    }
+  });
+
+  it('bounds retained streams while parsing late metrics and all warnings', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua benchmark noisy-stage-'));
+    cleanup.push(root);
+    const subject = join(root, 'private subject');
+    const artifacts = join(root, 'private artifacts');
+    mkdirSync(subject);
+    mkdirSync(artifacts);
+    const helperPath = join(root, 'noisy-helper.mjs');
+    writeFileSync(
+      helperPath,
+      `
+const [subject, tool, artifacts, cap] = process.argv.slice(2);
+process.stdout.write(\`stdout roots: \${subject}/out.txt \${tool}/worker.mjs \${artifacts}/out.json\\n\`);
+process.stdout.write('s'.repeat(Number(cap) * 2));
+process.stderr.write(\`stderr roots: \${subject}/error.txt \${tool}/worker.mjs \${artifacts}/error.json\\n\`);
+process.stderr.write('n'.repeat(Number(cap) * 2));
+process.stderr.write('\\n');
+for (let index = 0; index < 12; index += 1) {
+  const root = [subject, tool, artifacts][index % 3];
+  const warning = Buffer.from(\`Warning: \${String(index).padStart(2, '0')} \\u{1F9EA} \${root}/warning.txt\\n\`);
+  if (index === 0) {
+    for (const byte of warning) process.stderr.write(Buffer.from([byte]));
+  } else {
+    process.stderr.write(warning);
+  }
+}
+throw new Error(\`helper failed below \${subject}/failed.txt\`);
+`,
+    );
+    const redactionRoots = [
+      [subject, '<subject>'],
+      [benchmark.REPO_ROOT, '<tool>'],
+      [artifacts, '<artifacts>'],
+    ];
+
+    const stage = await benchmark.runNodeStage(
+      'noisy',
+      helperPath,
+      [
+        subject,
+        benchmark.REPO_ROOT,
+        artifacts,
+        String(benchmark.STAGE_OUTPUT_MAX_BYTES),
+      ],
+      redactionRoots,
+    );
+
+    expect(benchmark.STAGE_OUTPUT_MAX_BYTES).toBe(128 * 1024);
+    expect(benchmark.WARNING_SAMPLE_LIMIT).toBe(5);
+    expect(stage.status).toBe('failed');
+    expect(stage.stdoutTruncated).toBe(true);
+    expect(stage.stderrTruncated).toBe(true);
+    expect(Buffer.byteLength(stage.stdout)).toBeLessThanOrEqual(
+      benchmark.STAGE_OUTPUT_MAX_BYTES,
+    );
+    expect(Buffer.byteLength(stage.stderr)).toBeLessThanOrEqual(
+      benchmark.STAGE_OUTPUT_MAX_BYTES,
+    );
+    expect(stage.warningCount).toBe(12);
+    expect(stage.warningMessages).toHaveLength(benchmark.WARNING_SAMPLE_LIMIT);
+    expect(stage.warningMessagesTruncated).toBe(true);
+    expect(stage.warningMessages.map((message) => message.slice(0, 11))).toEqual([
+      'Warning: 00',
+      'Warning: 01',
+      'Warning: 02',
+      'Warning: 03',
+      'Warning: 04',
+    ]);
+    expect(
+      stage.warningMessages.every(
+        (message) =>
+          Buffer.byteLength(message) <= benchmark.STAGE_OUTPUT_MAX_BYTES,
+      ),
+    ).toBe(true);
+    expect(stage.peakRssBytes).toBeGreaterThan(0);
+    expect(stage.userCpuTimeMicros).toBeGreaterThanOrEqual(0);
+    expect(stage.systemCpuTimeMicros).toBeGreaterThanOrEqual(0);
+    const retained = [stage.stdout, stage.stderr, ...stage.warningMessages].join(
+      '\n',
+    );
+    expect(retained).toContain('<subject>');
+    expect(retained).toContain('<tool>');
+    expect(retained).toContain('<artifacts>');
+    expect(retained).not.toContain('__UA_BENCHMARK_METRICS__');
+    expect(retained).not.toContain(subject);
+    expect(retained).not.toContain(benchmark.REPO_ROOT);
+    expect(retained).not.toContain(artifacts);
+  });
+
+  it('parses a final metrics marker without a newline', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua benchmark eof-metrics-'));
+    cleanup.push(root);
+    const helperPath = join(root, 'eof-metrics-helper.mjs');
+    const metrics = {
+      peakRssBytes: 123456,
+      userCpuTimeMicros: 234,
+      systemCpuTimeMicros: 345,
+    };
+    writeFileSync(
+      helperPath,
+      `
+import { writeSync } from 'node:fs';
+writeSync(2, ${JSON.stringify(
+        `${benchmark.STAGE_METRICS_PREFIX}${JSON.stringify(metrics)}`,
+      )});
+process.exit(0);
+`,
+    );
+
+    const stage = await benchmark.runNodeStage('eof-metrics', helperPath, []);
+
+    expect(stage.status).toBe('ok');
+    expect(stage.peakRssBytes).toBe(metrics.peakRssBytes);
+    expect(stage.userCpuTimeMicros).toBe(metrics.userCpuTimeMicros);
+    expect(stage.systemCpuTimeMicros).toBe(metrics.systemCpuTimeMicros);
+    expect(stage.stderr).toBe('');
+    expect(stage.warningCount).toBe(0);
+  });
+
+  it('counts and samples a final warning without a newline', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua benchmark eof-warning-'));
+    cleanup.push(root);
+    const subject = join(root, 'private subject');
+    mkdirSync(subject);
+    const helperPath = join(root, 'eof-warning-helper.mjs');
+    writeFileSync(
+      helperPath,
+      `
+import { writeSync } from 'node:fs';
+writeSync(2, \`Warning: final \${process.argv[2]}/file.ts\`);
+process.exit(0);
+`,
+    );
+
+    const stage = await benchmark.runNodeStage(
+      'eof-warning',
+      helperPath,
+      [subject],
+      [[subject, '<subject>']],
+    );
+
+    expect(stage.status).toBe('ok');
+    expect(stage.warningCount).toBe(1);
+    expect(stage.warningMessages).toEqual([
+      'Warning: final <subject>/file.ts',
+    ]);
+    expect(stage.warningMessagesTruncated).toBe(false);
+    expect(stage.stderr).toBe('Warning: final <subject>/file.ts');
+    expect(stage.stderr.endsWith('\n')).toBe(false);
+    expect(stage.peakRssBytes).toBeNull();
+  });
+});
+
+describe('benchmark warning aggregation', () => {
+  it('samples structure warnings in deterministic batch input order', () => {
+    const warnings = benchmark.aggregateStageWarnings([
+      {
+        warningCount: 3,
+        warningMessages: [
+          'Warning: batch-0 first',
+          'Warning: batch-0 second',
+          'Warning: batch-0 third',
+        ],
+        warningMessagesTruncated: false,
+      },
+      {
+        warningCount: 4,
+        warningMessages: [
+          'Warning: batch-1 first',
+          'Warning: batch-1 second',
+          'Warning: batch-1 third',
+          'Warning: batch-1 fourth',
+        ],
+        warningMessagesTruncated: false,
+      },
+    ]);
+
+    expect(warnings).toEqual({
+      warningCount: 7,
+      warningMessages: [
+        'Warning: batch-0 first',
+        'Warning: batch-0 second',
+        'Warning: batch-0 third',
+        'Warning: batch-1 first',
+        'Warning: batch-1 second',
+      ],
+      warningMessagesTruncated: true,
+    });
+    expect(
+      benchmark.warningSummary([{ name: 'structure', ...warnings }]),
+    ).toEqual([
+      {
+        stage: 'structure',
+        count: 7,
+        messages: warnings.warningMessages,
+        truncated: true,
+      },
+    ]);
+  });
+});
+
+describe('canonical benchmark digests', () => {
+  it('sorts object keys while preserving array order', () => {
+    expect(benchmark.canonicalSha256).toBeTypeOf('function');
+    const value = { z: 1, nested: { b: null, a: true }, a: [3, 2, 1] };
+    const canonicalJson = '{"a":[3,2,1],"nested":{"a":true,"b":null},"z":1}';
+    const expected = createHash('sha256').update(canonicalJson).digest('hex');
+
+    expect(benchmark.canonicalSha256(value)).toBe(expected);
+    expect(
+      benchmark.canonicalSha256({ a: [3, 2, 1], nested: { a: true, b: null }, z: 1 }),
+    ).toBe(expected);
+    expect(benchmark.canonicalSha256({ ...value, a: [1, 2, 3] })).not.toBe(
+      expected,
+    );
+  });
+
+  it('combines structure digests in deterministic batch input order', () => {
+    expect(benchmark.buildOutputDigest).toBeTypeOf('function');
+    const batches = {
+      batches: [{ batchIndex: 1 }, { batchIndex: 2 }],
+    };
+    const first = { batchIndex: 1, digest: 'a'.repeat(64) };
+    const second = { batchIndex: 2, digest: 'b'.repeat(64) };
+
+    const ordered = benchmark.buildOutputDigest({}, batches, [first, second]);
+    expect(benchmark.buildOutputDigest({}, batches, [second, first])).toBe(
+      ordered,
+    );
+    expect(
+      benchmark.buildOutputDigest({}, batches, [
+        first,
+        { ...second, digest: 'c'.repeat(64) },
+      ]),
+    ).not.toBe(ordered);
+  });
+});
+
+describe('structure output summaries', () => {
+  const batch = {
+    batchIndex: 7,
+    files: [
+      { path: 'src/a.ts' },
+      { path: 'src/b.ts' },
+      { path: 'src/c.ts' },
+    ],
+  };
+
+  it('accepts the exact union of analyzed and skipped paths', () => {
+    expect(benchmark.summarizeStructureOutput).toBeTypeOf('function');
+    const output = {
+      scriptCompleted: true,
+      filesAnalyzed: 2,
+      filesSkipped: ['src/b.ts'],
+      results: [
+        { path: 'src/a.ts', functions: [{ name: 'a' }], exports: ['a'] },
+        { path: 'src/c.ts', classes: [{ name: 'C' }] },
+      ],
+    };
+
+    expect(benchmark.summarizeStructureOutput(batch, output)).toEqual({
+      batchIndex: 7,
+      digest: benchmark.canonicalSha256(output),
+      complete: true,
+      malformed: false,
+      expectedFiles: 3,
+      accountedExpectedPaths: 3,
+      filesAnalyzed: 2,
+      filesSkipped: 1,
+      missingStructurePaths: 0,
+      duplicateStructurePaths: 0,
+      unexpectedStructurePaths: 0,
+      entities: {
+        functions: 1,
+        classes: 1,
+        exports: 1,
+        callGraph: 0,
+        definitions: 0,
+        services: 0,
+        endpoints: 0,
+        steps: 0,
+        resources: 0,
+      },
+    });
+  });
+
+  it('reports missing, duplicate, and unexpected paths', () => {
+    expect(benchmark.summarizeStructureOutput).toBeTypeOf('function');
+    const summary = benchmark.summarizeStructureOutput(batch, {
+      scriptCompleted: true,
+      filesAnalyzed: 3,
+      filesSkipped: ['src/b.ts'],
+      results: [
+        { path: 'src/a.ts' },
+        { path: 'src/a.ts' },
+        { path: 'src/unexpected.ts' },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      complete: false,
+      malformed: false,
+      accountedExpectedPaths: 2,
+      missingStructurePaths: 1,
+      duplicateStructurePaths: 1,
+      unexpectedStructurePaths: 1,
+    });
+  });
+
+  it('treats an object without the required output shape as malformed', () => {
+    expect(benchmark.summarizeStructureOutput).toBeTypeOf('function');
+    expect(benchmark.summarizeStructureOutput(batch, {})).toMatchObject({
+      complete: false,
+      malformed: true,
+      accountedExpectedPaths: 0,
+      missingStructurePaths: 3,
+    });
+  });
+
+  it('aggregates file and entity counts from compact summaries', () => {
+    expect(benchmark.aggregateStructureSummaries).toBeTypeOf('function');
+    const first = benchmark.summarizeStructureOutput(batch, {
+      scriptCompleted: true,
+      filesAnalyzed: 2,
+      filesSkipped: ['src/b.ts'],
+      results: [
+        { path: 'src/a.ts', functions: [{ name: 'a' }] },
+        { path: 'src/c.ts', classes: [{ name: 'C' }] },
+      ],
+    });
+    const secondBatch = {
+      batchIndex: 8,
+      files: [{ path: 'src/d.ts' }],
+    };
+    const second = benchmark.summarizeStructureOutput(secondBatch, {
+      scriptCompleted: true,
+      filesAnalyzed: 1,
+      filesSkipped: [],
+      results: [{ path: 'src/d.ts', functions: [{}, {}], exports: [{}] }],
+    });
+
+    expect(benchmark.aggregateStructureSummaries([first, second])).toEqual({
+      filesAnalyzed: 3,
+      filesSkipped: 1,
+      entities: {
+        functions: 3,
+        classes: 1,
+        exports: 1,
+        callGraph: 0,
+        definitions: 0,
+        services: 0,
+        endpoints: 0,
+        steps: 0,
+        resources: 0,
+      },
+    });
+    expect(first).not.toHaveProperty('results');
+    expect(second).not.toHaveProperty('results');
+  });
+});
+
+describe('structure resource aggregation', () => {
+  it('sums worker CPU while retaining only the maximum worker RSS', () => {
+    expect(benchmark.aggregateStructureResources).toBeTypeOf('function');
+    expect(
+      benchmark.aggregateStructureResources([
+        {
+          peakRssBytes: 100,
+          userCpuTimeMicros: 20,
+          systemCpuTimeMicros: 4,
+        },
+        {
+          peakRssBytes: 250,
+          userCpuTimeMicros: 30,
+          systemCpuTimeMicros: 6,
+        },
+      ]),
+    ).toEqual({
+      maxWorkerPeakRssBytes: 250,
+      userCpuTimeMicros: 50,
+      systemCpuTimeMicros: 10,
+    });
+    expect(benchmark.aggregateStructureResources([])).toEqual({
+      maxWorkerPeakRssBytes: null,
+      userCpuTimeMicros: null,
+      systemCpuTimeMicros: null,
+    });
+  });
+
+  it('renders the structure worker maximum and summed CPU values', () => {
+    expect(benchmark.renderMarkdownReport).toBeTypeOf('function');
+    const markdown = benchmark.renderMarkdownReport({
+      schemaVersion: '1.0.0',
+      status: 'ok',
+      subject: { label: 'fixture', commit: null },
+      tool: { commit: null, packageVersion: '0.0.0' },
+      run: { startedAt: '2026-01-01T00:00:00.000Z', durationMs: 12 },
+      configuration: { concurrency: 2 },
+      llm: { invoked: false },
+      scale: {},
+      stages: {
+        structure: {
+          status: 'ok',
+          durationMs: 12,
+          maxWorkerPeakRssBytes: 250,
+          userCpuTimeMicros: 50,
+          systemCpuTimeMicros: 10,
+          outputBytes: 99,
+        },
+      },
+      integrity: {},
+      determinism: {},
+      environment: {
+        platform: 'test',
+        release: 'test',
+        arch: 'test',
+        nodeVersion: 'test',
+        cpuModel: 'test',
+        logicalCores: 1,
+        totalMemoryBytes: 1,
+      },
+      warnings: [],
+      error: null,
+    });
+
+    expect(markdown).toContain(
+      '| Stage | Status | Duration | Peak / max worker RSS (bytes) | User CPU (micros) | System CPU (micros) | Output (bytes) |',
+    );
+    expect(markdown).toContain('| structure | ok | 12 ms | 250 | 50 | 10 | 99 |');
+  });
+});
+
+describe('benchmark integrity aggregation', () => {
+  const scan = {
+    totalFiles: 3,
+    files: [
+      { path: 'src/a.ts' },
+      { path: 'src/b.ts' },
+      { path: 'src/c.ts' },
+    ],
+  };
+  const batch = {
+    batchIndex: 1,
+    files: scan.files,
+  };
+  const batches = { batches: [batch] };
+
+  it('keeps exact skipped-path accounting complete but degraded-capable', () => {
+    expect(benchmark.buildBenchmarkIntegrity).toBeTypeOf('function');
+    expect(benchmark.hasFailedIntegrity).toBeTypeOf('function');
+    const summary = benchmark.summarizeStructureOutput(batch, {
+      scriptCompleted: true,
+      filesAnalyzed: 2,
+      filesSkipped: ['src/b.ts'],
+      results: [{ path: 'src/a.ts' }, { path: 'src/c.ts' }],
+    });
+    const integrity = benchmark.buildBenchmarkIntegrity(
+      scan,
+      {},
+      batches,
+      [summary],
+      0,
+    );
+
+    expect(integrity).toMatchObject({
+      structureCoverage: 1,
+      filesSkipped: 1,
+      missingStructurePaths: 0,
+      duplicateStructurePaths: 0,
+      unexpectedStructurePaths: 0,
+      malformedStructureBatches: 0,
+    });
+    expect(benchmark.hasFailedIntegrity(integrity)).toBe(false);
+  });
+
+  it('fails incomplete and conflicting structure path accounting', () => {
+    expect(benchmark.buildBenchmarkIntegrity).toBeTypeOf('function');
+    expect(benchmark.hasFailedIntegrity).toBeTypeOf('function');
+    const summary = benchmark.summarizeStructureOutput(batch, {
+      scriptCompleted: true,
+      filesAnalyzed: 3,
+      filesSkipped: ['src/b.ts'],
+      results: [
+        { path: 'src/a.ts' },
+        { path: 'src/a.ts' },
+        { path: 'src/unexpected.ts' },
+      ],
+    });
+    const integrity = benchmark.buildBenchmarkIntegrity(
+      scan,
+      {},
+      batches,
+      [summary],
+      1,
+    );
+
+    expect(integrity).toMatchObject({
+      structureCoverage: 0.6667,
+      missingStructurePaths: 1,
+      duplicateStructurePaths: 1,
+      unexpectedStructurePaths: 1,
+      failedBatches: 1,
+    });
+    expect(benchmark.hasFailedIntegrity(integrity)).toBe(true);
+  });
+
+  it('rejects malformed output even when the expected path set is empty', () => {
+    const emptyScan = { totalFiles: 0, files: [] };
+    const emptyBatch = { batchIndex: 1, files: [] };
+    const summary = benchmark.summarizeStructureOutput(emptyBatch, {});
+    const integrity = benchmark.buildBenchmarkIntegrity(
+      emptyScan,
+      {},
+      { batches: [emptyBatch] },
+      [summary],
+      0,
+    );
+
+    expect(integrity).toMatchObject({
+      structureCoverage: 1,
+      missingStructurePaths: 0,
+      malformedStructureBatches: 1,
+    });
+    expect(benchmark.hasFailedIntegrity(integrity)).toBe(true);
+  });
+
+  it.each([
+    ['missing paths', { structureCoverage: 0.5, missingStructurePaths: 1 }],
+    ['duplicate paths', { duplicateStructurePaths: 1 }],
+    ['unexpected paths', { unexpectedStructurePaths: 1 }],
+    ['malformed output', { malformedStructureBatches: 1 }],
+    ['failed batches', { failedBatches: 1 }],
+  ])('rejects %s independently', (_label, overrides) => {
+    const completeIntegrity = {
+      allScannedFilesBatched: true,
+      missingImportTargets: 0,
+      structureCoverage: 1,
+      failedBatches: 0,
+      missingStructurePaths: 0,
+      duplicateStructurePaths: 0,
+      unexpectedStructurePaths: 0,
+      malformedStructureBatches: 0,
+    };
+
+    expect(
+      benchmark.hasFailedIntegrity({ ...completeIntegrity, ...overrides }),
+    ).toBe(true);
+  });
+});
+
+describe('path redaction', () => {
+  const cleanup = [];
+
+  afterEach(() => {
+    for (const path of cleanup.splice(0)) {
+      rmSync(path, { recursive: true, force: true });
+    }
+  });
+
+  it('redacts native, separator, file URL, and Windows aliases', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua benchmark redact-'));
+    cleanup.push(root);
+    const subject = join(root, 'subject root');
+    const tool = join(root, 'tool root');
+    const artifacts = join(root, 'artifact root');
+    mkdirSync(subject);
+    mkdirSync(tool);
+    mkdirSync(artifacts);
+
+    const slashSubject = subject.replaceAll('\\', '/');
+    const backslashSubject = subject.replaceAll('/', '\\');
+    const messages = [
+      `native ${join(subject, 'src', 'file.ts')}`,
+      `slash ${slashSubject}/src/file.ts`,
+      `backslash ${backslashSubject}\\src\\file.ts`,
+      `url ${pathToFileURL(subject).href}/src/file%20name.ts`,
+      `tool ${join(tool, 'worker.mjs')}`,
+      `artifacts ${join(artifacts, 'result.json')}`,
+    ];
+    if (process.platform === 'win32') {
+      messages.push(`extended \\\\?\\${backslashSubject}\\src\\file.ts`);
+      messages.push(`case ${subject.toUpperCase()}\\SRC\\FILE.TS`);
+    }
+
+    expect(benchmark.redactPaths).toBeTypeOf('function');
+    const redacted = benchmark.redactPaths(messages.join('\n'), [
+      [subject, '<subject>'],
+      [tool, '<tool>'],
+      [artifacts, '<artifacts>'],
+    ]);
+
+    expect(redacted).toContain('native <subject>');
+    expect(redacted).toContain('slash <subject>/src/file.ts');
+    expect(redacted).toContain('backslash <subject>\\src\\file.ts');
+    expect(redacted).toContain('url <subject>/src/file%20name.ts');
+    expect(redacted).toContain('tool <tool>');
+    expect(redacted).toContain('artifacts <artifacts>');
+    for (const privateRoot of [
+      subject,
+      slashSubject,
+      backslashSubject,
+      pathToFileURL(subject).href,
+      tool,
+      artifacts,
+    ]) {
+      expect(redacted).not.toContain(privateRoot);
+    }
+    if (process.platform === 'win32') {
+      expect(redacted).toContain('extended <subject>\\src\\file.ts');
+      expect(redacted).toContain('case <subject>\\SRC\\FILE.TS');
+    }
+  });
+
+  it('uses the longest realpath alias and preserves sibling prefixes', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua benchmark aliases-'));
+    cleanup.push(root);
+    const physicalSubject = join(root, 'physical subject');
+    const lexicalSubject = join(root, 'subject');
+    mkdirSync(physicalSubject);
+    symlinkSync(
+      physicalSubject,
+      lexicalSubject,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+    const realSubject = realpathSync.native(lexicalSubject);
+    const sibling = `${lexicalSubject}-copy`;
+
+    expect(benchmark.redactPaths).toBeTypeOf('function');
+    const redacted = benchmark.redactPaths(
+      [
+        join(lexicalSubject, 'lexical.txt'),
+        join(realSubject, 'physical.txt'),
+        join(sibling, 'public.txt'),
+      ].join('\n'),
+      [
+        [root, '<tool>'],
+        [lexicalSubject, '<subject>'],
+      ],
+    );
+
+    expect(redacted).toContain(join('<subject>', 'lexical.txt'));
+    expect(redacted).toContain(join('<subject>', 'physical.txt'));
+    expect(redacted).toContain(join('<tool>', 'subject-copy', 'public.txt'));
+    expect(redacted).not.toContain(join('<subject>-copy', 'public.txt'));
+    expect(redacted).not.toContain(join('<tool>', 'subject', 'lexical.txt'));
+  });
+
+  it.runIf(process.platform === 'win32')(
+    'redacts mixed-case extended UNC roots through ordinary aliases',
+    () => {
+      const extendedRoot = '\\\\?\\uNc\\localhost\\missing-share\\Repo Root';
+      const ordinaryRoot = '\\\\localhost\\missing-share\\Repo Root';
+      const redacted = benchmark.redactPaths(
+        [
+          `${extendedRoot}\\extended.txt`,
+          `${ordinaryRoot}\\ordinary.txt`,
+        ].join('\n'),
+        [[extendedRoot, '<subject>']],
+      );
+
+      expect(redacted).toBe(
+        ['<subject>\\extended.txt', '<subject>\\ordinary.txt'].join('\n'),
+      );
+    },
+  );
+
+  it('does not treat a terminal dot as a path boundary', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua benchmark dot-'));
+    cleanup.push(root);
+    const subject = join(root, 'repo');
+    mkdirSync(subject);
+    const sibling = `${subject.replaceAll('\\', '/')}.`;
+
+    expect(benchmark.redactPaths(sibling, [[subject, '<subject>']])).toBe(
+      sibling,
+    );
+  });
+
+  it('redacts exact roots and descendants without rewriting real siblings', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua benchmark boundary-'));
+    cleanup.push(root);
+    const subject = join(root, 'repo');
+    const descendant = join(subject, 'src', 'private.txt');
+    const spacedSibling = join(`${subject} copy`, 'public.txt');
+    const punctuatedSibling = join(`${subject},copy`, 'public.txt');
+    mkdirSync(dirname(descendant), { recursive: true });
+    mkdirSync(dirname(spacedSibling), { recursive: true });
+    mkdirSync(dirname(punctuatedSibling), { recursive: true });
+    writeFileSync(descendant, 'private\n');
+    writeFileSync(spacedSibling, 'public\n');
+    writeFileSync(punctuatedSibling, 'public\n');
+    const roots = [[subject, '<subject>']];
+
+    expect(benchmark.redactPaths(subject, roots)).toBe('<subject>');
+    expect(benchmark.redactPaths(descendant, roots)).toBe(
+      join('<subject>', 'src', 'private.txt'),
+    );
+    expect(benchmark.redactPaths(spacedSibling, roots)).toBe(spacedSibling);
+    expect(benchmark.redactPaths(punctuatedSibling, roots)).toBe(
+      punctuatedSibling,
+    );
+  });
+
+  it.runIf(process.platform !== 'win32')(
+    'preserves a valid POSIX terminal-dot sibling',
+    () => {
+      const root = mkdtempSync(join(tmpdir(), 'ua benchmark posix-dot-'));
+      cleanup.push(root);
+      const subject = join(root, 'repo');
+      mkdirSync(subject);
+      const sibling = `${subject}.`;
+
+      expect(benchmark.redactPaths(sibling, [[subject, '<subject>']])).toBe(
+        sibling,
+      );
+    },
+  );
+});
+
+describe('Git metadata probes', () => {
+  const cleanup = [];
+
+  afterEach(() => {
+    for (const path of cleanup.splice(0)) {
+      rmSync(path, { recursive: true, force: true });
+    }
+  });
+
+  it('reports ordinary clean and dirty repositories', () => {
+    const { root, subject } = makeGitSubject();
+    cleanup.push(root);
+    const commit = runGit(subject, ['rev-parse', 'HEAD']);
+
+    expect(benchmark.gitMetadata).toBeTypeOf('function');
+    expect(benchmark.gitMetadata(subject)).toEqual({ commit, dirty: false });
+
+    writeFileSync(join(subject, 'tracked.txt'), 'dirty\n');
+    expect(benchmark.gitMetadata(subject)).toEqual({ commit, dirty: true });
+  });
+
+  it('conservatively reports dirty when porcelain output exceeds its cap', () => {
+    const { root, subject } = makeGitSubject();
+    cleanup.push(root);
+
+    expect(benchmark.GIT_METADATA_MAX_BUFFER).toBeGreaterThan(0);
+    const fileCount =
+      Math.ceil(benchmark.GIT_METADATA_MAX_BUFFER / 60) + 200;
+    for (let index = 0; index < fileCount; index += 1) {
+      writeFileSync(
+        join(
+          subject,
+          `overflow-${String(index).padStart(5, '0')}-${'x'.repeat(40)}.txt`,
+        ),
+        '',
+      );
+    }
+
+    const boundedStatus = spawnSync(
+      'git',
+      ['-C', subject, 'status', '--porcelain'],
+      {
+        encoding: 'utf-8',
+        maxBuffer: benchmark.GIT_METADATA_MAX_BUFFER,
+        windowsHide: true,
+      },
+    );
+    expect(boundedStatus.error?.code).toBe('ENOBUFS');
+    expect(benchmark.gitMetadata(subject).dirty).toBe(true);
+  });
+});
+
+describe('large repository benchmark CLI', () => {
+  const cleanup = [];
+
+  afterEach(() => {
+    for (const path of cleanup.splice(0)) {
+      rmSync(path, { recursive: true, force: true });
+    }
+  });
+
+  it('parses a positional repository and validates concurrency', () => {
+    const { root, subject } = makeSubject();
+    cleanup.push(root);
+
+    const options = parseArgs(
+      [subject, '--concurrency', '3', '--label', 'polyglot-mini'],
+      root,
+    );
+    expect(options.repoRoot).toBe(subject);
+    expect(options.concurrency).toBe(3);
+    expect(options.label).toBe('polyglot-mini');
+    expect(options.markdownPath).toBe(
+      join(root, 'benchmark-results', 'large-repo-report.md'),
+    );
+    expect(() => parseArgs([subject, '--concurrency', '0'], root)).toThrow(
+      CliUsageError,
+    );
+  });
+
+  it.each(['2.5', '3junk', '1e1', ''])(
+    'rejects malformed concurrency %j in split and equals forms',
+    (rawConcurrency) => {
+      const { root, subject } = makeSubject();
+      cleanup.push(root);
+
+      expect(() =>
+        parseArgs([subject, '--concurrency', rawConcurrency], root),
+      ).toThrow(CliUsageError);
+      expect(() =>
+        parseArgs([subject, `--concurrency=${rawConcurrency}`], root),
+      ).toThrow(CliUsageError);
+    },
+  );
+
+  it('rejects report output paths equal to or inside the subject repository', () => {
+    const { root, subject } = makeSubject();
+    cleanup.push(root);
+
+    expect(() => parseArgs([subject, '--output', subject], root)).toThrow(
+      CliUsageError,
+    );
+    expect(() =>
+      parseArgs([subject, `--output=${join(subject, 'reports', 'result.json')}`], root),
+    ).toThrow(CliUsageError);
+    expect(() => parseArgs([subject], subject)).toThrow(CliUsageError);
+  });
+
+  it('rejects an outside JSON path whose derived Markdown path is the subject', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua benchmark output-'));
+    cleanup.push(root);
+    const subject = join(root, 'subject.md');
+    mkdirSync(subject);
+
+    expect(() =>
+      parseArgs([subject, '--output', join(root, 'subject.json')], root),
+    ).toThrow(CliUsageError);
+  });
+
+  it('accepts report paths under an outside sibling-prefix directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua benchmark sibling-'));
+    cleanup.push(root);
+    const subject = join(root, 'repo');
+    const outputPath = join(root, 'repo-copy', 'result.json');
+    mkdirSync(subject);
+
+    const options = parseArgs([subject, '--output', outputPath], root);
+
+    expect(options.outputPath).toBe(outputPath);
+    expect(options.markdownPath).toBe(join(root, 'repo-copy', 'result.md'));
+  });
+
+  it('rejects a non-existing report path through a physical repository alias', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua benchmark containment-'));
+    cleanup.push(root);
+    const subject = join(root, 'physical repo');
+    const subjectAlias = join(root, 'repo alias');
+    mkdirSync(subject);
+    symlinkSync(
+      subject,
+      subjectAlias,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+    const reportPath = join(subjectAlias, 'missing', 'report.json');
+
+    expect(() =>
+      parseArgs([subject, '--output', reportPath], root),
+    ).toThrow(CliUsageError);
+    expect(
+      benchmark.isPathInsideOrEqual(
+        subjectAlias,
+        join(subject, 'missing', 'report.json'),
+      ),
+    ).toBe(true);
+  });
+
+  it.runIf(process.platform === 'win32')(
+    'normalizes extended drive and UNC namespaces for containment',
+    () => {
+      const lexicalRoot = join(tmpdir(), 'ua namespace repo');
+      const extendedRoot = `\\\\?\\${lexicalRoot}`;
+      const ordinaryUncRoot = '\\\\localhost\\missing-share\\repo';
+      const extendedUncOutput =
+        '\\\\?\\UNC\\localhost\\missing-share\\repo\\report.json';
+
+      expect(
+        benchmark.isPathInsideOrEqual(
+          extendedRoot,
+          join(lexicalRoot, 'report.json'),
+        ),
+      ).toBe(true);
+      expect(
+        benchmark.isPathInsideOrEqual(ordinaryUncRoot, extendedUncOutput),
+      ).toBe(true);
+    },
+  );
+
+  it('records failed scan telemetry before writing the failed report', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua failed scan benchmark-'));
+    cleanup.push(root);
+    const subject = join(root, 'not-a-directory.txt');
+    const outputPath = join(root, 'reports', 'failed.json');
+    const markdownPath = join(root, 'reports', 'failed.md');
+    writeFileSync(subject, 'not a repository directory\n');
+
+    const result = await benchmark.runBenchmark({
+      repoRoot: subject,
+      outputPath,
+      markdownPath,
+      label: 'invalid-subject',
+      concurrency: 1,
+      keepArtifacts: false,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.report.status).toBe('failed');
+    expectValidReport(result.report);
+    expect(result.report.stages.scan).toMatchObject({
+      status: 'failed',
+      outputBytes: 0,
+      warningCount: 0,
+      warningMessages: [],
+      warningMessagesTruncated: false,
+    });
+    expect(result.report.stages.scan.durationMs).toBeGreaterThanOrEqual(0);
+    expect(result.report.stages.scan).toHaveProperty('peakRssBytes');
+    expect(result.report.stages.scan).toHaveProperty('userCpuTimeMicros');
+    expect(result.report.stages.scan).toHaveProperty('systemCpuTimeMicros');
+    expect(existsSync(outputPath)).toBe(true);
+    expect(existsSync(markdownPath)).toBe(true);
+    const serialized = readFileSync(outputPath, 'utf-8');
+    const persisted = JSON.parse(serialized);
+    expect(persisted.stages.scan.status).toBe('failed');
+    expect(persisted.error).not.toContain(subject);
+    expect(persisted.error).not.toContain(benchmark.REPO_ROOT);
+    expect(readFileSync(markdownPath, 'utf-8')).not.toContain(subject);
+  });
+
+  it('wraps cleanup operation failures without exposing artifact paths', () => {
+    const artifactRoot = join(tmpdir(), 'ua-large-bench-private-cleanup');
+    let cleanupError;
+
+    try {
+      benchmark.cleanupBenchmarkArtifacts(artifactRoot, {
+        rmSync() {
+          throw new Error(`EPERM while removing ${artifactRoot}`);
+        },
+      });
+    } catch (error) {
+      cleanupError = error;
+    }
+
+    expect(cleanupError).toBeInstanceOf(benchmark.BenchmarkArtifactCleanupError);
+    expect(cleanupError).toMatchObject({
+      message: 'Unable to remove temporary benchmark artifacts',
+      name: 'BenchmarkArtifactCleanupError',
+    });
+    expect(cleanupError).not.toHaveProperty('artifactRoot');
+    expect(cleanupError).not.toHaveProperty('cause');
+    expect(cleanupError.message).not.toContain(artifactRoot);
+    expect(cleanupError.message).not.toContain('EPERM');
+  });
+
+  it('rolls back both reports when the second report commit fails', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua report transaction-'));
+    cleanup.push(root);
+    const reportsDirectory = join(root, 'reports');
+    const outputPath = join(reportsDirectory, 'result.json');
+    const markdownPath = join(reportsDirectory, 'result.md');
+    const sentinelPath = join(reportsDirectory, 'sentinel.txt');
+    mkdirSync(reportsDirectory);
+    writeFileSync(outputPath, 'old json\n');
+    writeFileSync(markdownPath, 'old markdown\n');
+    writeFileSync(sentinelPath, 'unrelated\n');
+    const entriesBefore = readdirSync(reportsDirectory).sort();
+    let failedSecondCommit = false;
+    let deliveryError;
+
+    try {
+      benchmark.deliverBenchmarkReports(
+        {
+          outputPath,
+          markdownPath,
+          jsonContents: 'new json\n',
+          markdownContents: 'new markdown\n',
+        },
+        {
+          renameSync(source, destination) {
+            if (destination === markdownPath && source.endsWith('.tmp')) {
+              failedSecondCommit = true;
+              throw new Error(`EPERM renaming ${source} to ${destination}`);
+            }
+            renameSync(source, destination);
+          },
+        },
+      );
+    } catch (error) {
+      deliveryError = error;
+    }
+
+    expect(failedSecondCommit).toBe(true);
+    expect(deliveryError).toBeInstanceOf(benchmark.BenchmarkReportWriteError);
+    expect(deliveryError).toMatchObject({
+      message: 'Unable to write benchmark report files',
+      name: 'BenchmarkReportWriteError',
+    });
+    expect(deliveryError).not.toHaveProperty('cause');
+    expect(deliveryError.message).not.toContain(root);
+    expect(deliveryError.message).not.toContain('EPERM');
+    expect(readFileSync(outputPath, 'utf-8')).toBe('old json\n');
+    expect(readFileSync(markdownPath, 'utf-8')).toBe('old markdown\n');
+    expect(readFileSync(sentinelPath, 'utf-8')).toBe('unrelated\n');
+    expect(readdirSync(reportsDirectory).sort()).toEqual(entriesBefore);
+  });
+
+  it('removes an owned partial temp when a staging write fails', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua report partial write-'));
+    cleanup.push(root);
+    const reportsDirectory = join(root, 'reports');
+    const outputPath = join(reportsDirectory, 'result.json');
+    const markdownPath = join(reportsDirectory, 'result.md');
+    mkdirSync(reportsDirectory);
+    writeFileSync(outputPath, 'old json\n');
+    writeFileSync(markdownPath, 'old markdown\n');
+    const entriesBefore = readdirSync(reportsDirectory).sort();
+    let injectedFailure = false;
+    let deliveryError;
+
+    try {
+      benchmark.deliverBenchmarkReports(
+        {
+          outputPath,
+          markdownPath,
+          jsonContents: 'new json\n',
+          markdownContents: 'new markdown\n',
+        },
+        {
+          writeFileSync(path, contents, options) {
+            writeFileSync(path, contents.slice(0, 1), options);
+            injectedFailure = true;
+            throw new Error(`ENOSPC while writing ${path}`);
+          },
+        },
+      );
+    } catch (error) {
+      deliveryError = error;
+    }
+
+    expect(injectedFailure).toBe(true);
+    expect(deliveryError).toBeInstanceOf(benchmark.BenchmarkReportWriteError);
+    expect(deliveryError).not.toHaveProperty('cause');
+    expect(deliveryError.message).not.toContain(root);
+    expect(deliveryError.message).not.toContain('ENOSPC');
+    expect(readFileSync(outputPath, 'utf-8')).toBe('old json\n');
+    expect(readFileSync(markdownPath, 'utf-8')).toBe('old markdown\n');
+    expect(readdirSync(reportsDirectory).sort()).toEqual(entriesBefore);
+  });
+
+  it('handles an existing directory at the JSON report path without leaking artifacts', () => {
+    const { root, subject } = makeSubject();
+    cleanup.push(root);
+    const reportPath = join(root, 'reports', 'result.json');
+    const sentinelPath = join(reportPath, 'sentinel.txt');
+    mkdirSync(reportPath, { recursive: true });
+    writeFileSync(sentinelPath, 'keep me\n');
+    const artifactsBefore = benchmarkArtifactEntries();
+
+    const result = runCli([subject, '--output', reportPath]);
+
+    expectSafeReportWriteFailure(result, [
+      subject,
+      benchmark.REPO_ROOT,
+      reportPath,
+    ]);
+    expect(benchmarkArtifactEntries()).toEqual(artifactsBefore);
+    expect(readFileSync(sentinelPath, 'utf-8')).toBe('keep me\n');
+  }, 70_000);
+
+  it('preflights an existing Markdown directory before writing the JSON report', () => {
+    const { root, subject } = makeSubject();
+    cleanup.push(root);
+    const reportPath = join(root, 'reports', 'result.json');
+    const markdownPath = join(root, 'reports', 'result.md');
+    const sentinelPath = join(markdownPath, 'sentinel.txt');
+    mkdirSync(markdownPath, { recursive: true });
+    writeFileSync(sentinelPath, 'keep me too\n');
+    const artifactsBefore = benchmarkArtifactEntries();
+
+    const result = runCli([subject, '--output', reportPath]);
+
+    expectSafeReportWriteFailure(result, [
+      subject,
+      benchmark.REPO_ROOT,
+      reportPath,
+      markdownPath,
+    ]);
+    expect(benchmarkArtifactEntries()).toEqual(artifactsBefore);
+    expect(existsSync(reportPath)).toBe(false);
+    expect(readFileSync(sentinelPath, 'utf-8')).toBe('keep me too\n');
+  }, 70_000);
+
+  it('preserves but does not print artifacts when report delivery fails with keep-artifacts', () => {
+    const { root, subject } = makeSubject();
+    cleanup.push(root);
+    const reportPath = join(root, 'reports', 'result.json');
+    mkdirSync(reportPath, { recursive: true });
+    const artifactsBefore = benchmarkArtifactEntries();
+
+    const result = runCli([
+      subject,
+      '--output',
+      reportPath,
+      '--keep-artifacts',
+    ]);
+    const newArtifactEntries = benchmarkArtifactEntries().filter(
+      (entry) => !artifactsBefore.includes(entry),
+    );
+    for (const entry of newArtifactEntries) {
+      cleanup.push(join(tmpdir(), entry));
+    }
+
+    expectSafeReportWriteFailure(result, [
+      subject,
+      benchmark.REPO_ROOT,
+      reportPath,
+    ]);
+    expect(newArtifactEntries).toHaveLength(1);
+    expect(existsSync(join(tmpdir(), newArtifactEntries[0]))).toBe(true);
+  }, 70_000);
+
+  it('exposes a preserved artifact root as report delivery error metadata', async () => {
+    const { root, subject } = makeSubject();
+    cleanup.push(root);
+    const reportPath = join(root, 'reports', 'result.json');
+    mkdirSync(reportPath, { recursive: true });
+    const options = parseArgs(
+      [subject, '--output', reportPath, '--keep-artifacts'],
+      root,
+    );
+    const artifactsBefore = benchmarkArtifactEntries();
+    let deliveryError;
+
+    try {
+      await benchmark.runBenchmark(options);
+    } catch (error) {
+      deliveryError = error;
+    }
+    const newArtifactEntries = benchmarkArtifactEntries().filter(
+      (entry) => !artifactsBefore.includes(entry),
+    );
+    for (const entry of newArtifactEntries) {
+      cleanup.push(join(tmpdir(), entry));
+    }
+
+    expect(deliveryError).toBeInstanceOf(benchmark.BenchmarkReportWriteError);
+    expect(newArtifactEntries).toHaveLength(1);
+    expect(deliveryError).toMatchObject({
+      message: 'Unable to write benchmark report files',
+      artifactRoot: join(tmpdir(), newArtifactEntries[0]),
+    });
+    expect(existsSync(deliveryError.artifactRoot)).toBe(true);
+  }, 70_000);
+
+  it('runs all deterministic stages without writing into the subject repo', () => {
+    const { root, subject } = makeSubject();
+    cleanup.push(root);
+    const reportPath = join(root, 'reports', 'result.json');
+    const markdownPath = join(root, 'reports', 'result.md');
+    const secondReportPath = join(root, 'reports', 'result-second.json');
+    mkdirSync(join(subject, '.ua'), { recursive: true });
+    mkdirSync(join(subject, '.understand-anything'), { recursive: true });
+    writeFileSync(join(subject, '.ua', 'sentinel.txt'), 'keep me\n');
+    writeFileSync(
+      join(subject, '.understand-anything', 'sentinel.txt'),
+      'keep me too\n',
+    );
+    const before = snapshotTree(subject);
+
+    const result = runCli(
+      [
+        subject,
+        '--output',
+        reportPath,
+        '--label',
+        'polyglot-mini',
+        '--concurrency',
+        '2',
+      ],
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(existsSync(reportPath)).toBe(true);
+    expect(existsSync(markdownPath)).toBe(true);
+    expect(snapshotTree(subject)).toEqual(before);
+
+    const report = JSON.parse(readFileSync(reportPath, 'utf-8'));
+    const schema = JSON.parse(readFileSync(REPORT_SCHEMA, 'utf-8'));
+    const markdown = readFileSync(markdownPath, 'utf-8');
+    expectValidReport(report);
+    expect(report.schemaUrl).toBe(schema.$id);
+    expect(report.schemaVersion).toBe('1.0.0');
+    expect(report.status).toBe('ok');
+    expect(report.mode).toBe('deterministic');
+    expect(report.subject).toEqual({
+      label: 'polyglot-mini',
+      commit: null,
+      dirty: null,
+    });
+    expect(report.scale.files).toBe(3);
+    expect(report.scale.lines).toBeGreaterThan(0);
+    expect(report.stages.scan.status).toBe('ok');
+    expect(report.stages.imports.edges).toBe(1);
+    expect(report.stages.batching.totalBatches).toBeGreaterThan(0);
+    expect(report.stages.structure.filesAnalyzed).toBe(3);
+    expect(report.stages.structure.maxWorkerPeakRssBytes).toBeGreaterThan(0);
+    expect(report.stages.structure.userCpuTimeMicros).toBeGreaterThanOrEqual(0);
+    expect(report.stages.structure.systemCpuTimeMicros).toBeGreaterThanOrEqual(0);
+    expect(report.stages.structure).not.toHaveProperty('peakRssBytes');
+    expect(report.integrity.allScannedFilesBatched).toBe(true);
+    expect(report.integrity.structureCoverage).toBe(1);
+    expect(report.llm.invoked).toBe(false);
+    expect(report.determinism.inputDigest).toMatch(/^[a-f0-9]{64}$/);
+    expect(report.determinism.outputDigest).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.stringify(report)).not.toContain(subject);
+    expect(markdown).toContain('# Large Repository Benchmark Report');
+    expect(markdown).toContain('| Files | 3 |');
+    expect(markdown).toContain('| LLM invoked | No |');
+    expect(markdown).toContain('Peak / max worker RSS (bytes)');
+    expect(markdown).not.toContain(subject);
+
+    const secondResult = runCli([
+      subject,
+      '--output',
+      secondReportPath,
+      '--label',
+      'polyglot-mini',
+      '--concurrency',
+      '1',
+    ]);
+    expect(secondResult.status, secondResult.stderr).toBe(0);
+    expect(snapshotTree(subject)).toEqual(before);
+    const secondReport = JSON.parse(readFileSync(secondReportPath, 'utf-8'));
+    expect(report.configuration.concurrency).toBe(2);
+    expect(secondReport.configuration.concurrency).toBe(1);
+    expect(secondReport.scale).toEqual(report.scale);
+    expect(secondReport.integrity).toEqual(report.integrity);
+    expect(secondReport.determinism).toEqual(report.determinism);
+    expect(secondReport.stages.batching.batchSizes).toEqual(
+      report.stages.batching.batchSizes,
+    );
+  }, 70_000);
+
+  it('handles an empty repository as a valid deterministic run', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua empty benchmark-'));
+    cleanup.push(root);
+    const subject = join(root, 'empty subject');
+    const reportPath = join(root, 'empty.json');
+    mkdirSync(subject);
+
+    const result = runCli([subject, '--output', reportPath]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const report = JSON.parse(readFileSync(reportPath, 'utf-8'));
+    expectValidReport(report);
+    expect(report.status).toBe('ok');
+    expect(report.scale.files).toBe(0);
+    expect(report.stages.batching.totalBatches).toBe(0);
+    expect(report.stages.structure.batchesSucceeded).toBe(0);
+    expect(report.integrity.structureCoverage).toBe(1);
+  }, 70_000);
+
+  it('degrades for an accounted skip and uses the scan content digest', async () => {
+    const { root, subject } = makeSubject();
+    cleanup.push(root);
+    const reportPath = join(root, 'reports', 'degraded.json');
+    const options = parseArgs(
+      [subject, '--output', reportPath, '--keep-artifacts'],
+      root,
+    );
+    let removedAtStructure = false;
+
+    const result = await benchmark.runBenchmark(options, {
+      onProgress(stage) {
+        if (stage === 'structure') {
+          rmSync(join(subject, 'src', 'math.ts'));
+          removedAtStructure = true;
+        }
+      },
+    });
+    cleanup.push(result.artifactRoot);
+    const scan = JSON.parse(
+      readFileSync(join(result.artifactRoot, 'scan-result.json'), 'utf-8'),
+    );
+
+    expect(removedAtStructure).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.report.status).toBe('degraded');
+    expectValidReport(result.report);
+    expect(result.report.integrity).toMatchObject({
+      structureCoverage: 1,
+      filesSkipped: 1,
+      failedBatches: 0,
+      missingStructurePaths: 0,
+      duplicateStructurePaths: 0,
+      unexpectedStructurePaths: 0,
+      malformedStructureBatches: 0,
+    });
+    expect(result.report.determinism.inputDigest).toBe(scan.contentDigest);
+  }, 70_000);
+
+  it('changes the input digest when source bytes change but scan counts do not', () => {
+    const { root, subject } = makeSubject();
+    cleanup.push(root);
+    const firstReportPath = join(root, 'digest-first.json');
+    const secondReportPath = join(root, 'digest-second.json');
+
+    const firstResult = runCli([subject, '--output', firstReportPath]);
+    expect(firstResult.status, firstResult.stderr).toBe(0);
+    const firstReport = JSON.parse(readFileSync(firstReportPath, 'utf-8'));
+
+    writeFileSync(
+      join(subject, 'src', 'math.ts'),
+      'export function add(a: number, b: number) { return a - b; }\n',
+    );
+    const secondResult = runCli([subject, '--output', secondReportPath]);
+    expect(secondResult.status, secondResult.stderr).toBe(0);
+    const secondReport = JSON.parse(readFileSync(secondReportPath, 'utf-8'));
+
+    expect(secondReport.scale.files).toBe(firstReport.scale.files);
+    expect(secondReport.scale.lines).toBe(firstReport.scale.lines);
+    expect(secondReport.scale.bytes).toBe(firstReport.scale.bytes);
+    expect(secondReport.determinism.inputDigest).not.toBe(
+      firstReport.determinism.inputDigest,
+    );
+  }, 70_000);
+
+  it('returns usage errors without creating reports', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ua benchmark usage-'));
+    cleanup.push(root);
+    const reportPath = join(root, 'should-not-exist.json');
+
+    const help = runCli(['--help']);
+    expect(help.status).toBe(0);
+    expect(help.stdout).toContain('Usage:');
+
+    const invalid = runCli([
+      '--repo',
+      join(root, 'missing'),
+      '--output',
+      reportPath,
+    ]);
+    expect(invalid.status).toBe(2);
+    expect(invalid.stderr).toContain('Repository path does not exist');
+    expect(existsSync(reportPath)).toBe(false);
+  });
+});

--- a/tests/benchmark/test_large_repo_report_schema.test.mjs
+++ b/tests/benchmark/test_large_repo_report_schema.test.mjs
@@ -47,6 +47,7 @@ function validReport() {
   return {
     schemaUrl: schema.$id,
     schemaVersion: '1.0.0',
+    pairId: '11111111-1111-4111-8111-111111111111',
     status: 'ok',
     mode: 'deterministic',
     run: {
@@ -113,11 +114,18 @@ function validReport() {
         warningCount: 0,
         warningMessages: [],
         warningMessagesTruncated: false,
+        failureSamples: [],
+        failureSamplesTruncated: false,
         outputBytes: 128,
         batchesSucceeded: 1,
         batchesFailed: 0,
         filesAnalyzed: 1,
         filesSkipped: 0,
+        structureSucceeded: 1,
+        structureFailed: 0,
+        callGraphSucceeded: 1,
+        callGraphFailed: 0,
+        callGraphSkipped: 0,
         entities: {
           functions: 0,
           classes: 0,
@@ -139,6 +147,8 @@ function validReport() {
       unexpectedBatchFiles: 0,
       missingImportTargets: 0,
       structureCoverage: 1,
+      structureFailures: 0,
+      callGraphFailures: 0,
       filesSkipped: 0,
       failedBatches: 0,
       missingStructurePaths: 0,
@@ -158,6 +168,7 @@ function validReport() {
       costUsd: null,
     },
     warnings: [],
+    secondaryErrors: [],
     error: null,
   };
 }
@@ -169,6 +180,8 @@ describe('large repository report schema 1.0.0', () => {
     degraded.status = 'degraded';
     degraded.stages.structure.filesAnalyzed = 0;
     degraded.stages.structure.filesSkipped = 1;
+    degraded.stages.structure.structureSucceeded = 0;
+    degraded.stages.structure.callGraphSucceeded = 0;
     degraded.integrity.filesSkipped = 1;
 
     expectValid(ok);
@@ -258,6 +271,23 @@ describe('large repository report schema 1.0.0', () => {
   ])('rejects successful status with failing integrity %s', (field, value) => {
     const report = validReport();
     report.integrity[field] = value;
+    expectInvalid(report);
+  });
+
+  it('rejects degraded status without a warning or skipped-file reason', () => {
+    const report = validReport();
+    report.status = 'degraded';
+
+    expectInvalid(report);
+  });
+
+  it('rejects warning summaries whose count is zero', () => {
+    const report = validReport();
+    report.status = 'degraded';
+    report.warnings = [
+      { stage: 'scan', count: 0, messages: [], truncated: false },
+    ];
+
     expectInvalid(report);
   });
 });

--- a/tests/benchmark/test_large_repo_report_schema.test.mjs
+++ b/tests/benchmark/test_large_repo_report_schema.test.mjs
@@ -1,0 +1,263 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schemaPath = resolve(
+  __dirname,
+  '../../docs/benchmarks/large-repo-report-1.0.0.schema.json',
+);
+const schema = JSON.parse(readFileSync(schemaPath, 'utf-8'));
+const validateReport = new Ajv2020({
+  allErrors: true,
+  formats: { 'date-time': true },
+}).compile(schema);
+
+function expectValid(report) {
+  expect(
+    validateReport(report),
+    JSON.stringify(validateReport.errors, null, 2),
+  ).toBe(true);
+}
+
+function expectInvalid(report) {
+  expect(validateReport(report)).toBe(false);
+}
+
+function regularStage(overrides = {}) {
+  return {
+    status: 'ok',
+    durationMs: 1,
+    peakRssBytes: 1024,
+    userCpuTimeMicros: 10,
+    systemCpuTimeMicros: 5,
+    warningCount: 0,
+    warningMessages: [],
+    warningMessagesTruncated: false,
+    stdoutTruncated: false,
+    stderrTruncated: false,
+    outputBytes: 128,
+    ...overrides,
+  };
+}
+
+function validReport() {
+  return {
+    schemaUrl: schema.$id,
+    schemaVersion: '1.0.0',
+    status: 'ok',
+    mode: 'deterministic',
+    run: {
+      startedAt: '2026-01-01T00:00:00.000Z',
+      finishedAt: '2026-01-01T00:00:01.000Z',
+      durationMs: 1000,
+    },
+    tool: {
+      commit: null,
+      dirty: null,
+      packageVersion: '0.1.0',
+    },
+    subject: {
+      label: 'fixture',
+      commit: null,
+      dirty: null,
+    },
+    environment: {
+      platform: 'linux',
+      release: 'test',
+      arch: 'x64',
+      nodeVersion: 'v22.0.0',
+      cpuModel: 'test',
+      logicalCores: 1,
+      totalMemoryBytes: 1024,
+    },
+    configuration: {
+      concurrency: 1,
+      stages: ['scan', 'imports', 'batching', 'structure'],
+    },
+    scale: {
+      files: 1,
+      lines: 1,
+      bytes: 1,
+      missingFiles: 0,
+      filteredByUserIgnore: 0,
+      byCategory: { code: 1 },
+      byLanguage: { JavaScript: 1 },
+    },
+    stages: {
+      scan: regularStage({
+        files: 1,
+        lines: 1,
+        bytes: 1,
+        filteredByUserIgnore: 0,
+      }),
+      imports: regularStage({
+        filesScanned: 1,
+        filesWithImports: 0,
+        edges: 0,
+      }),
+      batching: regularStage({
+        algorithm: 'semantic-v1',
+        totalBatches: 1,
+        batchSizes: { min: 1, p50: 1, p95: 1, max: 1, mean: 1 },
+        estimatedAgentInputBytes: 1,
+      }),
+      structure: {
+        status: 'ok',
+        durationMs: 1,
+        maxWorkerPeakRssBytes: 1024,
+        userCpuTimeMicros: 10,
+        systemCpuTimeMicros: 5,
+        warningCount: 0,
+        warningMessages: [],
+        warningMessagesTruncated: false,
+        outputBytes: 128,
+        batchesSucceeded: 1,
+        batchesFailed: 0,
+        filesAnalyzed: 1,
+        filesSkipped: 0,
+        entities: {
+          functions: 0,
+          classes: 0,
+          exports: 0,
+          callGraph: 0,
+          definitions: 0,
+          services: 0,
+          endpoints: 0,
+          steps: 0,
+          resources: 0,
+        },
+        batchDurationMs: { min: 1, p50: 1, p95: 1, max: 1, mean: 1 },
+      },
+    },
+    integrity: {
+      allScannedFilesBatched: true,
+      missingBatchFiles: 0,
+      duplicateBatchFiles: 0,
+      unexpectedBatchFiles: 0,
+      missingImportTargets: 0,
+      structureCoverage: 1,
+      filesSkipped: 0,
+      failedBatches: 0,
+      missingStructurePaths: 0,
+      duplicateStructurePaths: 0,
+      unexpectedStructurePaths: 0,
+      malformedStructureBatches: 0,
+    },
+    determinism: {
+      algorithm: 'sha256',
+      inputDigest: '0'.repeat(64),
+      outputDigest: '1'.repeat(64),
+    },
+    llm: {
+      invoked: false,
+      inputTokens: null,
+      outputTokens: null,
+      costUsd: null,
+    },
+    warnings: [],
+    error: null,
+  };
+}
+
+describe('large repository report schema 1.0.0', () => {
+  it('accepts a complete ok report and a derived valid degraded report', () => {
+    const ok = validReport();
+    const degraded = structuredClone(ok);
+    degraded.status = 'degraded';
+    degraded.stages.structure.filesAnalyzed = 0;
+    degraded.stages.structure.filesSkipped = 1;
+    degraded.integrity.filesSkipped = 1;
+
+    expectValid(ok);
+    expectValid(degraded);
+  });
+
+  it.each([
+    [
+      'an incomplete ok report',
+      (report) => {
+        delete report.stages.structure;
+      },
+    ],
+    [
+      'the old warning shape',
+      (report) => {
+        report.status = 'degraded';
+        report.warnings = [{ stage: 'scan', count: 1 }];
+      },
+    ],
+    [
+      'the old structure memory field',
+      (report) => {
+        report.stages.structure.peakRssBytes =
+          report.stages.structure.maxWorkerPeakRssBytes;
+        delete report.stages.structure.maxWorkerPeakRssBytes;
+      },
+    ],
+    [
+      'a failed report with a null error',
+      (report) => {
+        report.status = 'failed';
+      },
+    ],
+  ])('rejects %s', (_name, mutate) => {
+    const report = validReport();
+    mutate(report);
+    expectInvalid(report);
+  });
+
+  it.each([
+    [
+      'warnings',
+      (report) => {
+        report.warnings = [
+          { stage: 'scan', count: 1, messages: ['warning'], truncated: false },
+        ];
+      },
+    ],
+    [
+      'skipped files',
+      (report) => {
+        report.integrity.filesSkipped = 1;
+      },
+    ],
+    [
+      'a stage warning',
+      (report) => {
+        report.stages.scan.warningCount = 1;
+        report.stages.scan.warningMessages = ['warning'];
+      },
+    ],
+    [
+      'a stage-level skipped file',
+      (report) => {
+        report.stages.structure.filesSkipped = 1;
+      },
+    ],
+  ])('rejects ok status with %s', (_name, mutate) => {
+    const report = validReport();
+    mutate(report);
+    expectInvalid(report);
+  });
+
+  it.each([
+    ['allScannedFilesBatched', false],
+    ['missingBatchFiles', 1],
+    ['duplicateBatchFiles', 1],
+    ['unexpectedBatchFiles', 1],
+    ['missingImportTargets', 1],
+    ['structureCoverage', 0.5],
+    ['failedBatches', 1],
+    ['missingStructurePaths', 1],
+    ['duplicateStructurePaths', 1],
+    ['unexpectedStructurePaths', 1],
+    ['malformedStructureBatches', 1],
+  ])('rejects successful status with failing integrity %s', (field, value) => {
+    const report = validReport();
+    report.integrity[field] = value;
+    expectInvalid(report);
+  });
+});

--- a/tests/skill/understand/test_compute_batches.test.mjs
+++ b/tests/skill/understand/test_compute_batches.test.mjs
@@ -10,9 +10,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = resolve(__dirname, '../../../understand-anything-plugin/skills/understand/compute-batches.mjs');
 const FIXTURES = resolve(__dirname, 'fixtures');
 
-function runScript(projectRoot, extraArgs = []) {
+function runScript(projectRoot, extraArgs = [], env = process.env) {
   return spawnSync('node', [SCRIPT, projectRoot, ...extraArgs], {
     encoding: 'utf-8',
+    env,
   });
 }
 
@@ -41,6 +42,35 @@ function setupProjectInDir(fixtureName, dirName) {
 function readBatches(projectRoot) {
   const p = join(projectRoot, '.understand-anything', 'intermediate', 'batches.json');
   return JSON.parse(readFileSync(p, 'utf-8'));
+}
+
+function setupAmbiguousRingProject() {
+  const root = mkdtempSync(join(tmpdir(), 'ua-cb-ring-'));
+  mkdirSync(join(root, '.understand-anything', 'intermediate'), { recursive: true });
+
+  const paths = ['zeta', 'äther', 'åland']
+    .flatMap(dir => ['a', 'b', 'c', 'd'].map(name => `src/${dir}/${name}.ts`));
+  for (const path of paths) {
+    const absolutePath = join(root, ...path.split('/'));
+    mkdirSync(dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, 'export {};\n');
+  }
+
+  const importMap = Object.fromEntries(paths.map((path, index) => [
+    path,
+    [paths[(index + 1) % paths.length]],
+  ]));
+  const files = paths.map(path => ({
+    path,
+    language: 'typescript',
+    sizeLines: 1,
+    fileCategory: 'code',
+  }));
+  writeFileSync(
+    join(root, '.understand-anything', 'intermediate', 'scan-result.json'),
+    JSON.stringify({ files, importMap }),
+  );
+  return root;
 }
 
 describe('compute-batches.mjs — Louvain basic', () => {
@@ -90,6 +120,130 @@ describe('compute-batches.mjs — Louvain basic', () => {
     );
 
     expect(json1).toBe(json2);
+  });
+});
+
+describe('compute-batches.mjs - deterministic Louvain', () => {
+  let projectRoot;
+
+  afterEach(() => {
+    if (projectRoot) rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('writes byte-identical batches for an ambiguous ring across fresh subprocesses', () => {
+    projectRoot = setupAmbiguousRingProject();
+    const outputPath = join(
+      projectRoot,
+      '.understand-anything',
+      'intermediate',
+      'batches.json',
+    );
+    const locales = ['en_US.UTF-8', 'sv_SE.UTF-8'];
+    const outputs = [];
+
+    for (let run = 0; run < 8; run++) {
+      const locale = locales[run % locales.length];
+      const result = runScript(projectRoot, [], {
+        ...process.env,
+        LANG: locale,
+        LC_ALL: locale,
+      });
+      expect(result.status).toBe(0);
+      outputs.push(readFileSync(outputPath, 'utf-8'));
+    }
+
+    expect(new Set(outputs).size).toBe(1);
+  }, 20_000);
+});
+
+describe('compute-batches.mjs — explicit benchmark paths', () => {
+  let projectRoot;
+
+  afterEach(() => {
+    if (projectRoot) rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('reads and writes outside the project data directory when requested', () => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'ua-cb-explicit-'));
+    const scanPath = join(projectRoot, 'benchmark-input', 'scan-result.json');
+    const outputPath = join(projectRoot, 'benchmark-output', 'batches.json');
+    mkdirSync(dirname(scanPath), { recursive: true });
+    writeFileSync(
+      scanPath,
+      readFileSync(join(FIXTURES, 'scan-result-3-cliques.json'), 'utf-8'),
+    );
+
+    const result = runScript(projectRoot, [
+      `--scan-result=${scanPath}`,
+      `--output=${outputPath}`,
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(existsSync(outputPath)).toBe(true);
+    expect(existsSync(join(projectRoot, '.ua'))).toBe(false);
+    expect(existsSync(join(projectRoot, '.understand-anything'))).toBe(false);
+
+    const batches = JSON.parse(readFileSync(outputPath, 'utf-8'));
+    expect(batches.totalFiles).toBe(9);
+    expect(batches.totalBatches).toBe(3);
+  });
+});
+
+describe('compute-batches.mjs - invalid benchmark path options', () => {
+  let testRoot;
+
+  afterEach(() => {
+    if (testRoot) rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  const scanOption = '--scan-result={scan}';
+  const outputOption = '--output={output}';
+  const changedOption = '--changed-files={changed}';
+  const invalidCases = [
+    ['an unknown option', [scanOption, '--ouput={output}']],
+    ['an unexpected positional argument', [scanOption, outputOption, 'unexpected']],
+    ['an empty --changed-files value', [scanOption, outputOption, '--changed-files=']],
+    ['an empty --scan-result value', ['--scan-result=', scanOption, outputOption]],
+    ['an empty --output value', [scanOption, '--output=']],
+    ['split --changed-files form', [scanOption, outputOption, '--changed-files', '{changed}']],
+    ['split --scan-result form', ['--scan-result', '{scan}', scanOption, outputOption]],
+    ['split --output form', [scanOption, '--output', '{output}']],
+    ['duplicate --changed-files options', [
+      scanOption, outputOption, changedOption, changedOption,
+    ]],
+    ['duplicate --scan-result options', [scanOption, scanOption, outputOption]],
+    ['duplicate --output options', [scanOption, outputOption, '--output={secondOutput}']],
+  ];
+
+  it.each(invalidCases)('rejects %s without creating a subject data directory', (
+    _name,
+    argTemplates,
+  ) => {
+    testRoot = mkdtempSync(join(tmpdir(), 'ua-cb-invalid-'));
+    const projectRoot = join(testRoot, 'subject-项目');
+    const scanPath = join(testRoot, 'input data', 'scan-result.json');
+    const outputPath = join(testRoot, 'output data', 'batches.json');
+    const secondOutputPath = join(testRoot, 'other output', 'batches.json');
+    const changedPath = join(testRoot, 'changed files.txt');
+    mkdirSync(projectRoot, { recursive: true });
+    mkdirSync(dirname(scanPath), { recursive: true });
+    writeFileSync(scanPath, JSON.stringify({ files: [], importMap: {} }));
+    writeFileSync(changedPath, 'src/example.ts\n');
+
+    const paths = {
+      changed: changedPath,
+      scan: scanPath,
+      output: outputPath,
+      secondOutput: secondOutputPath,
+    };
+    const args = argTemplates.map(arg =>
+      arg.replace(/\{(\w+)\}/g, (_match, key) => paths[key]));
+    const result = runScript(projectRoot, args);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/Error: compute-batches: (invalid|duplicate) option/);
+    expect(existsSync(join(projectRoot, '.ua'))).toBe(false);
+    expect(existsSync(join(projectRoot, '.understand-anything'))).toBe(false);
   });
 });
 

--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -30,14 +30,14 @@ function setupTree(files) {
  * `extraNodeArgs` is prepended to the node argv before the script path, so
  * tests can pass `--import` loader hooks to force specific failure modes.
  */
-function runScript(projectRoot, input, extraNodeArgs = []) {
+function runScript(projectRoot, input, extraNodeArgs = [], env = process.env) {
   const inputPath = join(projectRoot, 'ua-eim-input.json');
   const outputPath = join(projectRoot, 'ua-eim-output.json');
   writeFileSync(inputPath, JSON.stringify(input), 'utf-8');
   const result = spawnSync(
     'node',
     [...extraNodeArgs, SCRIPT, inputPath, outputPath],
-    { encoding: 'utf-8' },
+    { encoding: 'utf-8', env },
   );
   let output = null;
   try {
@@ -45,7 +45,13 @@ function runScript(projectRoot, input, extraNodeArgs = []) {
   } catch {
     /* output missing on hard failure */
   }
-  return { status: result.status, stdout: result.stdout, stderr: result.stderr, output };
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    output,
+    outputText: output ? readFileSync(outputPath, 'utf-8') : null,
+  };
 }
 
 describe('extract-import-map.mjs — TypeScript / JavaScript resolver', () => {
@@ -89,6 +95,44 @@ describe('extract-import-map.mjs — TypeScript / JavaScript resolver', () => {
     expect(result.output.stats.filesScanned).toBe(4);
     expect(result.output.stats.filesWithImports).toBe(1);
     expect(result.output.stats.totalEdges).toBe(2);
+  });
+
+  it('orders Unicode import targets by locale-independent UTF-16 code units', () => {
+    projectRoot = setupTree({
+      'src/index.ts': `import './ä';\nimport './Z';\nimport './a';\n`,
+      'src/ä.ts': 'export const umlaut = true;\n',
+      'src/Z.ts': 'export const upper = true;\n',
+      'src/a.ts': 'export const lower = true;\n',
+    });
+    const input = {
+      projectRoot,
+      files: [
+        { path: 'src/ä.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'src/index.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'src/a.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'src/Z.ts', language: 'typescript', fileCategory: 'code' },
+      ],
+    };
+
+    const cLocale = runScript(projectRoot, input, [], {
+      ...process.env,
+      LANG: 'C',
+      LC_ALL: 'C',
+    });
+    const swedishLocale = runScript(projectRoot, input, [], {
+      ...process.env,
+      LANG: 'sv_SE.UTF-8',
+      LC_ALL: 'sv_SE.UTF-8',
+    });
+
+    expect(cLocale.status, cLocale.stderr).toBe(0);
+    expect(swedishLocale.status, swedishLocale.stderr).toBe(0);
+    expect(cLocale.output.importMap['src/index.ts']).toEqual([
+      'src/Z.ts',
+      'src/a.ts',
+      'src/ä.ts',
+    ]);
+    expect(swedishLocale.outputText).toBe(cLocale.outputText);
   });
 
   it('resolves tsconfig paths aliases', () => {

--- a/tests/skill/understand/test_extract_structure_outcomes.test.mjs
+++ b/tests/skill/understand/test_extract_structure_outcomes.test.mjs
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import * as extractStructure from '../../../understand-anything-plugin/skills/understand/extract-structure-result.mjs';
+
+describe('extract-structure analysis outcomes', () => {
+  it('records final structure and call-graph exceptions after full-analysis fallback', () => {
+    expect(extractStructure.analyzeFileWithOutcomes).toBeTypeOf('function');
+    const registry = {
+      analyzeFileFull() {
+        throw new Error('combined parser failed');
+      },
+      analyzeFile() {
+        throw new Error('structure parser failed');
+      },
+      extractCallGraph() {
+        throw new Error('call graph failed');
+      },
+    };
+
+    expect(
+      extractStructure.analyzeFileWithOutcomes(
+        registry,
+        { path: 'src/failing.ts', fileCategory: 'code' },
+        'export const value = 1;\n',
+      ),
+    ).toEqual({
+      analysis: null,
+      callGraph: null,
+      structureOutcome: 'failed',
+      callGraphOutcome: 'failed',
+    });
+  });
+
+  it('does not count missing parser return values as successful analysis', () => {
+    const registry = {
+      analyzeFileFull() {
+        return undefined;
+      },
+      analyzeFile() {
+        return undefined;
+      },
+      extractCallGraph() {
+        return undefined;
+      },
+    };
+
+    expect(
+      extractStructure.analyzeFileWithOutcomes(
+        registry,
+        { path: 'src/missing.ts', fileCategory: 'code' },
+        'export const value = 1;\n',
+      ),
+    ).toMatchObject({
+      structureOutcome: 'failed',
+      callGraphOutcome: 'failed',
+    });
+  });
+});

--- a/tests/skill/understand/test_extract_structure_outcomes.test.mjs
+++ b/tests/skill/understand/test_extract_structure_outcomes.test.mjs
@@ -2,8 +2,682 @@ import { describe, expect, it } from 'vitest';
 
 import * as extractStructure from '../../../understand-anything-plugin/skills/understand/extract-structure-result.mjs';
 
+const REQUIRED_STRUCTURE_ARRAY_FIELDS = [
+  'functions',
+  'classes',
+  'imports',
+  'exports',
+];
+const OPTIONAL_STRUCTURE_ARRAY_FIELDS = [
+  'sections',
+  'definitions',
+  'services',
+  'endpoints',
+  'steps',
+  'resources',
+];
+
+function validAnalysis() {
+  return {
+    functions: [],
+    classes: [],
+    imports: [],
+    exports: [],
+  };
+}
+
+function validCallGraph() {
+  return [{ caller: 'entry', callee: 'target', lineNumber: 1 }];
+}
+
+const VALID_STRUCTURE_ENTRIES = {
+  functions: {
+    name: 'run',
+    lineRange: [1, 2],
+    params: ['value'],
+    returnType: 'string',
+  },
+  classes: {
+    name: 'Runner',
+    lineRange: [1, 3],
+    methods: ['run'],
+    properties: ['value'],
+  },
+  imports: {
+    source: './dependency.js',
+    specifiers: ['dependency'],
+    lineNumber: 1,
+  },
+  exports: {
+    name: 'run',
+    lineNumber: 2,
+    isDefault: false,
+  },
+  sections: {
+    name: 'Overview',
+    level: 1,
+    lineRange: [1, 2],
+  },
+  definitions: {
+    name: 'users',
+    kind: 'table',
+    lineRange: [1, 2],
+    fields: ['id'],
+  },
+  services: {
+    name: 'api',
+    image: 'example/api',
+    ports: [8080],
+    lineRange: [1, 2],
+  },
+  endpoints: {
+    method: 'GET',
+    path: '/health',
+    lineRange: [1, 2],
+  },
+  steps: {
+    name: 'build',
+    lineRange: [1, 2],
+  },
+  resources: {
+    name: 'bucket',
+    kind: 'storage',
+    lineRange: [1, 2],
+  },
+};
+
+const MALFORMED_STRUCTURE_ENTRIES = [
+  ['a null function entry', 'functions', null],
+  ['an array function entry', 'functions', []],
+  ['a function with a non-string name', 'functions', {
+    ...VALID_STRUCTURE_ENTRIES.functions,
+    name: 1,
+  }],
+  ['a function with a non-pair line range', 'functions', {
+    ...VALID_STRUCTURE_ENTRIES.functions,
+    lineRange: [1],
+  }],
+  ['a function with non-string params', 'functions', {
+    ...VALID_STRUCTURE_ENTRIES.functions,
+    params: ['value', 2],
+  }],
+  ['a function with a non-string return type', 'functions', {
+    ...VALID_STRUCTURE_ENTRIES.functions,
+    returnType: false,
+  }],
+  ['a class with a non-string name', 'classes', {
+    ...VALID_STRUCTURE_ENTRIES.classes,
+    name: false,
+  }],
+  ['a class with an overlong line range', 'classes', {
+    ...VALID_STRUCTURE_ENTRIES.classes,
+    lineRange: [1, 2, 3],
+  }],
+  ['a class with a non-array methods field', 'classes', {
+    ...VALID_STRUCTURE_ENTRIES.classes,
+    methods: 'run',
+  }],
+  ['a class with non-string properties', 'classes', {
+    ...VALID_STRUCTURE_ENTRIES.classes,
+    properties: ['value', null],
+  }],
+  ['an import with a non-string source', 'imports', {
+    ...VALID_STRUCTURE_ENTRIES.imports,
+    source: null,
+  }],
+  ['an import with non-string specifiers', 'imports', {
+    ...VALID_STRUCTURE_ENTRIES.imports,
+    specifiers: ['dependency', 1],
+  }],
+  ['an import with a non-number line', 'imports', {
+    ...VALID_STRUCTURE_ENTRIES.imports,
+    lineNumber: '1',
+  }],
+  ['an export with a non-string name', 'exports', {
+    ...VALID_STRUCTURE_ENTRIES.exports,
+    name: {},
+  }],
+  ['an export with a fractional line', 'exports', {
+    ...VALID_STRUCTURE_ENTRIES.exports,
+    lineNumber: 1.5,
+  }],
+  ['an export with a non-boolean default flag', 'exports', {
+    ...VALID_STRUCTURE_ENTRIES.exports,
+    isDefault: 'false',
+  }],
+  ['a section with a non-string name', 'sections', {
+    ...VALID_STRUCTURE_ENTRIES.sections,
+    name: 0,
+  }],
+  ['a section with an infinite level', 'sections', {
+    ...VALID_STRUCTURE_ENTRIES.sections,
+    level: Infinity,
+  }],
+  ['a section with a fractional line range', 'sections', {
+    ...VALID_STRUCTURE_ENTRIES.sections,
+    lineRange: [1, 2.5],
+  }],
+  ['a definition with a non-string name', 'definitions', {
+    ...VALID_STRUCTURE_ENTRIES.definitions,
+    name: undefined,
+  }],
+  ['a definition with a non-string kind', 'definitions', {
+    ...VALID_STRUCTURE_ENTRIES.definitions,
+    kind: 1,
+  }],
+  ['a definition with a non-finite line range', 'definitions', {
+    ...VALID_STRUCTURE_ENTRIES.definitions,
+    lineRange: [1, Infinity],
+  }],
+  ['a definition with a non-array fields field', 'definitions', {
+    ...VALID_STRUCTURE_ENTRIES.definitions,
+    fields: 'id',
+  }],
+  ['a service with a non-string name', 'services', {
+    ...VALID_STRUCTURE_ENTRIES.services,
+    name: false,
+  }],
+  ['a service with a non-string image', 'services', {
+    ...VALID_STRUCTURE_ENTRIES.services,
+    image: 7,
+  }],
+  ['a service with fractional ports', 'services', {
+    ...VALID_STRUCTURE_ENTRIES.services,
+    ports: [80.5],
+  }],
+  ['a service with a non-array optional line range', 'services', {
+    ...VALID_STRUCTURE_ENTRIES.services,
+    lineRange: '1-2',
+  }],
+  ['an endpoint with a non-string method', 'endpoints', {
+    ...VALID_STRUCTURE_ENTRIES.endpoints,
+    method: 7,
+  }],
+  ['an endpoint with a non-string path', 'endpoints', {
+    ...VALID_STRUCTURE_ENTRIES.endpoints,
+    path: null,
+  }],
+  ['an endpoint with a non-number line range', 'endpoints', {
+    ...VALID_STRUCTURE_ENTRIES.endpoints,
+    lineRange: [1, '2'],
+  }],
+  ['a step with a non-string name', 'steps', {
+    ...VALID_STRUCTURE_ENTRIES.steps,
+    name: [],
+  }],
+  ['a step with a NaN line range', 'steps', {
+    ...VALID_STRUCTURE_ENTRIES.steps,
+    lineRange: [1, NaN],
+  }],
+  ['a resource with a non-string name', 'resources', {
+    ...VALID_STRUCTURE_ENTRIES.resources,
+    name: 1,
+  }],
+  ['a resource with a non-string kind', 'resources', {
+    ...VALID_STRUCTURE_ENTRIES.resources,
+    kind: null,
+  }],
+  ['a resource with a null line range', 'resources', {
+    ...VALID_STRUCTURE_ENTRIES.resources,
+    lineRange: null,
+  }],
+];
+
+const VALID_BOUNDARY_ANALYSES = [
+  ['required collections with optional fields and arrays absent', {
+    functions: [{
+      name: 'run',
+      lineRange: [-1, 0],
+      params: [],
+      extraFunctionProperty: true,
+    }],
+    classes: [{
+      name: 'Runner',
+      lineRange: [-2, 0],
+      methods: [],
+      properties: [],
+      extraClassProperty: true,
+    }],
+    imports: [{
+      source: './dependency.js',
+      specifiers: [],
+      lineNumber: 0,
+      extraImportProperty: true,
+    }],
+    exports: [{
+      name: 'run',
+      lineNumber: -1,
+      extraExportProperty: true,
+    }],
+    extraAnalysisProperty: true,
+  }],
+  ['optional collections with nested optional fields absent', {
+    ...validAnalysis(),
+    sections: [{
+      name: 'Overview',
+      level: 0,
+      lineRange: [-1, 0],
+      extraSectionProperty: true,
+    }],
+    definitions: [{
+      name: 'users',
+      kind: 'table',
+      lineRange: [-1, 0],
+      fields: [],
+      extraDefinitionProperty: true,
+    }],
+    services: [{
+      name: 'api',
+      ports: [0, -1],
+      extraServiceProperty: true,
+    }],
+    endpoints: [{
+      path: '/health',
+      lineRange: [-1, 0],
+      extraEndpointProperty: true,
+    }],
+    steps: [{
+      name: 'build',
+      lineRange: [-1, 0],
+      extraStepProperty: true,
+    }],
+    resources: [{
+      name: 'bucket',
+      kind: 'storage',
+      lineRange: [-1, 0],
+      extraResourceProperty: true,
+    }],
+    extraAnalysisProperty: true,
+  }],
+];
+
+function analysisWithEntry(collection, entry) {
+  return {
+    ...validAnalysis(),
+    [collection]: [entry],
+  };
+}
+
+function analyzeStructuralOutput(mode, analysis) {
+  const parser = mode === 'full'
+    ? {
+        analyzeFileFull() {
+          return { structure: analysis, callGraph: validCallGraph() };
+        },
+      }
+    : {
+        analyzeFile() {
+          return analysis;
+        },
+      };
+  const registry = {
+    getPluginForFile() {
+      return parser;
+    },
+    analyzeFileFull(path, content) {
+      return parser.analyzeFileFull(path, content);
+    },
+    analyzeFile(path, content) {
+      return parser.analyzeFile(path, content);
+    },
+  };
+
+  return extractStructure.analyzeFileWithOutcomes(
+    registry,
+    { path: `src/${mode}-structure.ts`, fileCategory: 'code' },
+    'export const value = 1;\n',
+  );
+}
+
 describe('extract-structure analysis outcomes', () => {
-  it('records final structure and call-graph exceptions after full-analysis fallback', () => {
+  it('skips structure and call-graph analysis when no parser supports the file', () => {
+    const registry = {
+      getPluginForFile() {
+        return null;
+      },
+    };
+
+    expect(
+      extractStructure.analyzeFileWithOutcomes(
+        registry,
+        { path: 'src/unsupported.xyz', fileCategory: 'code' },
+        'unsupported content\n',
+      ),
+    ).toEqual({
+      analysis: null,
+      callGraph: null,
+      structureOutcome: 'skipped',
+      callGraphOutcome: 'skipped',
+    });
+  });
+
+  it('skips call-graph analysis when the selected parser only supports structure', () => {
+    const analysis = validAnalysis();
+    const parser = {
+      analyzeFile() {
+        return analysis;
+      },
+    };
+    const registry = {
+      getPluginForFile() {
+        return parser;
+      },
+      analyzeFile(path, content) {
+        return parser.analyzeFile(path, content);
+      },
+    };
+
+    expect(
+      extractStructure.analyzeFileWithOutcomes(
+        registry,
+        { path: 'src/structure-only.ts', fileCategory: 'code' },
+        'export const value = 1;\n',
+      ),
+    ).toEqual({
+      analysis,
+      callGraph: null,
+      structureOutcome: 'succeeded',
+      callGraphOutcome: 'skipped',
+    });
+  });
+
+  it('uses separate structure analysis for non-code files even when full analysis is advertised', () => {
+    const analysis = validAnalysis();
+    let fullCalls = 0;
+    let separateCalls = 0;
+    const parser = {
+      analyzeFileFull() {
+        fullCalls += 1;
+        throw new Error('full analysis must not run for non-code files');
+      },
+      analyzeFile() {
+        separateCalls += 1;
+        return analysis;
+      },
+    };
+    const registry = {
+      getPluginForFile() {
+        return parser;
+      },
+      analyzeFileFull(path, content) {
+        return parser.analyzeFileFull(path, content);
+      },
+      analyzeFile(path, content) {
+        return parser.analyzeFile(path, content);
+      },
+    };
+
+    const result = extractStructure.analyzeFileWithOutcomes(
+      registry,
+      { path: 'README.md', fileCategory: 'docs' },
+      '# Documentation\n',
+    );
+
+    expect({ result, fullCalls, separateCalls }).toEqual({
+      result: {
+        analysis,
+        callGraph: null,
+        structureOutcome: 'succeeded',
+        callGraphOutcome: 'skipped',
+      },
+      fullCalls: 0,
+      separateCalls: 1,
+    });
+  });
+
+  it.each([
+    [
+      'throws',
+      () => {
+        throw new Error('combined parser failed');
+      },
+    ],
+    ['returns null', () => null],
+    ['returns undefined', () => undefined],
+  ])(
+    'does not hide advertised full analysis that %s behind successful separate calls',
+    (_behavior, analyzeFileFull) => {
+      const fallbackAnalysis = validAnalysis();
+      const fallbackCallGraph = validCallGraph();
+      const parser = {
+        analyzeFileFull,
+        analyzeFile() {
+          return fallbackAnalysis;
+        },
+        extractCallGraph() {
+          return fallbackCallGraph;
+        },
+      };
+      const registry = {
+        getPluginForFile() {
+          return parser;
+        },
+        analyzeFileFull(path, content) {
+          return parser.analyzeFileFull(path, content);
+        },
+        analyzeFile(path, content) {
+          return parser.analyzeFile(path, content);
+        },
+        extractCallGraph(path, content) {
+          return parser.extractCallGraph(path, content);
+        },
+      };
+
+      expect(
+        extractStructure.analyzeFileWithOutcomes(
+          registry,
+          { path: 'src/full-failing.ts', fileCategory: 'code' },
+          'export const value = 1;\n',
+        ),
+      ).toEqual({
+        analysis: null,
+        callGraph: null,
+        structureOutcome: 'failed',
+        callGraphOutcome: 'failed',
+      });
+    },
+  );
+
+  it('validates structure independently in a full-analysis result', () => {
+    const callGraph = validCallGraph();
+    const parser = {
+      analyzeFileFull() {
+        return { structure: {}, callGraph };
+      },
+    };
+    const registry = {
+      getPluginForFile() {
+        return parser;
+      },
+      analyzeFileFull(path, content) {
+        return parser.analyzeFileFull(path, content);
+      },
+    };
+
+    expect(
+      extractStructure.analyzeFileWithOutcomes(
+        registry,
+        { path: 'src/full-structure-invalid.ts', fileCategory: 'code' },
+        'export const value = 1;\n',
+      ),
+    ).toEqual({
+      analysis: null,
+      callGraph,
+      structureOutcome: 'failed',
+      callGraphOutcome: 'succeeded',
+    });
+  });
+
+  it('validates call-graph entries independently in a full-analysis result', () => {
+    const analysis = validAnalysis();
+    const parser = {
+      analyzeFileFull() {
+        return {
+          structure: analysis,
+          callGraph: [{ caller: 'entry', callee: 'target', lineNumber: 1.5 }],
+        };
+      },
+    };
+    const registry = {
+      getPluginForFile() {
+        return parser;
+      },
+      analyzeFileFull(path, content) {
+        return parser.analyzeFileFull(path, content);
+      },
+    };
+
+    expect(
+      extractStructure.analyzeFileWithOutcomes(
+        registry,
+        { path: 'src/full-call-graph-invalid.ts', fileCategory: 'code' },
+        'export const value = 1;\n',
+      ),
+    ).toEqual({
+      analysis,
+      callGraph: null,
+      structureOutcome: 'succeeded',
+      callGraphOutcome: 'failed',
+    });
+  });
+
+  it.each([
+    ['a number', 42],
+    ['an array', []],
+    ['an object without required arrays', {}],
+    ...REQUIRED_STRUCTURE_ARRAY_FIELDS.map(field => [
+      `a non-array ${field} field`,
+      { ...validAnalysis(), [field]: null },
+    ]),
+    ...OPTIONAL_STRUCTURE_ARRAY_FIELDS.map(field => [
+      `a non-array optional ${field} field`,
+      { ...validAnalysis(), [field]: {} },
+    ]),
+  ])('rejects separate structural output containing %s', (_description, malformed) => {
+    const parser = {
+      analyzeFile() {
+        return malformed;
+      },
+    };
+    const registry = {
+      getPluginForFile() {
+        return parser;
+      },
+      analyzeFile(path, content) {
+        return parser.analyzeFile(path, content);
+      },
+    };
+
+    expect(
+      extractStructure.analyzeFileWithOutcomes(
+        registry,
+        { path: 'src/malformed-structure.ts', fileCategory: 'code' },
+        'export const value = 1;\n',
+      ),
+    ).toEqual({
+      analysis: null,
+      callGraph: null,
+      structureOutcome: 'failed',
+      callGraphOutcome: 'skipped',
+    });
+  });
+
+  it.each(MALFORMED_STRUCTURE_ENTRIES)(
+    'rejects %s through separate and full structural analysis',
+    (_description, collection, malformedEntry) => {
+      const malformed = analysisWithEntry(collection, malformedEntry);
+      const callGraph = validCallGraph();
+      const results = {
+        separate: analyzeStructuralOutput('separate', malformed),
+        full: analyzeStructuralOutput('full', malformed),
+      };
+
+      expect(results).toEqual({
+        separate: {
+          analysis: null,
+          callGraph: null,
+          structureOutcome: 'failed',
+          callGraphOutcome: 'skipped',
+        },
+        full: {
+          analysis: null,
+          callGraph,
+          structureOutcome: 'failed',
+          callGraphOutcome: 'succeeded',
+        },
+      });
+    },
+  );
+
+  it.each(VALID_BOUNDARY_ANALYSES)(
+    'accepts %s through separate and full structural analysis',
+    (_description, analysis) => {
+      const callGraph = validCallGraph();
+
+      expect({
+        separate: analyzeStructuralOutput('separate', analysis),
+        full: analyzeStructuralOutput('full', analysis),
+      }).toEqual({
+        separate: {
+          analysis,
+          callGraph: null,
+          structureOutcome: 'succeeded',
+          callGraphOutcome: 'skipped',
+        },
+        full: {
+          analysis,
+          callGraph,
+          structureOutcome: 'succeeded',
+          callGraphOutcome: 'succeeded',
+        },
+      });
+    },
+  );
+
+  it.each([
+    ['a non-string caller', { caller: 1, callee: 'target', lineNumber: 1 }],
+    ['a non-string callee', { caller: 'entry', callee: null, lineNumber: 1 }],
+    ['a non-number line', { caller: 'entry', callee: 'target', lineNumber: '1' }],
+    ['an infinite line', { caller: 'entry', callee: 'target', lineNumber: Infinity }],
+    ['a NaN line', { caller: 'entry', callee: 'target', lineNumber: NaN }],
+    ['a fractional line', { caller: 'entry', callee: 'target', lineNumber: 1.5 }],
+  ])('rejects a separate call graph containing %s', (_description, malformedEntry) => {
+    const analysis = validAnalysis();
+    const parser = {
+      analyzeFile() {
+        return analysis;
+      },
+      extractCallGraph() {
+        return [malformedEntry];
+      },
+    };
+    const registry = {
+      getPluginForFile() {
+        return parser;
+      },
+      analyzeFile(path, content) {
+        return parser.analyzeFile(path, content);
+      },
+      extractCallGraph(path, content) {
+        return parser.extractCallGraph(path, content);
+      },
+    };
+
+    expect(
+      extractStructure.analyzeFileWithOutcomes(
+        registry,
+        { path: 'src/malformed-call-graph.ts', fileCategory: 'code' },
+        'export const value = 1;\n',
+      ),
+    ).toEqual({
+      analysis,
+      callGraph: null,
+      structureOutcome: 'succeeded',
+      callGraphOutcome: 'failed',
+    });
+  });
+
+  it('records advertised full-analysis exceptions as failures', () => {
     expect(extractStructure.analyzeFileWithOutcomes).toBeTypeOf('function');
     const registry = {
       analyzeFileFull() {

--- a/tests/skill/understand/test_scan_project.test.mjs
+++ b/tests/skill/understand/test_scan_project.test.mjs
@@ -7,6 +7,7 @@ import {
   rmSync,
   chmodSync,
   existsSync,
+  symlinkSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
@@ -60,12 +61,13 @@ const _runScriptOutputDirs = [];
  * { status, stdout, stderr, output } where `output` is the parsed JSON
  * written by the script (or null on failure).
  */
-function runScript(projectRoot) {
+function runScript(projectRoot, extraArgs = [], envOverrides = {}) {
   const outputDir = mkdtempSync(join(tmpdir(), 'ua-scan-out-'));
   _runScriptOutputDirs.push(outputDir);
   const outputPath = join(outputDir, 'scan-output.json');
-  const result = spawnSync('node', [SCRIPT, projectRoot, outputPath], {
+  const result = spawnSync('node', [SCRIPT, projectRoot, outputPath, ...extraArgs], {
     encoding: 'utf-8',
+    env: { ...process.env, ...envOverrides },
   });
   let output = null;
   try {
@@ -517,6 +519,19 @@ describe('scan-project.mjs — data-dir resolution (.ua vs legacy)', () => {
     expect(byPath(r.output, 'fixtures/snap2.json')).toBeUndefined();
     expect(r.output.filteredByIgnore).toBe(2);
   });
+
+  it('can exclude persistent analysis data for isolated benchmark scans', () => {
+    projectRoot = setupTree({
+      '.ua/knowledge-graph.json': '{ "nodes": [] }\n',
+      '.understand-anything/meta.json': '{ "version": 1 }\n',
+      'src/index.ts': 'export const x = 1;\n',
+    });
+
+    const r = runScript(projectRoot, ['--exclude-analysis-data']);
+
+    expect(r.status).toBe(0);
+    expect(r.output.files.map(file => file.path)).toEqual(['src/index.ts']);
+  });
 });
 
 describe('scan-project.mjs — special-file recognition', () => {
@@ -566,6 +581,105 @@ describe('scan-project.mjs — determinism', () => {
     expect(r1.status).toBe(0);
     expect(r2.status).toBe(0);
     expect(JSON.stringify(r1.output)).toBe(JSON.stringify(r2.output));
+  });
+
+  it('keeps Unicode and space-containing paths stable across process locales', () => {
+    projectRoot = setupTree({
+      '!bang.ts': 'export const bang = true;\n',
+      '_under.ts': 'export const under = true;\n',
+      'space dir/å.ts': 'export const nested = true;\n',
+      'ä.ts': 'export const umlaut = true;\n',
+      '中.ts': 'export const cjk = true;\n',
+    });
+
+    const cLocale = runScript(projectRoot, [], { LANG: 'C', LC_ALL: 'C' });
+    const swedishLocale = runScript(projectRoot, [], {
+      LANG: 'sv_SE.UTF-8',
+      LC_ALL: 'sv_SE.UTF-8',
+    });
+    const expectedPaths = [
+      '!bang.ts',
+      '_under.ts',
+      'space dir/å.ts',
+      'ä.ts',
+      '中.ts',
+    ];
+
+    expect(cLocale.status).toBe(0);
+    expect(swedishLocale.status).toBe(0);
+    expect(cLocale.output.files.map(file => file.path)).toEqual(expectedPaths);
+    expect(swedishLocale.output.files.map(file => file.path)).toEqual(expectedPaths);
+    expect(JSON.stringify(cLocale.output)).toBe(JSON.stringify(swedishLocale.output));
+  });
+
+  it('emits a top-level lowercase SHA-256 content fingerprint as contentDigest', () => {
+    projectRoot = setupTree({
+      'src/value.ts': 'export const value = 1;\n',
+    });
+
+    const result = runScript(projectRoot);
+
+    expect(result.status).toBe(0);
+    expect(result.output.contentDigest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('changes the content fingerprint when bytes change but metadata does not', () => {
+    projectRoot = setupTree({
+      'src/value.ts': 'export const value = "aa";\n',
+    });
+    const before = runScript(projectRoot);
+
+    writeFileSync(
+      join(projectRoot, 'src/value.ts'),
+      'export const value = "bb";\n',
+      'utf-8',
+    );
+    const after = runScript(projectRoot);
+
+    expect(before.status).toBe(0);
+    expect(after.status).toBe(0);
+    expect(byPath(before.output, 'src/value.ts').sizeLines).toBe(1);
+    expect(byPath(after.output, 'src/value.ts').sizeLines).toBe(1);
+    expect(after.output.files).toEqual(before.output.files);
+    expect(after.output.contentDigest).not.toBe(before.output.contentDigest);
+  });
+
+  it('omits a Git-tracked outbound symlink and never fingerprints its target bytes', () => {
+    projectRoot = setupTree({
+      'src/inside.ts': 'export const inside = true;\n',
+    });
+    const externalRoot = mkdtempSync(join(tmpdir(), 'ua-scan-external-'));
+    const externalFile = join(externalRoot, 'secret.ts');
+
+    try {
+      writeFileSync(externalFile, 'export const secret = "first";\n', 'utf-8');
+      try {
+        symlinkSync(externalFile, join(projectRoot, 'outbound-link.ts'), 'file');
+      } catch (error) {
+        if (process.platform === 'win32') return;
+        throw error;
+      }
+      const add = spawnSync('git', ['add', '--', 'outbound-link.ts'], {
+        cwd: projectRoot,
+        encoding: 'utf-8',
+      });
+      expect(add.status).toBe(0);
+
+      const before = runScript(projectRoot);
+      writeFileSync(externalFile, 'export const secret = "second";\n', 'utf-8');
+      const after = runScript(projectRoot);
+
+      expect(before.status).toBe(0);
+      expect(after.status).toBe(0);
+      expect(byPath(before.output, 'src/inside.ts')).toBeDefined();
+      expect(byPath(before.output, 'outbound-link.ts')).toBeUndefined();
+      expect(before.stderr).toMatch(
+        /Warning: scan-project: outbound-link\.ts — symbolic link skipped — file skipped from output/,
+      );
+      expect(after.output.contentDigest).toBe(before.output.contentDigest);
+    } finally {
+      rmSync(externalRoot, { recursive: true, force: true });
+    }
   });
 });
 
@@ -767,6 +881,7 @@ describe('scan-project.mjs — output schema invariants', () => {
     expect(typeof out.totalFiles).toBe('number');
     expect(out.totalFiles).toBe(out.files.length);
     expect(typeof out.filteredByIgnore).toBe('number');
+    expect(out.contentDigest).toMatch(/^[0-9a-f]{64}$/);
     expect(['small', 'moderate', 'large', 'very-large']).toContain(
       out.estimatedComplexity,
     );
@@ -776,6 +891,9 @@ describe('scan-project.mjs — output schema invariants', () => {
     expect(typeof out.stats.byLanguage).toBe('object');
     // Per-file shape
     for (const f of out.files) {
+      expect(Object.keys(f).sort()).toEqual([
+        'fileCategory', 'language', 'path', 'sizeLines',
+      ]);
       expect(typeof f.path).toBe('string');
       expect(typeof f.language).toBe('string');
       expect(typeof f.sizeLines).toBe('number');
@@ -785,17 +903,17 @@ describe('scan-project.mjs — output schema invariants', () => {
     }
   });
 
-  it('files[] is sorted by path.localeCompare', () => {
+  it('files[] is sorted by a locale-independent code-unit order', () => {
     projectRoot = setupTree({
-      'zzz.ts': '\n',
-      'aaa.ts': '\n',
-      'mmm.ts': '\n',
-      'subdir/file.ts': '\n',
+      '!bang.ts': '\n',
+      '0.ts': '\n',
+      '_under.ts': '\n',
+      'a.ts': '\n',
+      'ä.ts': '\n',
     });
     const r = runScript(projectRoot);
     expect(r.status).toBe(0);
     const paths = r.output.files.map(f => f.path);
-    const sortedPaths = [...paths].sort((a, b) => a.localeCompare(b));
-    expect(paths).toEqual(sortedPaths);
+    expect(paths).toEqual(['!bang.ts', '0.ts', '_under.ts', 'a.ts', 'ä.ts']);
   });
 });

--- a/understand-anything-plugin/skills/understand/compute-batches.mjs
+++ b/understand-anything-plugin/skills/understand/compute-batches.mjs
@@ -7,15 +7,26 @@
  *
  * Usage:
  *   node compute-batches.mjs <project-root> [--changed-files=<path>]
+ *     [--scan-result=<path>] [--output=<path>]
  *
  * Input/output live under the project's data dir (`.ua/`, or legacy
  * `.understand-anything/` when that directory already exists — resolved by
  * core's resolveUaDir):
  *   Input:  <ua-dir>/intermediate/scan-result.json
  *   Output: <ua-dir>/intermediate/batches.json
+ *
+ * `--scan-result` and `--output` let read-only tooling (for example the
+ * large-repository benchmark runner) keep intermediate artifacts outside the
+ * analyzed project. Omitting them preserves the normal /understand paths.
  */
 
-import { readFileSync, writeFileSync, existsSync, realpathSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -252,6 +263,13 @@ function normalizeRelativePathForMatch(pathText) {
     .replace(/\/+/g, '/');
 }
 
+// ECMAScript string comparison uses a stable UTF-16 code-unit order and does
+// not depend on the host locale or ICU version.
+function comparePaths(a, b) {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
 /**
  * Returns Map<path, communityId> via Louvain. May throw — caller must catch
  * and fall back if it does. Honors UA_COMPUTE_BATCHES_FORCE_LOUVAIN_THROW=1
@@ -262,15 +280,18 @@ function runLouvain(codeFiles, importMap) {
     throw new Error('forced throw via UA_COMPUTE_BATCHES_FORCE_LOUVAIN_THROW');
   }
   const g = new Graph({ type: 'undirected', allowSelfLoops: false });
-  for (const f of codeFiles) g.addNode(f.path);
-  for (const [src, targets] of Object.entries(importMap)) {
+  const sortedCodePaths = codeFiles.map(f => f.path).sort(comparePaths);
+  for (const path of sortedCodePaths) g.addNode(path);
+  const sortedImports = Object.entries(importMap)
+    .sort(([a], [b]) => comparePaths(a, b));
+  for (const [src, targets] of sortedImports) {
     if (!g.hasNode(src)) continue;
-    for (const tgt of targets) {
+    for (const tgt of [...targets].sort(comparePaths)) {
       if (!g.hasNode(tgt) || src === tgt || g.hasEdge(src, tgt)) continue;
       g.addEdge(src, tgt);
     }
   }
-  const cs = louvain(g);  // { nodeId: communityId }
+  const cs = louvain(g, { randomWalk: false });  // { nodeId: communityId }
   return new Map(Object.entries(cs));
 }
 
@@ -331,7 +352,7 @@ function mergeSmallBatches(bareBatches) {
   // Pool and sort deterministically by path so repeated runs match byte-for-byte.
   const pooledFiles = smallMergeable
     .flatMap(b => b.files)
-    .sort((a, b) => a.path.localeCompare(b.path));
+    .sort((a, b) => comparePaths(a.path, b.path));
 
   const miscBatches = [];
   for (let i = 0; i < pooledFiles.length; i += MAX_MERGE_TARGET) {
@@ -361,34 +382,55 @@ function mergeSmallBatches(bareBatches) {
 async function main() {
   const projectRoot = process.argv[2];
   if (!projectRoot) {
-    process.stderr.write('Usage: node compute-batches.mjs <project-root> [--changed-files=<path>]\n');
+    process.stderr.write(
+      'Usage: node compute-batches.mjs <project-root> [--changed-files=<path>] ' +
+      '[--scan-result=<path>] [--output=<path>]\n',
+    );
     process.exit(1);
   }
 
-  let changedFiles = null;
+  const helperOptions = new Map();
   for (const arg of process.argv.slice(3)) {
-    const m = arg.match(/^--changed-files=(.+)$/);
-    if (m) {
-      const p = m[1];
-      let content;
-      try {
-        content = readFileSync(p, 'utf-8');
-      } catch (err) {
-        process.stderr.write(
-          `Error: compute-batches: --changed-files path not readable: ${p} (${err.message})\n`,
-        );
-        process.exit(1);
-      }
-      const lines = content
-        .split('\n')
-        .map(normalizeRelativePathForMatch)
-        .filter(Boolean);
-      changedFiles = new Set(lines);
+    const match = arg.match(/^--(changed-files|scan-result|output)=(.+)$/);
+    if (!match) {
+      process.stderr.write(`Error: compute-batches: invalid option: ${arg}\n`);
+      process.exit(1);
     }
+    const [, optionName, optionValue] = match;
+    if (helperOptions.has(optionName)) {
+      process.stderr.write(`Error: compute-batches: duplicate option: --${optionName}\n`);
+      process.exit(1);
+    }
+    helperOptions.set(optionName, optionValue);
   }
 
+  let changedFiles = null;
+  const changedFilesPath = helperOptions.get('changed-files');
+  if (changedFilesPath) {
+    let content;
+    try {
+      content = readFileSync(changedFilesPath, 'utf-8');
+    } catch (err) {
+      process.stderr.write(
+        `Error: compute-batches: --changed-files path not readable: ${changedFilesPath} ` +
+        `(${err.message})\n`,
+      );
+      process.exit(1);
+    }
+    const lines = content
+      .split('\n')
+      .map(normalizeRelativePathForMatch)
+      .filter(Boolean);
+    changedFiles = new Set(lines);
+  }
+
+  const scanResultValue = helperOptions.get('scan-result');
+  const outputValue = helperOptions.get('output');
+  const scanResultPath = scanResultValue ? resolve(scanResultValue) : null;
+  const outputPath = outputValue ? resolve(outputValue) : null;
+
   const uaDir = resolveUaDir(projectRoot);
-  const scanPath = join(uaDir, 'intermediate', 'scan-result.json');
+  const scanPath = scanResultPath ?? join(uaDir, 'intermediate', 'scan-result.json');
   if (!existsSync(scanPath)) {
     process.stderr.write(`Error: scan-result.json not found at ${scanPath}\n`);
     process.exit(1);
@@ -458,7 +500,7 @@ async function main() {
       if (b[1].length !== a[1].length) return b[1].length - a[1].length;
       const minA = [...a[1]].sort()[0];
       const minB = [...b[1]].sort()[0];
-      return minA.localeCompare(minB);
+      return comparePaths(minA, minB);
     });
 
   // Build per-batch file list with full file metadata from scan
@@ -541,7 +583,7 @@ async function main() {
       if (rawCount > MAX_NEIGHBORS) {
         kept.sort((a, b2) => (NEIGHBOR_DEGREE.get(b2.path) || 0)
                             - (NEIGHBOR_DEGREE.get(a.path) || 0)
-                            || a.path.localeCompare(b2.path));  // deterministic tiebreak
+                            || comparePaths(a.path, b2.path));  // deterministic tiebreak
         const beforeSlice = kept.length;
         kept = kept.slice(0, MAX_NEIGHBORS);
         process.stderr.write(
@@ -586,7 +628,8 @@ async function main() {
     batches: finalBatches,
   };
 
-  const outPath = join(uaDir, 'intermediate', 'batches.json');
+  const outPath = outputPath ?? join(uaDir, 'intermediate', 'batches.json');
+  mkdirSync(dirname(outPath), { recursive: true });
   writeFileSync(outPath, JSON.stringify(output, null, 2), 'utf-8');
   const batchSizes = finalBatches.map(b => b.files.length);
   const maxSize = batchSizes.length ? Math.max(...batchSizes) : 0;

--- a/understand-anything-plugin/skills/understand/extract-import-map.mjs
+++ b/understand-anything-plugin/skills/understand/extract-import-map.mjs
@@ -96,6 +96,13 @@ function toPosix(p) {
   return p.split(/[\\/]/).filter(Boolean).join('/');
 }
 
+// ECMAScript relational string comparison is lexicographic over UTF-16 code
+// units, so path ordering is stable across ICU versions, locales, and hosts.
+function comparePaths(a, b) {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
 /**
  * Join a directory with a relative segment, normalizing `.`/`..` segments and
  * returning a forward-slash POSIX path. Anchored at project root (no leading
@@ -476,7 +483,7 @@ async function buildResolutionContext(projectRoot, files) {
     goFilesByDir.get(d).push(p);
   }
   for (const arr of goFilesByDir.values()) {
-    arr.sort((a, b) => a.localeCompare(b));
+    arr.sort(comparePaths);
   }
 
   // Build per-extension suffix indices for dotted-FQN resolvers (Java,
@@ -1022,7 +1029,7 @@ function buildSuffixIndex(files, extPredicate) {
   }
   // Deterministic order within each bucket
   for (const arr of idx.values()) {
-    arr.sort((a, b) => a.localeCompare(b));
+    arr.sort(comparePaths);
   }
   return idx;
 }
@@ -1043,7 +1050,7 @@ function buildPackageIndex(files, extPredicate) {
     }
   }
   for (const arr of idx.values()) {
-    arr.sort((a, b) => a.localeCompare(b));
+    arr.sort(comparePaths);
   }
   return idx;
 }
@@ -1100,7 +1107,7 @@ function buildSwiftModuleIndex(files, packageTargets) {
   const idx = new Map();
   const targetEntries = [...packageTargets.entries()].map(([name, paths]) => [
     name,
-    [...paths].sort((a, b) => a.localeCompare(b)),
+    [...paths].sort(comparePaths),
   ]);
 
   for (const f of files) {
@@ -1123,7 +1130,7 @@ function buildSwiftModuleIndex(files, packageTargets) {
 
   const out = new Map();
   for (const [moduleName, paths] of idx.entries()) {
-    out.set(moduleName, [...paths].sort((a, b) => a.localeCompare(b)));
+    out.set(moduleName, [...paths].sort(comparePaths));
   }
   return out;
 }
@@ -1199,7 +1206,7 @@ export function resolveScalaImport(rawImport, specifiers, _file, ctx) {
 
   if (specs.includes('*')) {
     for (const m of resolveScalaPackage(rawImport, ctx)) out.add(m);
-    return [...out].sort((a, b) => a.localeCompare(b));
+    return [...out].sort(comparePaths);
   }
 
   if (isPlain) {
@@ -1208,7 +1215,7 @@ export function resolveScalaImport(rawImport, specifiers, _file, ctx) {
       const pkg = rawImport.slice(0, -(specs[0].length + 1));
       for (const m of resolveScalaDottedFqn(`${pkg}.package`, ctx)) out.add(m);
     }
-    return [...out].sort((a, b) => a.localeCompare(b));
+    return [...out].sort(comparePaths);
   }
 
   let unresolvedSelector = false;
@@ -1223,7 +1230,7 @@ export function resolveScalaImport(rawImport, specifiers, _file, ctx) {
     for (const m of resolveScalaDottedFqn(`${rawImport}.package`, ctx)) out.add(m);
   }
 
-  return [...out].sort((a, b) => a.localeCompare(b));
+  return [...out].sort(comparePaths);
 }
 
 function resolveScalaDottedFqn(fqn, ctx) {
@@ -1244,7 +1251,7 @@ function compareScalaPackageMembers(a, b) {
   const aPackage = /\/package\.s(?:cala|c)$/.test(a);
   const bPackage = /\/package\.s(?:cala|c)$/.test(b);
   if (dirOf(a) === dirOf(b) && aPackage !== bPackage) return aPackage ? 1 : -1;
-  return a.localeCompare(b);
+  return comparePaths(a, b);
 }
 
 // ---------------------------------------------------------------------------
@@ -1913,7 +1920,7 @@ async function main() {
       resolved = [...resolvedSet].sort((a, b) =>
         file.language === 'scala'
           ? compareScalaPackageMembers(a, b)
-          : a.localeCompare(b),
+          : comparePaths(a, b),
       );
     } catch (err) {
       process.stderr.write(

--- a/understand-anything-plugin/skills/understand/extract-structure-result.mjs
+++ b/understand-anything-plugin/skills/understand/extract-structure-result.mjs
@@ -1,5 +1,124 @@
 // Pure result mapping for extract-structure.mjs.
 // Kept separate from the CLI entrypoint so unit tests do not import a shebang script.
+const REQUIRED_STRUCTURE_ARRAY_FIELDS = [
+  'functions',
+  'classes',
+  'imports',
+  'exports',
+];
+const OPTIONAL_STRUCTURE_ARRAY_FIELDS = [
+  'sections',
+  'definitions',
+  'services',
+  'endpoints',
+  'steps',
+  'resources',
+];
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isStringArray(value) {
+  return Array.isArray(value) && value.every(item => typeof item === 'string');
+}
+
+function isFiniteInteger(value) {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    Number.isInteger(value);
+}
+
+function isLineRange(value) {
+  return Array.isArray(value) &&
+    value.length === 2 &&
+    value.every(isFiniteInteger);
+}
+
+function hasValidOptionalField(value, field, validator) {
+  return value[field] === undefined || validator(value[field]);
+}
+
+function isValidEntryArray(value, validator) {
+  return Array.isArray(value) &&
+    value.every(entry => isPlainObject(entry) && validator(entry));
+}
+
+const STRUCTURE_ENTRY_VALIDATORS = {
+  functions: entry =>
+    typeof entry.name === 'string' &&
+    isLineRange(entry.lineRange) &&
+    isStringArray(entry.params) &&
+    hasValidOptionalField(entry, 'returnType', value => typeof value === 'string'),
+  classes: entry =>
+    typeof entry.name === 'string' &&
+    isLineRange(entry.lineRange) &&
+    isStringArray(entry.methods) &&
+    isStringArray(entry.properties),
+  imports: entry =>
+    typeof entry.source === 'string' &&
+    isStringArray(entry.specifiers) &&
+    isFiniteInteger(entry.lineNumber),
+  exports: entry =>
+    typeof entry.name === 'string' &&
+    isFiniteInteger(entry.lineNumber) &&
+    hasValidOptionalField(entry, 'isDefault', value => typeof value === 'boolean'),
+  sections: entry =>
+    typeof entry.name === 'string' &&
+    isFiniteInteger(entry.level) &&
+    isLineRange(entry.lineRange),
+  definitions: entry =>
+    typeof entry.name === 'string' &&
+    typeof entry.kind === 'string' &&
+    isLineRange(entry.lineRange) &&
+    isStringArray(entry.fields),
+  services: entry =>
+    typeof entry.name === 'string' &&
+    hasValidOptionalField(entry, 'image', value => typeof value === 'string') &&
+    Array.isArray(entry.ports) &&
+    entry.ports.every(isFiniteInteger) &&
+    hasValidOptionalField(entry, 'lineRange', isLineRange),
+  endpoints: entry =>
+    hasValidOptionalField(entry, 'method', value => typeof value === 'string') &&
+    typeof entry.path === 'string' &&
+    isLineRange(entry.lineRange),
+  steps: entry =>
+    typeof entry.name === 'string' &&
+    isLineRange(entry.lineRange),
+  resources: entry =>
+    typeof entry.name === 'string' &&
+    typeof entry.kind === 'string' &&
+    isLineRange(entry.lineRange),
+};
+
+function isValidStructuralAnalysis(analysis) {
+  if (!isPlainObject(analysis)) {
+    return false;
+  }
+
+  return REQUIRED_STRUCTURE_ARRAY_FIELDS.every(field =>
+    isValidEntryArray(analysis[field], STRUCTURE_ENTRY_VALIDATORS[field])) &&
+    OPTIONAL_STRUCTURE_ARRAY_FIELDS.every(field =>
+      hasValidOptionalField(
+        analysis,
+        field,
+        value => isValidEntryArray(value, STRUCTURE_ENTRY_VALIDATORS[field]),
+      ));
+}
+
+function isValidCallGraph(callGraph) {
+  return Array.isArray(callGraph) && callGraph.every(entry =>
+    isPlainObject(entry) &&
+    typeof entry.caller === 'string' &&
+    typeof entry.callee === 'string' &&
+    isFiniteInteger(entry.lineNumber));
+}
+
 function mapCallGraph(callGraph) {
   return callGraph && callGraph.length > 0
     ? callGraph.map(entry => ({
@@ -13,45 +132,81 @@ function mapCallGraph(callGraph) {
 export function analyzeFileWithOutcomes(registry, file, content) {
   const wantsCallGraph =
     file.fileCategory === 'code' || file.fileCategory === 'script';
-  let analysis = null;
-  let callGraph = null;
-  let structureOutcome = 'failed';
-  let callGraphOutcome = wantsCallGraph ? 'failed' : 'skipped';
+  const selectedPlugin = typeof registry.getPluginForFile === 'function'
+    ? registry.getPluginForFile(file.path)
+    : registry;
 
-  let full = null;
-  if (wantsCallGraph && typeof registry.analyzeFileFull === 'function') {
+  if (selectedPlugin === null) {
+    return {
+      analysis: null,
+      callGraph: null,
+      structureOutcome: 'skipped',
+      callGraphOutcome: 'skipped',
+    };
+  }
+
+  const supportsFullAnalysis =
+    typeof selectedPlugin?.analyzeFileFull === 'function';
+  const supportsSeparateCallGraph =
+    typeof selectedPlugin?.extractCallGraph === 'function';
+
+  if (wantsCallGraph && supportsFullAnalysis) {
+    let full;
     try {
       full = registry.analyzeFileFull(file.path, content);
     } catch {
-      full = null;
+      return {
+        analysis: null,
+        callGraph: null,
+        structureOutcome: 'failed',
+        callGraphOutcome: wantsCallGraph ? 'failed' : 'skipped',
+      };
     }
+
+    const analysis = isValidStructuralAnalysis(full?.structure)
+      ? full.structure
+      : null;
+    const hasValidCallGraph = wantsCallGraph && isValidCallGraph(full?.callGraph);
+    const callGraph = hasValidCallGraph ? mapCallGraph(full.callGraph) : null;
+
+    return {
+      analysis,
+      callGraph,
+      structureOutcome: analysis === null ? 'failed' : 'succeeded',
+      callGraphOutcome: wantsCallGraph
+        ? hasValidCallGraph ? 'succeeded' : 'failed'
+        : 'skipped',
+    };
   }
 
-  if (full) {
-    analysis = full.structure ?? null;
-    callGraph = mapCallGraph(full.callGraph);
-    structureOutcome = analysis === null ? 'failed' : 'succeeded';
-    callGraphOutcome = Array.isArray(full.callGraph) ? 'succeeded' : 'failed';
-  } else {
-    try {
-      analysis = registry.analyzeFile(file.path, content) ?? null;
-      structureOutcome = analysis === null ? 'failed' : 'succeeded';
-    } catch {
-      analysis = null;
-      structureOutcome = 'failed';
-    }
+  let analysis = null;
+  let callGraph = null;
+  let structureOutcome = 'failed';
+  let callGraphOutcome = wantsCallGraph && supportsSeparateCallGraph
+    ? 'failed'
+    : 'skipped';
 
-    if (wantsCallGraph) {
-      try {
-        const extractedCallGraph = registry.extractCallGraph(file.path, content);
+  try {
+    const extractedAnalysis = registry.analyzeFile(file.path, content);
+    if (isValidStructuralAnalysis(extractedAnalysis)) {
+      analysis = extractedAnalysis;
+      structureOutcome = 'succeeded';
+    }
+  } catch {
+    analysis = null;
+    structureOutcome = 'failed';
+  }
+
+  if (wantsCallGraph && supportsSeparateCallGraph) {
+    try {
+      const extractedCallGraph = registry.extractCallGraph(file.path, content);
+      if (isValidCallGraph(extractedCallGraph)) {
         callGraph = mapCallGraph(extractedCallGraph);
-        callGraphOutcome = Array.isArray(extractedCallGraph)
-          ? 'succeeded'
-          : 'failed';
-      } catch {
-        callGraph = null;
-        callGraphOutcome = 'failed';
+        callGraphOutcome = 'succeeded';
       }
+    } catch {
+      callGraph = null;
+      callGraphOutcome = 'failed';
     }
   }
 

--- a/understand-anything-plugin/skills/understand/extract-structure-result.mjs
+++ b/understand-anything-plugin/skills/understand/extract-structure-result.mjs
@@ -1,5 +1,63 @@
 // Pure result mapping for extract-structure.mjs.
 // Kept separate from the CLI entrypoint so unit tests do not import a shebang script.
+function mapCallGraph(callGraph) {
+  return callGraph && callGraph.length > 0
+    ? callGraph.map(entry => ({
+        caller: entry.caller,
+        callee: entry.callee,
+        lineNumber: entry.lineNumber,
+      }))
+    : null;
+}
+
+export function analyzeFileWithOutcomes(registry, file, content) {
+  const wantsCallGraph =
+    file.fileCategory === 'code' || file.fileCategory === 'script';
+  let analysis = null;
+  let callGraph = null;
+  let structureOutcome = 'failed';
+  let callGraphOutcome = wantsCallGraph ? 'failed' : 'skipped';
+
+  let full = null;
+  if (wantsCallGraph && typeof registry.analyzeFileFull === 'function') {
+    try {
+      full = registry.analyzeFileFull(file.path, content);
+    } catch {
+      full = null;
+    }
+  }
+
+  if (full) {
+    analysis = full.structure ?? null;
+    callGraph = mapCallGraph(full.callGraph);
+    structureOutcome = analysis === null ? 'failed' : 'succeeded';
+    callGraphOutcome = Array.isArray(full.callGraph) ? 'succeeded' : 'failed';
+  } else {
+    try {
+      analysis = registry.analyzeFile(file.path, content) ?? null;
+      structureOutcome = analysis === null ? 'failed' : 'succeeded';
+    } catch {
+      analysis = null;
+      structureOutcome = 'failed';
+    }
+
+    if (wantsCallGraph) {
+      try {
+        const extractedCallGraph = registry.extractCallGraph(file.path, content);
+        callGraph = mapCallGraph(extractedCallGraph);
+        callGraphOutcome = Array.isArray(extractedCallGraph)
+          ? 'succeeded'
+          : 'failed';
+      } catch {
+        callGraph = null;
+        callGraphOutcome = 'failed';
+      }
+    }
+  }
+
+  return { analysis, callGraph, structureOutcome, callGraphOutcome };
+}
+
 export function buildResult(file, totalLines, nonEmptyLines, analysis, callGraph, batchImportData) {
   const base = {
     path: file.path,

--- a/understand-anything-plugin/skills/understand/extract-structure.mjs
+++ b/understand-anything-plugin/skills/understand/extract-structure.mjs
@@ -109,6 +109,12 @@ async function main() {
 
     const { analysis, callGraph, structureOutcome, callGraphOutcome } =
       analyzeFileWithOutcomes(registry, file, content);
+
+    if (structureOutcome === 'skipped') {
+      filesSkipped.push(file.path);
+      continue;
+    }
+
     analysisOutcomes.structure[structureOutcome] += 1;
     analysisOutcomes.callGraph[callGraphOutcome] += 1;
 

--- a/understand-anything-plugin/skills/understand/extract-structure.mjs
+++ b/understand-anything-plugin/skills/understand/extract-structure.mjs
@@ -20,9 +20,15 @@ import { createRequire } from 'node:module';
 import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
-import { buildResult as buildExtractResult } from './extract-structure-result.mjs';
+import {
+  analyzeFileWithOutcomes,
+  buildResult as buildExtractResult,
+} from './extract-structure-result.mjs';
 
-export { buildResult } from './extract-structure-result.mjs';
+export {
+  analyzeFileWithOutcomes,
+  buildResult,
+} from './extract-structure-result.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // skills/understand/ -> plugin root is two dirs up
@@ -77,6 +83,10 @@ async function main() {
 
   const results = [];
   const filesSkipped = [];
+  const analysisOutcomes = {
+    structure: { succeeded: 0, failed: 0 },
+    callGraph: { succeeded: 0, failed: 0, skipped: 0 },
+  };
 
   for (const file of batchFiles) {
     const absolutePath = join(projectRoot, file.path);
@@ -97,56 +107,10 @@ async function main() {
     const totalLines = content.endsWith('\n') ? Math.max(0, lines.length - 1) : lines.length;
     const nonEmptyLines = lines.filter(l => l.trim().length > 0).length;
 
-    const wantsCallGraph =
-      file.fileCategory === 'code' || file.fileCategory === 'script';
-
-    const mapCallGraph = cg =>
-      cg && cg.length > 0
-        ? cg.map(entry => ({
-            caller: entry.caller,
-            callee: entry.callee,
-            lineNumber: entry.lineNumber,
-          }))
-        : null;
-
-    let analysis = null;
-    let callGraph = null;
-
-    // Single-parse fast path: when both structure and call graph are needed,
-    // analyzeFileFull parses the file once instead of analyzeFile +
-    // extractCallGraph parsing it twice (~40% less parse work on code files).
-    // Falls back to the two separate calls (preserving their independent
-    // degradation) when the registry/plugin lacks the combined method or it
-    // throws.
-    let full = null;
-    if (wantsCallGraph && typeof registry.analyzeFileFull === 'function') {
-      try {
-        full = registry.analyzeFileFull(file.path, content);
-      } catch {
-        full = null;
-      }
-    }
-
-    if (full) {
-      analysis = full.structure;
-      callGraph = mapCallGraph(full.callGraph);
-    } else {
-      // Structural analysis via registry
-      try {
-        analysis = registry.analyzeFile(file.path, content);
-      } catch {
-        // If analysis throws, treat as degraded — still include basic metrics
-      }
-
-      // Call graph extraction (code files only)
-      if (wantsCallGraph) {
-        try {
-          callGraph = mapCallGraph(registry.extractCallGraph(file.path, content));
-        } catch {
-          // Call graph extraction failed — non-fatal
-        }
-      }
-    }
+    const { analysis, callGraph, structureOutcome, callGraphOutcome } =
+      analyzeFileWithOutcomes(registry, file, content);
+    analysisOutcomes.structure[structureOutcome] += 1;
+    analysisOutcomes.callGraph[callGraphOutcome] += 1;
 
     // Build result object
     const result = buildExtractResult(file, totalLines, nonEmptyLines, analysis, callGraph, batchImportData);
@@ -158,6 +122,7 @@ async function main() {
     scriptCompleted: true,
     filesAnalyzed: results.length,
     filesSkipped,
+    analysisOutcomes,
     results,
   };
 

--- a/understand-anything-plugin/skills/understand/scan-project.mjs
+++ b/understand-anything-plugin/skills/understand/scan-project.mjs
@@ -26,13 +26,14 @@
  *   - Complexity estimation (project-scanner.md Step 7 thresholds)
  *
  * Usage:
- *   node scan-project.mjs <projectRoot> <outputPath>
+ *   node scan-project.mjs <projectRoot> <outputPath> [--exclude-analysis-data]
  *
  * Output JSON (subset of what project-scanner.md Phase 1 expects — the LLM
  * agent merges this with Step A's narrative fields and Step C's importMap to
  * produce the final scan-result.json):
  *   {
  *     "scriptCompleted": true,
+ *     "contentDigest": "<sha256 lowercase hex>",
  *     "files": [{ "path": "...", "language": "...", "sizeLines": N, "fileCategory": "..." }, ...],
  *     "totalFiles": N,
  *     "filteredByIgnore": M,
@@ -45,16 +46,18 @@
  *   `Warning: scan-project: <path> — <reason> — file skipped from output`
  * to stderr and the file is dropped; the rest of the scan completes.
  *
- * Determinism: files are sorted by `path.localeCompare` before emission, and
- * the underlying enumeration is deterministic (git ls-files returns a stable
- * order; the fallback walker sorts each directory's entries).
+ * Determinism: files are sorted by a locale-independent UTF-16 code-unit
+ * comparison before emission. The content digest uses that same order and
+ * length-frames each UTF-8 relative path plus its raw file bytes.
  */
 
 import { createRequire } from 'node:module';
+import { createHash } from 'node:crypto';
 import { dirname, resolve, join, basename, extname, relative, sep } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   existsSync,
+  lstatSync,
   readFileSync,
   readdirSync,
   realpathSync,
@@ -459,6 +462,17 @@ function toPosix(p) {
 }
 
 /**
+ * Locale-independent string order. ECMAScript relational string comparison
+ * is lexicographic over UTF-16 code units, so the result cannot vary with ICU,
+ * process locale, or operating system settings.
+ */
+function compareStableStrings(a, b) {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+/**
  * Enumerate all files in `projectRoot` via `git ls-files`. Returns an
  * array of project-relative POSIX paths, or null if the directory is not
  * a git repository (or git is not installed). Caller falls back to the
@@ -531,7 +545,7 @@ function enumerateViaWalk(projectRoot) {
     // Sort deterministically by name; mix files and dirs together so the
     // final output (after the path sort) is identical regardless of
     // OS-specific readdir order.
-    entries.sort((a, b) => a.name.localeCompare(b.name));
+    entries.sort((a, b) => compareStableStrings(a.name, b.name));
     for (const ent of entries) {
       if (ent.isDirectory()) {
         if (HARD_SKIP_DIRS.has(ent.name)) continue;
@@ -621,15 +635,15 @@ function hasUserIgnoreFile(projectRoot) {
 // ---------------------------------------------------------------------------
 
 /**
- * Count newline-delimited lines in a file. Returns the number of `\n`
- * characters; this matches `wc -l` semantics (which counts newlines, not
- * "lines of content"). Files without a trailing newline therefore report
- * one fewer than the visible line count — same behavior as wc.
+ * Read a file once and count its newline-delimited lines. Returns both the raw
+ * bytes and the number of `\n` characters; the caller feeds those same bytes
+ * directly into the content digest without a second read or a whole-repo
+ * content concatenation. The count matches `wc -l` semantics.
  *
  * Per-file failure: emits a Warning: and returns null. Caller decides
  * whether to drop the file or keep it with sizeLines=0.
  */
-function countLines(absPath, posixPath) {
+function readAndCountLines(absPath, posixPath) {
   try {
     const buf = readFileSync(absPath);
     // Manual newline count beats split('\n').length on large files — no
@@ -638,7 +652,7 @@ function countLines(absPath, posixPath) {
     for (let i = 0; i < buf.length; i++) {
       if (buf[i] === 0x0a) count++;
     }
-    return count;
+    return { bytes: buf, sizeLines: count };
   } catch (err) {
     process.stderr.write(
       `Warning: scan-project: ${posixPath} — line count failed ` +
@@ -648,18 +662,44 @@ function countLines(absPath, posixPath) {
   }
 }
 
+const CONTENT_DIGEST_DOMAIN = Buffer.from('understand-anything:scan-content:v1\0', 'utf-8');
+
+/**
+ * Add one scanned regular file to the aggregate fingerprint. Entries arrive
+ * in compareStableStrings path order. Each frame is:
+ *   uint32be(path UTF-8 byte length) || uint64be(content byte length) ||
+ *   UTF-8 path bytes || raw content bytes
+ * Length prefixes make path/content and adjacent-entry boundaries unambiguous.
+ */
+function updateContentDigest(hash, posixPath, contentBytes) {
+  const pathBytes = Buffer.from(posixPath, 'utf-8');
+  const lengths = Buffer.allocUnsafe(12);
+  lengths.writeUInt32BE(pathBytes.length, 0);
+  lengths.writeBigUInt64BE(BigInt(contentBytes.length), 4);
+  hash.update(lengths);
+  hash.update(pathBytes);
+  hash.update(contentBytes);
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const [, , projectRoot, outputPath] = process.argv;
+  const [, , projectRoot, outputPath, ...options] = process.argv;
   if (!projectRoot || !outputPath) {
     process.stderr.write(
-      'Usage: node scan-project.mjs <projectRoot> <outputPath>\n',
+      'Usage: node scan-project.mjs <projectRoot> <outputPath> ' +
+      '[--exclude-analysis-data]\n',
     );
     process.exit(1);
   }
+  const unknownOption = options.find(option => option !== '--exclude-analysis-data');
+  if (unknownOption) {
+    process.stderr.write(`scan-project.mjs failed: unknown option: ${unknownOption}\n`);
+    process.exit(1);
+  }
+  const excludeAnalysisData = options.includes('--exclude-analysis-data');
 
   if (!existsSync(projectRoot)) {
     process.stderr.write(
@@ -676,7 +716,11 @@ async function main() {
   }
 
   // 1. Enumerate. Either git ls-files or recursive walk.
-  const candidates = enumerateFiles(projectRoot);
+  const candidates = enumerateFiles(projectRoot).filter(
+    rel =>
+      !excludeAnalysisData ||
+      (!rel.startsWith('.ua/') && !rel.startsWith('.understand-anything/')),
+  );
 
   // 2. Filter via createIgnoreFilter (defaults + user .understandignore).
   //    Build a defaults-only filter in parallel to count user-driven drops.
@@ -701,42 +745,56 @@ async function main() {
     }
   }
 
+  // The per-file pass, output, stats key insertion, and content fingerprint
+  // all consume this one locale-independent path order.
+  kept.sort(compareStableStrings);
+
   // 3. Per-file: language + category + line count.
   //    Drop files that fail line counting (per-file resilience).
   const fileEntries = [];
+  const contentHash = createHash('sha256');
+  contentHash.update(CONTENT_DIGEST_DOMAIN);
   for (const rel of kept) {
     const absPath = join(projectRoot, rel);
-    // Stat first — git ls-files could include paths that vanished between
-    // listing and processing; the walker shouldn't but defensive anyway.
+    // lstat first so Git-enumerated symlinks are rejected before any operation
+    // can follow them to a repository-external target.
     try {
-      const st = statSync(absPath);
+      const st = lstatSync(absPath);
+      if (st.isSymbolicLink()) {
+        process.stderr.write(
+          `Warning: scan-project: ${rel} — symbolic link skipped ` +
+          `— file skipped from output\n`,
+        );
+        continue;
+      }
       if (!st.isFile()) {
-        // Symlinks-to-dir, special files, etc. — skip silently. Not a
-        // warning condition because git wouldn't have tracked it as a file.
+        // Directories and special files are not scanned as regular-file input.
         continue;
       }
     } catch (err) {
       process.stderr.write(
-        `Warning: scan-project: ${rel} — stat failed (${err.message}) ` +
+        `Warning: scan-project: ${rel} — lstat failed (${err.message}) ` +
         `— file skipped from output\n`,
       );
       continue;
     }
-    const sizeLines = countLines(absPath, rel);
-    if (sizeLines === null) {
-      // countLines already emitted the Warning: line.
+    const scanned = readAndCountLines(absPath, rel);
+    if (scanned === null) {
+      // readAndCountLines already emitted the Warning: line.
       continue;
     }
+    updateContentDigest(contentHash, rel, scanned.bytes);
     fileEntries.push({
       path: rel,
       language: detectLanguage(rel),
-      sizeLines,
+      sizeLines: scanned.sizeLines,
       fileCategory: detectCategory(rel),
     });
   }
 
-  // 4. Determinism: sort by path.localeCompare.
-  fileEntries.sort((a, b) => a.path.localeCompare(b.path));
+  // 4. Determinism: preserve the documented locale-independent path order.
+  fileEntries.sort((a, b) => compareStableStrings(a.path, b.path));
+  const contentDigest = contentHash.digest('hex');
 
   // 5. Stats.
   const byCategory = {};
@@ -750,6 +808,7 @@ async function main() {
 
   const output = {
     scriptCompleted: true,
+    contentDigest,
     files: fileEntries,
     totalFiles: fileEntries.length,
     filteredByIgnore,


### PR DESCRIPTION
## Summary

This PR adds a reproducible benchmark for the non-LLM stages of `/understand`:
file scanning, import extraction, batch planning, and Tree-sitter structure
extraction.

It gives contributors a shared way to measure large repositories and find
bottlenecks using repeatable evidence. It does not call an LLM or write
analysis data into the repository being tested.

Each run produces matching JSON and Markdown reports with repository scale,
timing, CPU and memory use, warnings, failures, and input/output digests.
Private paths, hostnames, and Git remotes are not included.

## Usage

```sh
corepack pnpm benchmark:large-repo /absolute/path/to/repository \
  --label public-repository-name \
  --output /absolute/path/to/results/report.json
```

The output must be outside the tested repository. Temporary files are cleaned
up by default.

## What this adds

- Deterministic file selection, ordering, batching, and content digests.
- Isolated benchmark stages with bounded concurrency and failure reporting.
- Paired JSON/Markdown reports validated by schema version `1.0.0`.
- Cross-platform instructions and a pinned TensorFlow reproduction recipe.

## Related work

- Refs #76 for `/understand` performance work.
- Refs #483 for large-codebase evaluation.
- Follow-up to the scale discussion around #576.

## Limitations

- This is not an end-to-end `/understand` benchmark. It does not run an LLM,
  count tokens, estimate cost, build the final knowledge graph, or open the
  dashboard.
- `estimatedAgentInputBytes` measures bytes, not tokens or cost.
- TensorFlow is currently a pinned recipe, not a completed measurement.
- This PR does not claim verified support for one-million-line repositories.
- Timing and memory should only be compared across same-machine runs with the
  same concurrency and matching digests.

## Current plan

1. Land the reproducible benchmark and report format.
2. Collect at least three same-digest community runs, including the pinned
   TensorFlow revision and other monorepos.
3. Compare repeated runs on the same machine.
4. Use the results to choose and verify the next optimization.
5. Benchmark LLM, token, and cost behavior separately in future work.

## Testing

- Install, lint, and core/skill/viewer builds passed.
- Core tests: 934 passed.
- Root Vitest suite: 380 passed, 7 platform-specific skips.
- Python helpers: 95 passed, 1 platform-specific skip.
- Benchmark/schema tests: 70 passed, 1 platform-specific skip.
- A real CLI smoke test produced schema-valid paired reports, leaked no private
  paths, and left the tested repository clean.

## Versioning

N/A — this PR adds internal benchmark tooling, tests, and documentation.
