### PR TITLE
fix: stop auto-update loops on generated graph commits

### DIFF
--- a/tests/skill/understand/test_skill_security_snippets.test.mjs
+++ b/tests/skill/understand/test_skill_security_snippets.test.mjs
@@ -39,6 +39,19 @@ describe('skill command hardening', () => {
     expect(content).not.toMatch(/rm\s+-rf\s+<TARGET_DIR>/);
   });
 
+  it('does not rewrite metadata for generated-only commits', () => {
+    const content = readRepoFile(
+      'understand-anything-plugin/hooks/auto-update-prompt.md',
+    );
+
+    expect(content).toMatch(
+      /Before filtering by extension, remove every path under the selected `\$UA_DIR`/,
+    );
+    expect(content).toMatch(
+      /If no paths remain after removing `\$UA_DIR`[\s\S]*without writing `meta\.json`/,
+    );
+  });
+
   it('quotes dashboard cd targets and GRAPH_DIR assignment', () => {
     const content = readRepoFile('understand-anything-plugin/skills/understand-dashboard/SKILL.md');
 

--- a/understand-anything-plugin/hooks/auto-update-prompt.md
+++ b/understand-anything-plugin/hooks/auto-update-prompt.md
@@ -29,15 +29,17 @@ Incrementally update the knowledge graph using deterministic structural fingerpr
    ```
    If no files changed: update `meta.json` with the new commit hash and **STOP**.
 
-7. Filter to source files only (`.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rs`, `.java`, `.rb`, `.cpp`, `.c`, `.h`, `.cs`, `.swift`, `.kt`, `.php`).
+7. Before filtering by extension, remove every path under the selected `$UA_DIR` from the changed-file list. The selected data directory (`.ua/` or legacy `.understand-anything/`) contains generated graph artefacts, not project source changes. Do **not** update `meta.json` merely because files in this directory changed. If no paths remain after removing `$UA_DIR`, report "Only generated graph artefacts changed. The graph baseline remains associated with the analysed source commit." and **STOP** without writing `meta.json`.
+
+8. Filter the remaining paths to source files only (`.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rs`, `.java`, `.rb`, `.cpp`, `.c`, `.h`, `.cs`, `.swift`, `.kt`, `.php`).
    If no source files changed: update `meta.json` with the new commit hash, report "Only non-source files changed. Metadata updated." and **STOP**.
 
-8. Create intermediate directory:
+9. Create intermediate directory:
    ```bash
    mkdir -p "$UA_DIR/intermediate"
    ```
 
-9. **Apply `.understandignore` exclusions** (same semantics as `/understand` Step 2.5 in `agents/project-scanner.md`).
+10. **Apply `.understandignore` exclusions** (same semantics as `/understand` Step 2.5 in `agents/project-scanner.md`).
 
    Without this step, files in user-excluded paths (migrations, vendored code, tests) are counted as structural changes and can spuriously escalate the action to `FULL_UPDATE` even when the real change set is tiny.
 


### PR DESCRIPTION
## Summary

Prevent the auto-update flow from rewriting `.ua/meta.json` or `.understand-anything/meta.json` when a commit contains only generated graph artefacts. This keeps the graph baseline tied to the source commit that was analysed and stops metadata-only self-update loops.

## Linked issue(s)

Closes #626

## How I tested this

- [x] `pnpm lint`
- [ ] `pnpm --filter @understand-anything/core test` — 975 tests passed; one pre-existing Windows `EPERM` timeout occurred in `graph-freshness.integration.test.ts` while cleaning a temporary directory.
- [x] `pnpm test -- tests/skill/understand/test_skill_security_snippets.test.mjs`
- [x] Reproduced the issue with a disposable Git history containing source, graph-only, and metadata-only commits; filtering the selected graph directory leaves no source paths.

## Versioning

- [x] N/A — internal/docs-only change