### PR TITLE
fix(docs): fix italic formatting in Korean README skill invocation guide

### DIFF
--- a/READMEs/README.ko-KR.md
+++ b/READMEs/README.ko-KR.md
@@ -201,7 +201,7 @@ iwr -useb https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/i
 
 설치 스크립트는 저장소를 `~/.understand-anything/repo`에 클론하고 선택한 플랫폼에 맞는 심볼릭 링크를 생성합니다. 설치 후 CLI 또는 IDE를 재시작하세요.
 
-> **스킬 호출 방식 안내:** 호출 접두사는 플랫폼마다 다릅니다. 대부분의 플랫폼은 슬래시 명령(`/understand`)을 사용하지만, **Codex는 `$`를 사용합니다** — `/understand`가 아니라 `$understand`를 입력하세요. 두 접두사 모두 인식되지 않으면 *"understand 스킬로 이 프로젝트를 분석해 줘"*처럼 자연어로 요청하면 됩니다.
+> **스킬 호출 방식 안내:** 호출 접두사는 플랫폼마다 다릅니다. 대부분의 플랫폼은 슬래시 명령(`/understand`)을 사용하지만, **Codex는 `$`를 사용합니다** — `/understand`가 아니라 `$understand`를 입력하세요. 두 접두사 모두 인식되지 않으면 *"understand 스킬로 이 프로젝트를 분석해 줘"* 처럼 자연어로 요청하면 됩니다.
 
 - 지원되는 `<platform>` 값: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `nanobot`, `kiro`
 - 이후 업데이트: `./install.sh --update`


### PR DESCRIPTION
## Summary

<!-- One or two sentences on what this PR changes and why. -->

Fixed missing space after asterisk in Korean README that prevented *italic formatting* from rendering correctly.

## Linked issue(s)

<!-- e.g. Closes #123, Refs #456. Leave empty if there's no tracking issue. -->

## How I tested this

<!-- Concrete steps. "Ran the test suite" is fine; "Ran /understand on a 3k-file
Swift repo and verified the dashboard shows non-empty edges" is better. -->

- [ ] `pnpm lint`
- [ ] `pnpm --filter @understand-anything/core test`
- [ ] `pnpm test`
- [ ] Manual smoke test (describe above)

## Versioning

<!-- If this PR ships a user-visible behavior change, bump the version in ALL
five manifests per CLAUDE.md. If it's docs/tests/internal-only, leave them
alone and the maintainer will bump on merge. -->

- [ ] Version bumped in all five manifests, OR
- [x] N/A — internal/docs-only change
