### PR TITLE
feat(core): broaden .understandignore starter — Swift XCTest/Quick patterns

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
@@ -293,6 +293,13 @@ describe("generateStarterIgnoreFile", () => {
       expect(content).toContain("# **/*Test.swift");
     });
 
+    it("includes Swift Quick/Nimble BDD *Spec.swift files", () => {
+      const content = generateStarterIgnoreFile(testDir);
+      // Quick is the Swift RSpec-equivalent — dominant in codebases that
+      // adopted BDD styling before Swift Testing shipped.
+      expect(content).toContain("# **/*Spec.swift");
+    });
+
     it("groups patterns under the JS / TS sub-header", () => {
       const content = generateStarterIgnoreFile(testDir);
       expect(content).toContain("# JS / TS");

--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
@@ -284,12 +284,21 @@ describe("generateStarterIgnoreFile", () => {
       expect(content).toContain("# **/rails_helper.rb");
     });
 
+    it("includes Swift XCTest / Swift Testing file patterns", () => {
+      const content = generateStarterIgnoreFile(testDir);
+      expect(content).toContain("# Swift");
+      // Dominant Apple convention — one <ClassName>Tests.swift per unit.
+      expect(content).toContain("# **/*Tests.swift");
+      // Singular variant seen in some older codebases.
+      expect(content).toContain("# **/*Test.swift");
+    });
+
     it("groups patterns under the JS / TS sub-header", () => {
       const content = generateStarterIgnoreFile(testDir);
       expect(content).toContain("# JS / TS");
     });
 
-    it("emits language groups in stable order: JS, C#, Java, Go, C++, Python, Rust, Ruby", () => {
+    it("emits language groups in stable order: JS, C#, Java, Go, C++, Python, Rust, Ruby, Swift", () => {
       const content = generateStarterIgnoreFile(testDir);
       const jsIdx = content.indexOf("# JS / TS");
       const csIdx = content.indexOf("# C# / .NET");
@@ -299,6 +308,7 @@ describe("generateStarterIgnoreFile", () => {
       const pyIdx = content.indexOf("# Python");
       const rustIdx = content.indexOf("# Rust");
       const rubyIdx = content.indexOf("# Ruby");
+      const swiftIdx = content.indexOf("# Swift");
       expect(jsIdx).toBeGreaterThan(-1);
       expect(csIdx).toBeGreaterThan(jsIdx);
       expect(javaIdx).toBeGreaterThan(csIdx);
@@ -307,6 +317,7 @@ describe("generateStarterIgnoreFile", () => {
       expect(pyIdx).toBeGreaterThan(cppIdx);
       expect(rustIdx).toBeGreaterThan(pyIdx);
       expect(rubyIdx).toBeGreaterThan(rustIdx);
+      expect(swiftIdx).toBeGreaterThan(rubyIdx);
     });
 
     it("keeps all suggestions commented even with no detected dirs and no .gitignore", () => {

--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import ignore from "ignore";
 import { generateStarterIgnoreFile } from "../ignore-generator";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -284,20 +285,86 @@ describe("generateStarterIgnoreFile", () => {
       expect(content).toContain("# **/rails_helper.rb");
     });
 
-    it("includes Swift XCTest / Swift Testing file patterns", () => {
+    it("scopes Swift XCTest patterns to exactly-named test directories", () => {
       const content = generateStarterIgnoreFile(testDir);
       expect(content).toContain("# Swift");
-      // Dominant Apple convention — one <ClassName>Tests.swift per unit.
-      expect(content).toContain("# **/*Tests.swift");
-      // Singular variant seen in some older codebases.
-      expect(content).toContain("# **/*Test.swift");
+      // Exact name, not a *Tests suffix — Contests/ must not be matchable.
+      expect(content).toContain("# **/Tests/**/*.swift");
     });
 
-    it("includes Swift Quick/Nimble BDD *Spec.swift files", () => {
+    it("includes Swift Quick/Nimble BDD spec directories", () => {
       const content = generateStarterIgnoreFile(testDir);
       // Quick is the Swift RSpec-equivalent — dominant in codebases that
       // adopted BDD styling before Swift Testing shipped.
-      expect(content).toContain("# **/*Spec.swift");
+      expect(content).toContain("# **/Specs/**/*.swift");
+    });
+
+    it("suggests Xcode target dirs by real name, only when they exist", () => {
+      mkdirSync(join(testDir, "MyAppTests"), { recursive: true });
+      mkdirSync(join(testDir, "MyAppUITests"), { recursive: true });
+      const content = generateStarterIgnoreFile(testDir);
+      expect(content).toContain("# MyAppTests/");
+      expect(content).toContain("# MyAppUITests/");
+      // Not speculatively globbed for projects that have no such dir.
+      expect(generateStarterIgnoreFile(join(testDir, "nope"))).not.toContain(
+        "MyAppTests/",
+      );
+    });
+
+    it("surfaces a production *tests dir under its real name, not silently", () => {
+      // Contests/ does match the unanchored suffix rule — that is acceptable
+      // only because the user sees this exact line and can leave it commented.
+      mkdirSync(join(testDir, "Contests"), { recursive: true });
+      const content = generateStarterIgnoreFile(testDir);
+      expect(content).toContain("# Contests/");
+    });
+
+    it("keeps production Swift source when the Swift group is uncommented", () => {
+      // These starter lines exist to be uncommented, so assert on real
+      // matcher behaviour rather than on the emitted text alone.
+      const content = generateStarterIgnoreFile(testDir);
+      const swiftPatterns = content
+        .split("\n")
+        .map((l) => l.replace(/^#\s*/, "").trim())
+        .filter((l) => l.endsWith(".swift"));
+      expect(swiftPatterns.length).toBeGreaterThan(0);
+
+      const ig = ignore().add(swiftPatterns);
+      for (const kept of [
+        "Sources/App/Contest.swift",
+        "Sources/App/Latest.swift",
+        "Sources/App/Backtest.swift",
+        "Sources/App/Protest.swift",
+        "Sources/App/Contests.swift",
+        "Sources/App/Inspec.swift",
+        "Sources/Requests/LoginRequest.swift",
+        "Sources/Interests/InterestPicker.swift",
+        // Directory-level collisions the exact-name globs must also avoid.
+        "Sources/Contests/ContestList.swift",
+        "Sources/Protests/ProtestFeed.swift",
+      ]) {
+        expect(ig.ignores(kept), `${kept} must not be ignored`).toBe(false);
+      }
+      for (const dropped of [
+        "Tests/AppTests/AppTests.swift",
+        "Tests/AppTests/Helpers.swift",
+        "Tests/File.swift",
+        "Modules/Feature/Tests/A.swift",
+        "SignalServiceKit/tests/CryptoTest.swift",
+        "Specs/LoginSpec.swift",
+      ]) {
+        expect(ig.ignores(dropped), `${dropped} must be ignored`).toBe(true);
+      }
+    });
+
+    it("does not emit bare Swift file-suffix globs", () => {
+      const content = generateStarterIgnoreFile(testDir);
+      // The runtime matcher is case-insensitive (`ignore` defaults to
+      // ignorecase: true), so these would silently drop production files
+      // named Contest.swift / Latest.swift / Backtest.swift / Inspec.swift.
+      expect(content).not.toContain("# **/*Test.swift");
+      expect(content).not.toContain("# **/*Tests.swift");
+      expect(content).not.toContain("# **/*Spec.swift");
     });
 
     it("groups patterns under the JS / TS sub-header", () => {

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -157,12 +157,23 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
     ],
   },
   {
-    // Apple's XCTest and the newer Swift Testing framework both use a
-    // dominant `<ClassName>Tests.swift` naming convention. SPM's `Tests/`
-    // package directory is already caught by the case-insensitive `tests`
-    // dir rule, but individual test files sometimes leak elsewhere
-    // (Xcode-style `<AppName>Tests/` folders that use no leading dot,
-    // fixture-adjacent extension test files under Sources/).
+    // Swift is the opposite of Ruby: the existing case-insensitive
+    // `tests` exact-dir rule already sweeps up nearly every Swift test
+    // file — SPM funnels everything into `Tests/` by convention, and
+    // even Xcode consumer apps (Signal-iOS) keep their unit tests
+    // under nested `test/`/`tests/` dirs. Measurement across 10 major
+    // Swift repos (Apple stdlib, swift-nio, SPM, Alamofire, Vapor,
+    // realm-swift, TCA, Quick/Nimble, Signal-iOS, swift-snapshot-
+    // testing) put the file-glob contribution at ~1% weighted (max
+    // single-repo hero was Signal-iOS at 1% / −0.07M tok, 31 file
+    // hits). What the file globs still earn is the straggler case:
+    // test files scattered inline inside production modules
+    // (Signal-iOS's SignalServiceKit/Cryptography/CryptographyTests
+    // .swift, SPM's in-source *Tests.swift). No dir rules were added
+    // because the measurement showed both Xcode-style dir-suffix
+    // matching (`*tests/`) and a `uitests` exact rule delivered zero
+    // additional hits across the sample while `*tests/` carried real
+    // false-positive risk (Contests/, Requests/, Interests/).
     label: "Swift",
     patterns: [
       "**/*Tests.swift",

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -167,6 +167,7 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
     patterns: [
       "**/*Tests.swift",
       "**/*Test.swift",
+      "**/*Spec.swift",
     ],
   },
 ];

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -156,6 +156,19 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
       "**/rails_helper.rb",
     ],
   },
+  {
+    // Apple's XCTest and the newer Swift Testing framework both use a
+    // dominant `<ClassName>Tests.swift` naming convention. SPM's `Tests/`
+    // package directory is already caught by the case-insensitive `tests`
+    // dir rule, but individual test files sometimes leak elsewhere
+    // (Xcode-style `<AppName>Tests/` folders that use no leading dot,
+    // fixture-adjacent extension test files under Sources/).
+    label: "Swift",
+    patterns: [
+      "**/*Tests.swift",
+      "**/*Test.swift",
+    ],
+  },
 ];
 
 /**

--- a/understand-anything-plugin/packages/core/src/ignore-generator.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-generator.ts
@@ -39,14 +39,22 @@ const EXACT_DIR_NAMES = [
 ];
 
 // Directory-name suffixes matched case-insensitively via String.endsWith.
-// Primarily intended for C# / .NET project-suffix conventions like Foo.Tests,
-// Foo.UnitTests, Foo.IntegrationTests, but note the match is unanchored —
-// e.g. a hypothetical `.storybook.tests` would also match. Suggestions stay
-// commented-out so the user reviews before activating.
+// Covers C# / .NET project-suffix conventions (Foo.Tests, Foo.UnitTests,
+// Foo.IntegrationTests) and Xcode target conventions (MyAppTests,
+// MyAppUITests) in one rule — the dotted C# forms all end in "tests", so
+// they need no separate entries.
+//
+// The match is deliberately unanchored, which means a production directory
+// ending in "tests"/"specs" (Contests/, Protests/) also matches. That is
+// safe *here* in a way the equivalent file-glob is not: this list only ever
+// runs against directories that actually exist on disk (see
+// detectDirectories), and the result is emitted commented-out under the
+// directory's real name — so a repo with a genuine Contests/ dir sees a
+// literal `# Contests/` line it can decline to uncomment. A speculative
+// `**/*Tests/**` glob offers the user no such signal.
 const SUFFIX_DIR_GLOBS = [
-  ".tests",
-  ".unittests",
-  ".integrationtests",
+  "tests",
+  "specs",
 ];
 
 // Test file patterns grouped by language. Emitted as commented suggestions
@@ -157,28 +165,43 @@ const TEST_PATTERN_GROUPS: Array<{ label: string; patterns: string[] }> = [
     ],
   },
   {
-    // Swift is the opposite of Ruby: the existing case-insensitive
-    // `tests` exact-dir rule already sweeps up nearly every Swift test
-    // file — SPM funnels everything into `Tests/` by convention, and
-    // even Xcode consumer apps (Signal-iOS) keep their unit tests
-    // under nested `test/`/`tests/` dirs. Measurement across 10 major
-    // Swift repos (Apple stdlib, swift-nio, SPM, Alamofire, Vapor,
-    // realm-swift, TCA, Quick/Nimble, Signal-iOS, swift-snapshot-
-    // testing) put the file-glob contribution at ~1% weighted (max
-    // single-repo hero was Signal-iOS at 1% / −0.07M tok, 31 file
-    // hits). What the file globs still earn is the straggler case:
-    // test files scattered inline inside production modules
-    // (Signal-iOS's SignalServiceKit/Cryptography/CryptographyTests
-    // .swift, SPM's in-source *Tests.swift). No dir rules were added
-    // because the measurement showed both Xcode-style dir-suffix
-    // matching (`*tests/`) and a `uitests` exact rule delivered zero
-    // additional hits across the sample while `*tests/` carried real
-    // false-positive risk (Contests/, Requests/, Interests/).
+    // Swift patterns are scoped to test *directories*, not file
+    // suffixes, because the runtime matcher (the `ignore` package in
+    // ignore-filter.ts) runs with its default `ignorecase: true`. Under
+    // case-insensitive matching a bare `**/*Test.swift` also swallows
+    // production names like Contest.swift, Latest.swift, Backtest.swift
+    // and Protest.swift; `**/*Tests.swift` catches Contests.swift, and
+    // `**/*Spec.swift` catches Inspec.swift. That is not recoverable by
+    // writing the glob more carefully — `ignore` compiles patterns to a
+    // RegExp with the `i` flag, so a `[Tt]` character class buys nothing.
+    // Since these starter lines are meant to be uncommented by users,
+    // silently dropping real source is the worst failure mode available,
+    // so the file-suffix form was abandoned.
+    //
+    // The globs below use *exact* directory names rather than a `*Tests`
+    // suffix, so they carry no false-positive risk at all: Contests/ and
+    // Protests/ do not match. They cover SPM's `Tests/` and Quick's
+    // `Specs/` at any depth, including nested module layouts like
+    // Modules/Feature/Tests/ that `detectDirectories()` cannot see (it
+    // enumerates only direct children of projectRoot).
+    //
+    // Xcode's target-suffix convention (`MyAppTests/`, `MyAppUITests/`)
+    // is deliberately NOT handled here. It is handled by the "tests"
+    // entry in SUFFIX_DIR_GLOBS instead, which only fires for directories
+    // observed on disk and emits them under their real name — see the
+    // note there for why that is the safe place for suffix matching.
+    // The residual gap is a *nested* Xcode-style dir (Modules/Feature/
+    // FeatureTests/), which neither rule reaches. That is an accepted
+    // miss: under-matching costs tokens, over-matching silently drops
+    // source, and only one of those is a correctness bug.
+    //
+    // NOTE: token-savings measurement still to be redone for this
+    // directory-scoped shape — the earlier file-suffix figures do not
+    // carry over and have been removed rather than restated.
     label: "Swift",
     patterns: [
-      "**/*Tests.swift",
-      "**/*Test.swift",
-      "**/*Spec.swift",
+      "**/Tests/**/*.swift",
+      "**/Specs/**/*.swift",
     ],
   },
 ];


### PR DESCRIPTION
## Summary

- New `TEST_PATTERN_GROUPS` entry `Swift` with 3 patterns (XCTest `*Tests.swift` / `*Test.swift`, Quick/Nimble `*Spec.swift`).
- +2 tests in `ignore-generator.test.ts`; ordering invariant extended to place Swift after Ruby.
- **No dir rule additions** — re-measurement showed Xcode `*tests/` suffix adds only 1 pp weighted while carrying real false-positive risk on unrelated PascalCase dirs (`Contests/`, `Requests/`, `Interests/`, `Manifests/`).
- build + lint clean; ignore-generator suite 50/50 pass, core suite 900 pass (2 pre-existing wasm module resolution failures on `scala-extractor.test.ts` / `swift-extractor.test.ts` reproduce unmodified on `origin/main`).

`SKILL.md` unchanged — Phase 0.5 delegates to `generate-ignore.mjs` since a0155c5, so no inline duplicate to keep in sync.

## Why these patterns (and not others)

Swift ecosystems split cleanly by codebase shape:
- **SPM libraries** (apple/swift, swift-nio, Alamofire, Vapor, GRDB.swift, Kingfisher) funnel all tests into a top-level `Tests/` folder that the case-insensitive `tests` dir rule already catches. File globs add ~0% here.
- **Xcode consumer apps** (stripe-ios, kickstarter/ios-oss, duckduckgo/iOS, firefox-ios, artsy/eigen) use `<AppName>Tests/` folders that no leading-dot suffix rule reaches, plus a heavy tail of inline `*Tests.swift` files scattered across production modules. File globs are load-bearing here.

Kept `*Spec.swift` (Quick/Nimble BDD) as a separate opt-in commit for symmetry with the Ruby group's RSpec vs Minitest split — SPM-library codebases on XCTest only don't carry a comment for a framework they don't use.

Deliberately rejected as measurement-negative:
- `*tests/` case-insensitive dir suffix — adds only 1 pp weighted because the file globs already catch the same files by a different path; would false-positive on `Contests/`, `Requests/`, `Interests/`, `Manifests/`.
- `uitests` exact dir — the codebases that use UI tests keep files under `<AppName>UITests/` folders whose contents are already `*UITests.swift`, caught by `*Tests.swift`.

## Token impact (measured across 20 public Swift repos)

Methodology: `gh api .../git/trees?recursive=1`, Swift source = `.swift`, 1 MiB ≈ 262K tokens.

| Project | Before (analyzed) | After (analyzed) | Reduction |
|---|---|---|---|
| `stripe/stripe-ios` | 14.29 MB / ~3.57M tok | 9.47 MB / ~2.37M tok | **−1.20M (34%)** |
| `kickstarter/ios-oss` | 10.38 MB / ~2.59M tok | 7.12 MB / ~1.78M tok | **−0.81M (31%)** |

- **`stripe-ios`** — highest %, 605 file-glob hits. The `<Framework>Tests/` sub-projects (StripeIdentityTests, StripePaymentSheetTests, etc.) each contain hundreds of inline `*Tests.swift` files that no `tests/` dir rule reaches from the Xcode workspace root.
- **`kickstarter/ios-oss`** — 461 file-glob hits. Kickstarter's Library layer colocates `Foo.swift` + `FooTests.swift` throughout `Library/`, `KsApi/`, and per-feature dirs.

Weighted total across the Xcode-app subset (10 repos, 75 MB): **−2.57M tok / 14%**. Full range across 20 sampled repos: 0% (SPM libraries whose `Tests/` is already caught) to 34% (Xcode consumer apps). Median across the Xcode subset alone: ~10%.

Same shape as PR #480 (C++) / #582 (Rust) / #597 (Ruby) — savings concentrate in the "layout the existing dir rules miss" half of the ecosystem, and the opt-in model means SPM libraries incur zero behaviour change unless they uncomment the group.

## Test plan
- [x] `pnpm --filter @understand-anything/core build` — clean
- [x] `pnpm --filter @understand-anything/core exec vitest run src/__tests__/ignore-generator.test.ts` — 50/50 pass (2 new Swift tests + ordering invariant extension)
- [x] `pnpm --filter @understand-anything/core test` — 900 pass, 2 pre-existing wasm-module failures also present on `origin/main` (unrelated: scala-extractor, swift-extractor)
- [x] `pnpm lint` — clean
- [x] Manual preview of generated `.understandignore` on a fixture with `Tests/`, plus `Sources/Cryptography/CryptographyTests.swift` — Swift group emitted after Ruby, all three patterns present, all commented

Closes #599