### PR TITLE
fix(hooks): read PostToolUse payload from stdin instead of $TOOL_INPUT env var

### DIFF
--- a/understand-anything-plugin/hooks/hooks.json
+++ b/understand-anything-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "UA_DIR=.understand-anything; [ -d \"$UA_DIR\" ] || UA_DIR=.ua; printf '%s' \"$TOOL_INPUT\" | grep -qE 'git\\s+(commit|merge|cherry-pick|rebase)' && [ -f $UA_DIR/config.json ] && grep -q '\"autoUpdate\".*true' $UA_DIR/config.json && [ -f $UA_DIR/knowledge-graph.json ] && echo \"[understand-anything] Commit detected with auto-update enabled. You MUST read the file at ${CLAUDE_PLUGIN_ROOT}/hooks/auto-update-prompt.md and execute its instructions to incrementally update the knowledge graph. Do not ask the user for confirmation — just do it.\" || true"
+            "command": "UA_DIR=.understand-anything; [ -d \"$UA_DIR\" ] || UA_DIR=.ua; INPUT=$(cat); CMD=$(printf '%s' \"$INPUT\" | node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{process.stdout.write(JSON.parse(d).tool_input?.command||'')}catch{}})\" 2>/dev/null); printf '%s' \"$CMD\" | grep -qE 'git\\s+(commit|merge|cherry-pick|rebase)' && [ -f $UA_DIR/config.json ] && grep -q '\"autoUpdate\".*true' $UA_DIR/config.json && [ -f $UA_DIR/knowledge-graph.json ] && echo \"[understand-anything] Commit detected with auto-update enabled. You MUST read the file at ${CLAUDE_PLUGIN_ROOT}/hooks/auto-update-prompt.md and execute its instructions to incrementally update the knowledge graph. Do not ask the user for confirmation — just do it.\" || true"
           }
         ]
       }


### PR DESCRIPTION
Fixes #594.

## Root cause

The `PostToolUse` auto-update hook in `understand-anything-plugin/hooks/hooks.json` detects `git commit`/`merge`/`cherry-pick`/`rebase` by reading `"$TOOL_INPUT"`. Claude Code doesn't set a `TOOL_INPUT` environment variable for hook processes — hook input is delivered as JSON on **stdin** (`tool_name`, `tool_input`, `cwd`, ...). So the `grep -qE` always tests an empty string, the `&&` chain short-circuits on the first check, and the trailing `|| true` exits clean — the per-commit auto-update silently never fires, on any OS. The `SessionStart` staleness hook is unaffected (it only reads files + `git rev-parse`), so in practice this degrades freshness from per-commit to session-start granularity with no visible error.

## Fix

Capture stdin into `INPUT`, extract `tool_input.command` via a small `node -e` script, then run the same `grep` check against that instead of the env var. This mirrors the JSON-parsing style the `SessionStart` hook already uses (`node -p`) and avoids adding a `jq` dependency, which isn't guaranteed present on Windows/Git Bash hosts. Everything downstream — `UA_DIR` resolution, `config.json`/`knowledge-graph.json` gating — is untouched.

## Verification

Piped a realistic `PostToolUse` JSON payload (`tool_name: "Bash"`, `tool_input.command: "git commit -m ..."`) into both the old and new hook command via stdin, with no `TOOL_INPUT` env var set (matching real Claude Code invocation):

- **Before:** empty stdout, hook never fires.
- **After:** `[understand-anything] Commit detected with auto-update enabled. You MUST read the file at .../hooks/auto-update-prompt.md ...` — hook fires correctly.

Also checked: `git merge`/`cherry-pick`/`rebase` trigger correctly; non-matching commands and non-Bash tool payloads (no `tool_input.command`) stay silent; commit messages with embedded quotes don't break JSON parsing; malformed stdin doesn't crash the hook; `autoUpdate: false` and missing `knowledge-graph.json` still correctly suppress the hook.

## Testing

This is a config-only change (no TypeScript/JS source touched, and no test suite references `hooks.json` or `TOOL_INPUT`), so I verified by exercising the actual shell command directly against simulated hook payloads rather than through `pnpm test`. JSON validity of the edited file confirmed.
