### PR TITLE
fix(skills): save onboarding guide as UA_ONBOARDING.md

### DIFF
--- a/understand-anything-plugin/skills/understand-onboard/SKILL.md
+++ b/understand-anything-plugin/skills/understand-onboard/SKILL.md
@@ -66,5 +66,5 @@ The knowledge graph JSON has this structure:
    - **Complexity Hotspots**: areas to approach carefully (from complexity values)
 
 9. Format as clean markdown
-10. Offer to save the guide to `docs/ONBOARDING.md` in the project
+10. Offer to save the guide to `docs/UA_ONBOARDING.md` in the project
 11. Suggest the user commit it to the repo for the team


### PR DESCRIPTION
## Summary

Change the `/understand-onboard` default output path from `docs/ONBOARDING.md` to `docs/UA_ONBOARDING.md` so generated code-orientation docs do not collide with conventional team onboarding docs.

## Linked issue(s)

Closes #591

## How I tested this

- [ ] `pnpm lint`
- [ ] `pnpm --filter @understand-anything/core test`
- [ ] `pnpm test`
- [x] Manual inspection: verified the skill now offers `docs/UA_ONBOARDING.md` and no longer uses `docs/ONBOARDING.md`

## Versioning

- [ ] Version bumped in all five manifests, OR
- [x] N/A — skill documentation-only change
