### PR TITLE
feat(core): broaden .understandignore starter — Ruby RSpec/Minitest patterns

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
@@ -274,6 +274,16 @@ describe("generateStarterIgnoreFile", () => {
       expect(content).toContain("# **/test_*.rb");
     });
 
+    it("includes Ruby test-harness helper file patterns", () => {
+      const content = generateStarterIgnoreFile(testDir);
+      // Bootstrapping / configuration files loaded by RSpec + Minitest;
+      // conventionally under spec/ or test/ but sometimes referenced
+      // from elsewhere via `require_relative`.
+      expect(content).toContain("# **/spec_helper.rb");
+      expect(content).toContain("# **/test_helper.rb");
+      expect(content).toContain("# **/rails_helper.rb");
+    });
+
     it("groups patterns under the JS / TS sub-header", () => {
       const content = generateStarterIgnoreFile(testDir);
       expect(content).toContain("# JS / TS");

--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
@@ -264,12 +264,22 @@ describe("generateStarterIgnoreFile", () => {
       expect(content).toContain("# **/*_bench.rs");
     });
 
+    it("includes Ruby RSpec + Minitest file patterns", () => {
+      const content = generateStarterIgnoreFile(testDir);
+      expect(content).toContain("# Ruby");
+      // RSpec — dominant in Rails-adjacent projects (discourse, homebrew).
+      expect(content).toContain("# **/*_spec.rb");
+      // Minitest — Rails core default (rails/rails, activerecord).
+      expect(content).toContain("# **/*_test.rb");
+      expect(content).toContain("# **/test_*.rb");
+    });
+
     it("groups patterns under the JS / TS sub-header", () => {
       const content = generateStarterIgnoreFile(testDir);
       expect(content).toContain("# JS / TS");
     });
 
-    it("emits language groups in stable order: JS, C#, Java, Go, C++, Python, Rust", () => {
+    it("emits language groups in stable order: JS, C#, Java, Go, C++, Python, Rust, Ruby", () => {
       const content = generateStarterIgnoreFile(testDir);
       const jsIdx = content.indexOf("# JS / TS");
       const csIdx = content.indexOf("# C# / .NET");
@@ -278,6 +288,7 @@ describe("generateStarterIgnoreFile", () => {
       const cppIdx = content.indexOf("# C++");
       const pyIdx = content.indexOf("# Python");
       const rustIdx = content.indexOf("# Rust");
+      const rubyIdx = content.indexOf("# Ruby");
       expect(jsIdx).toBeGreaterThan(-1);
       expect(csIdx).toBeGreaterThan(jsIdx);
       expect(javaIdx).toBeGreaterThan(csIdx);
@@ -285,6 +296,7 @@ describe("generateStarterIgnoreFile", () => {
       expect(cppIdx).toBeGreaterThan(goIdx);
       expect(pyIdx).toBeGreaterThan(cppIdx);
       expect(rustIdx).toBeGreaterThan(pyIdx);
+      expect(rubyIdx).toBeGreaterThan(rustIdx);
     });
 
     it("keeps all suggestions commented even with no detected dirs and no .gitignore", () => {

--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
@@ -168,6 +168,12 @@ describe("generateStarterIgnoreFile", () => {
       const content = generateStarterIgnoreFile(testDir);
       expect(content).toContain("# benches/");
     });
+
+    it("suggests spec/ directories (RSpec convention)", () => {
+      mkdirSync(join(testDir, "spec"), { recursive: true });
+      const content = generateStarterIgnoreFile(testDir);
+      expect(content).toContain("# spec/");
+    });
   });
 
   describe("language-grouped test file patterns", () => {

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -146,6 +146,9 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
       "**/*_spec.rb",
       "**/*_test.rb",
       "**/test_*.rb",
+      "**/spec_helper.rb",
+      "**/test_helper.rb",
+      "**/rails_helper.rb",
     ],
   },
 ];

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -134,6 +134,20 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
       "**/*_bench.rs",
     ],
   },
+  {
+    // Ruby ecosystems split between two test frameworks with distinct
+    // file-naming conventions: RSpec (`*_spec.rb` under spec/) and
+    // Minitest (`*_test.rb` or `test_*.rb` under test/). The dir rules
+    // catch each convention's top-level home, but individual files
+    // sometimes leak elsewhere (lib/**/*_spec.rb in gem repos, engine
+    // test files under app/**/*_test.rb in Rails engines).
+    label: "Ruby",
+    patterns: [
+      "**/*_spec.rb",
+      "**/*_test.rb",
+      "**/test_*.rb",
+    ],
+  },
 ];
 
 /**

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -135,12 +135,17 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
     ],
   },
   {
-    // Ruby ecosystems split between two test frameworks with distinct
-    // file-naming conventions: RSpec (`*_spec.rb` under spec/) and
-    // Minitest (`*_test.rb` or `test_*.rb` under test/). The dir rules
-    // catch each convention's top-level home, but individual files
-    // sometimes leak elsewhere (lib/**/*_spec.rb in gem repos, engine
-    // test files under app/**/*_test.rb in Rails engines).
+    // Ruby clusters tests aggressively, matching the C++ shape rather
+    // than Rust's inline convention. Measurement across 10 major Ruby
+    // repos (rails, discourse, homebrew, jekyll, fastlane, rubocop,
+    // ruby, liquid, kamal, rspec-rails) showed a 51% weighted-total
+    // reduction — the highest of any language group. Almost all of
+    // that comes from the newly-added `spec/` dir rule (RSpec's home);
+    // the file globs below add another 5 pp on top by catching
+    // `*_spec.rb` in gem-repo `lib/` trees, Minitest files that leak
+    // outside `test/` in Rails engines, and the ubiquitous
+    // `spec_helper.rb` / `test_helper.rb` / `rails_helper.rb` bootstrap
+    // trio. Hero projects: rubocop (67%), discourse (60%, −5.53M tok).
     label: "Ruby",
     patterns: [
       "**/*_spec.rb",

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -35,6 +35,7 @@ const EXACT_DIR_NAMES = [
   "benchmark",
   "benchmarks",
   "benches",
+  "spec",
 ];
 
 // Directory-name suffixes matched case-insensitively via String.endsWith.


### PR DESCRIPTION
## Summary

- `EXACT_DIR_NAMES` += `spec` — RSpec's canonical home directory (used by discourse, homebrew, gitlab, fastlane, rubocop, and every `rspec-rails` scaffold). This is the load-bearing addition: `spec/` alone drives 46 pp of the 51% weighted total reduction below.
- New `TEST_PATTERN_GROUPS` entry `Ruby` with 6 patterns (RSpec `*_spec.rb`, Minitest `*_test.rb` / `test_*.rb`, harness bootstraps `spec_helper.rb` / `test_helper.rb` / `rails_helper.rb`).
- +3 tests in `ignore-generator.test.ts`; ordering invariant extended to place Ruby after Rust.
- build + lint clean; ignore-generator suite 48/48 pass, core suite 898 pass (2 pre-existing wasm module resolution failures on `scala-extractor.test.ts` / `swift-extractor.test.ts` reproduce unmodified on `origin/main`).

`SKILL.md` unchanged — Phase 0.5 delegates to `generate-ignore.mjs` since a0155c5, so no inline duplicate to keep in sync.

## Why these patterns (and not others)

Ruby is closer to C++ in ecosystem shape than to Rust: aggressive test clustering under known dirs, plus a few naming conventions the starter had never been taught about. The `spec/` gap was the load-bearing miss — with it added, every RSpec-based project (which is most modern Rails-adjacent Ruby) sees the discourse-scale reduction the moment it opts in.

Rejected as too project-specific or ambiguous: `**/*_shared_examples.rb` (RSpec-only, files usually live under `spec/support/` which is already caught by `spec/`), `**/factories.rb` (FactoryBot — under `spec/factories/`, same), `**/schema.rb` (Rails-generated, but path is `db/schema.rb` — surfaces via `.gitignore` extraction rather than a starter suggestion).

Kept `spec_helper.rb` / `test_helper.rb` / `rails_helper.rb` as separate opt-in globs because engines and multi-app monorepos occasionally reference them via `require_relative` from outside the canonical spec/test trees.

## Token impact (measured across 10 public Ruby repos)

Methodology: `gh api .../git/trees?recursive=1`, Ruby source = `.rb .rake .gemspec`, 1 MiB ≈ 262K tokens. Two hero projects reported below — the highest **percentage** win and the highest **absolute** win — same pattern as PR #582.

| Project | Before (analyzed) | After (analyzed) | Reduction |
|---|---|---|---|
| `rubocop/rubocop` | 10.38 MB / ~2.59M tok | 3.38 MB / ~0.84M tok | **−1.75M (67%)** |
| `discourse/discourse` | 36.84 MB / ~9.21M tok | 14.71 MB / ~3.67M tok | **−5.53M (60%)** |

- **`rubocop`** — highest %. RSpec-dominant repo where `spec/` was the bulk of the untouched source tree.
- **`discourse`** — highest absolute saving. 3798 files under `spec/` — the single largest un-caught test tree in the survey.

Weighted total across all 10 repos: **−11.80M tok / 51%** on 92 MB of Ruby source — the highest of any language group added so far. Full breakdown (for context, not repeated in the hero table): `ruby/ruby` 59% / −3.66M, `rspec/rspec-rails` 61%, `fastlane/fastlane` 42%, `rails/rails` 2% (already covered by existing `test/` dir rule), `Homebrew/brew` 1%, `jekyll/jekyll` 0%, `shopify/liquid` 3%, `basecamp/kamal` 0%.

The `spec/` dir rule alone accounts for 46 pp of the 51% weighted total; the file globs add another 5 pp by catching `*_spec.rb` in gem `lib/` trees, Minitest files that leak outside `test/` in Rails engines, and the helper bootstraps.

## Test plan
- [x] `pnpm --filter @understand-anything/core build` — clean
- [x] `pnpm --filter @understand-anything/core exec vitest run src/__tests__/ignore-generator.test.ts` — 48/48 pass (3 new Ruby tests + the `spec/` dir test)
- [x] `pnpm --filter @understand-anything/core test` — 898 pass, 2 pre-existing wasm-module failures also present on `origin/main` (unrelated: scala-extractor, swift-extractor)
- [x] `pnpm lint` — clean
- [x] Manual preview of generated `.understandignore` on a fixture with `spec/`, `test/`, plus a `lib/foo.rb` + `lib/foo_spec.rb` — Ruby group emitted after Rust, all six patterns present, `# spec/` in the detected-dirs section, all commented

Closes #596
